### PR TITLE
Add JSONL performance tips to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ async with AsyncGzipFile(
 - **Binary I/O**: Typically near parity for bulk reads/writes, and can be slower for very small chunk sizes.
 - **Concurrency**: Non-blocking I/O can improve throughput in latency-bound multi-file workloads.
 - **Memory**: Optimized buffer management for stable memory usage.
+- **JSONL**: For large gzipped JSONL files, prefer `AsyncGzipTextFile(..., newline="\n", chunk_size=512 * 1024)` to reduce line-iteration overhead.
 
 See the [Performance Guide](https://geoff-davis.github.io/aiogzip/performance/) for detailed benchmarks.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -68,6 +68,38 @@ async def process_jsonl():
 asyncio.run(process_jsonl())
 ```
 
+### Reading JSONL Efficiently
+
+If your data is standard UTF-8 JSONL with `\n` line endings, configure the text
+reader explicitly:
+
+```python
+import asyncio
+import json
+from aiogzip import AsyncGzipTextFile
+
+async def process_jsonl_fast():
+    async with AsyncGzipTextFile(
+        "logs.jsonl.gz",
+        "rt",
+        newline="\n",
+        chunk_size=512 * 1024,
+    ) as f:
+        async for line in f:
+            record = json.loads(line)
+            # Process record...
+
+asyncio.run(process_jsonl_fast())
+```
+
+Why this helps:
+
+- `newline="\n"` skips universal-newline handling that JSONL does not need.
+- A larger `chunk_size` reduces async read overhead during line iteration.
+
+This is a good default for large gzipped JSONL files. If memory pressure matters
+more than throughput, lower the chunk size.
+
 ## Concurrent File Processing
 
 One of the biggest advantages of `aiogzip` is the ability to process multiple files concurrently without blocking the event loop.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -61,7 +61,36 @@ However, for multi-gigabyte files, always prefer **streaming** (line-by-line or 
 - If you need text, use `AsyncGzipTextFile` (or `mode="rt"/"wt"`). It handles decoding more efficiently than you can typically do manually in Python loop.
 - If you just need to move bytes (e.g., upload to S3), use `AsyncGzipBinaryFile`.
 
-### 4. Buffer Management
+### 4. Tune JSONL Reads Explicitly
+
+For gzipped JSONL, prefer text mode and tell the reader exactly what newline
+format to expect:
+
+```python
+import json
+from aiogzip import AsyncGzipTextFile
+
+async with AsyncGzipTextFile(
+    "events.jsonl.gz",
+    "rt",
+    newline="\n",
+    chunk_size=512 * 1024,
+) as f:
+    async for line in f:
+        record = json.loads(line)
+```
+
+Why this is faster:
+
+- `newline="\n"` avoids universal-newline detection and translation overhead.
+- Larger `chunk_size` values reduce the number of async reads and line-scanning passes.
+- For JSONL workloads, `AsyncGzipTextFile` is typically faster than iterating
+  bytes from `AsyncGzipBinaryFile` and calling `json.loads()` on each line.
+
+In local measurements on gzipped JSONL reads, `newline="\n"` plus a larger
+chunk size was materially faster than the default text-mode configuration.
+
+### 5. Buffer Management
 
 `aiogzip` maintains an internal buffer.
 


### PR DESCRIPTION
## Summary
- Added JSONL performance tip to README (recommend `newline="\n"` and larger `chunk_size`)
- Added "Reading JSONL Efficiently" example to docs/examples.md
- Added "Tune JSONL Reads Explicitly" section to docs/performance.md, renumbered existing sections

## Test plan
- [ ] Verify docs render correctly on GitHub Pages
- [ ] Confirm code examples are syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)