### PR TITLE
Add release skills to unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add `/release-prep` and `/release-tag` Claude Code skills to streamline the release process.
+
 ## [1.3.2] - 2026-04-14
 
 ### Documentation


### PR DESCRIPTION
## Summary
- Add missing changelog entry for the `/release-prep` and `/release-tag` skills under `[Unreleased]`
- Previous PR was merged before this commit was pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)