### PR TITLE
Add changelog entry and release skills

### DIFF
--- a/.claude/commands/release-prep.md
+++ b/.claude/commands/release-prep.md
@@ -8,10 +8,15 @@ Prepare a new release of aiogzip. This skill handles changelog generation, versi
 
 ## Steps
 
+### 0. Pre-flight checks
+
+- Run `git fetch origin main` to ensure we have the latest remote state.
+- Check for uncommitted changes. If there are any, stop and tell the user to commit or stash them first (branch switching may lose work).
+
 ### 1. Generate changelog entries
 
-- Run `git describe --tags --abbrev=0` to find the latest tag.
-- Run `git log <latest-tag>..HEAD --oneline` to get commits since that tag.
+- Run `git describe --tags --abbrev=0 origin/main` to find the latest tag.
+- Run `git log <latest-tag>..origin/main --oneline` to get commits since that tag.
 - Read `CHANGELOG.md` and check the `[Unreleased]` section.
 - If `[Unreleased]` is empty, auto-generate entries from the commit log, grouped by category:
   - **Added** — new features or capabilities
@@ -42,7 +47,7 @@ Prepare a new release of aiogzip. This skill handles changelog generation, versi
 
 ### 5. Create release branch and PR
 
-- Create branch `release/v<version>` from current HEAD.
+- Create branch `release/v<version>` from `origin/main`.
 - Stage `CHANGELOG.md` and `src/aiogzip/__init__.py`.
 - Commit with message: `Prepare release v<version>`
 - Push the branch.

--- a/.claude/commands/release-prep.md
+++ b/.claude/commands/release-prep.md
@@ -1,0 +1,51 @@
+# Release Prep
+
+Prepare a new release of aiogzip. This skill handles changelog generation, version bumping, and creating the release PR.
+
+## Arguments
+
+- `$ARGUMENTS` — optional version string (e.g., `1.4.0`). If omitted, infer from changelog categories.
+
+## Steps
+
+### 1. Generate changelog entries
+
+- Run `git describe --tags --abbrev=0` to find the latest tag.
+- Run `git log <latest-tag>..HEAD --oneline` to get commits since that tag.
+- Read `CHANGELOG.md` and check the `[Unreleased]` section.
+- If `[Unreleased]` is empty, auto-generate entries from the commit log, grouped by category:
+  - **Added** — new features or capabilities
+  - **Changed** — changes to existing functionality
+  - **Fixed** — bug fixes
+  - **Performance** — performance improvements
+  - **Documentation** — docs changes
+  - **Refactor** — code restructuring without behavior change
+- Present the generated entries to the user and ask for confirmation before proceeding.
+
+### 2. Determine version
+
+- Read the current version from `src/aiogzip/__init__.py` (`__version__`).
+- If a version was provided as `$ARGUMENTS`, use that.
+- Otherwise, infer the bump type from the changelog categories using semver conventions:
+  - If there are **Added** or **Changed** entries → suggest a **minor** bump
+  - If there are only **Fixed**, **Documentation**, **Performance**, or **Refactor** entries → suggest a **patch** bump
+- Present the suggested version to the user and ask for confirmation.
+
+### 3. Update CHANGELOG.md
+
+- Replace the empty `[Unreleased]` section content with a fresh blank section.
+- Insert a new section `[<version>] - <YYYY-MM-DD>` below `[Unreleased]` with the generated/confirmed entries.
+
+### 4. Bump version
+
+- Update `__version__` in `src/aiogzip/__init__.py` to the new version.
+
+### 5. Create release branch and PR
+
+- Create branch `release/v<version>` from current HEAD.
+- Stage `CHANGELOG.md` and `src/aiogzip/__init__.py`.
+- Commit with message: `Prepare release v<version>`
+- Push the branch.
+- Create a PR with title `Prepare release v<version>` and body summarizing the changelog entries.
+- Report the PR URL to the user.
+- Remind the user: after CI passes and the PR is merged, run `/release-tag` to tag and publish.

--- a/.claude/commands/release-tag.md
+++ b/.claude/commands/release-tag.md
@@ -1,0 +1,34 @@
+# Release Tag
+
+Tag a merged release and publish to PyPI + GitHub Releases. Run this after a `/release-prep` PR has been merged.
+
+## Steps
+
+### 1. Verify merge
+
+- Confirm we are on the `main` branch. If not, switch to it.
+- Run `git pull` to get the latest.
+- Read the current version from `src/aiogzip/__init__.py` (`__version__`).
+- Verify the version has been bumped (i.e., no tag `v<version>` exists yet).
+- If a tag already exists for this version, tell the user and stop.
+
+### 2. Confirm with user
+
+- Show the user the version that will be tagged and ask for confirmation before proceeding.
+
+### 3. Tag and push
+
+- Run `git tag v<version>` on the current HEAD.
+- Run `git push origin v<version>`.
+- Tell the user the tag has been pushed and that the PyPI publish workflow has been triggered.
+
+### 4. Create GitHub Release
+
+- Read the `[<version>]` section from `CHANGELOG.md` to use as release notes.
+- Run `gh release create v<version> --title "v<version>" --latest --notes "<changelog section>"`.
+- Report the release URL to the user.
+
+### 5. Clean up
+
+- Delete the local release branch if it still exists (`release/v<version>`).
+- Remind the user to verify the PyPI publish succeeded at the GitHub Actions tab.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-04-14
+
+### Documentation
+
+- Add JSONL performance tips to README, examples guide, and performance guide.
+- Recommend `newline="\n"` and larger `chunk_size` for efficient gzipped JSONL reads.
+
 ## [1.3.1] - 2026-04-01
 
 ### Performance


### PR DESCRIPTION
## Summary
- Add 1.3.2 changelog entry (JSONL performance tips documentation)
- Add `/release-prep` and `/release-tag` Claude Code skills to streamline the release process
- `/release-prep` auto-generates changelog, infers semver bump, creates release PR
- `/release-tag` tags the merge, pushes to trigger PyPI publish, creates GitHub release

## Test plan
- [ ] Merge, then test `/release-prep` on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)