### PR TITLE
Bump version to 1.3.2

### DIFF
--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -29,7 +29,7 @@ from ._common import (
 )
 from ._text import AsyncGzipTextFile
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 
 def AsyncGzipFile(


### PR DESCRIPTION
## Summary
- Bump version from 1.3.1 to 1.3.2 for release

## After merge
Tag `main` with `v1.3.2` to trigger PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)