### PR TITLE
Prepare release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-04-14
+
 ### Added
 
 - Add `/release-prep` and `/release-tag` Claude Code skills to streamline the release process.

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -29,7 +29,7 @@ from ._common import (
 )
 from ._text import AsyncGzipTextFile
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 
 def AsyncGzipFile(


### PR DESCRIPTION
## Summary
- Bump version to 1.3.3
- Move `[Unreleased]` changelog entries into `[1.3.3] - 2026-04-14`

### Changelog
- Add `/release-prep` and `/release-tag` Claude Code skills to streamline the release process.

## After merge
Run `/release-tag` to tag, publish to PyPI, and create the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)