### PR TITLE
Prepare release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-04-16
+
 ### Added
 
 - New `max_decompressed_size` keyword on `AsyncGzipBinaryFile` and `AsyncGzipTextFile`: when set, reads abort with `OSError` once the cumulative decompressed output exceeds the cap. Intended as a decompression-bomb guard for untrusted input.
@@ -27,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Tooling
 
 - Add a `scripts/check_py38_compat.py` pre-commit hook that rejects PEP 585 generic subscripts (`tuple[...]`, `list[...]`, `PathLike[...]`, ...) and PEP 604 union operators in `src/`. `mypy` ≥ 1.15 no longer accepts `python_version = "3.8"`, so this grep-based check guards the library's declared Python 3.8+ support.
+- `/release-prep` skill now refuses to run when the current branch has commits ahead of `origin/main` that are not yet merged, preventing silent exclusion of feature work from the release.
 
 ## [1.3.3] - 2026-04-14
 

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -29,7 +29,7 @@ from ._common import (
 )
 from ._text import AsyncGzipTextFile
 
-__version__ = "1.3.3"
+__version__ = "1.4.0"
 
 
 def AsyncGzipFile(


### PR DESCRIPTION
Release preparation for **1.4.0**. Bumps `__version__` and stamps `[1.4.0] - 2026-04-16` in the changelog. All substantive changes already landed in PR #6.

## Highlights

### Added
- `max_decompressed_size` kwarg — decompression-bomb guard for untrusted input.
- `strict_size` kwarg — refuse writes past the gzip ISIZE 4 GiB limit instead of silently wrapping.

### Fixed
- **Behavior change:** truncated gzip streams now raise `gzip.BadGzipFile` on `read()` and `seek(0, SEEK_END)` instead of silently returning partial data.
- Write accounting (`_crc` / `_input_size` / `_position`) stays consistent after a failed underlying write; CRC masked to 32 bits; subsequent writes on a broken stream refuse rather than corrupt.
- `_cleanup_failed_enter` nulls `_file` in `finally` when close raises.
- 128 MiB upper bound on `chunk_size` and `peek(size=…)`.

### Performance
- zlib compress/decompress offloaded to the default executor for inputs ≥ 256 KiB. Concurrent-I/O benchmark ~4× faster; single-stream latency unchanged.

### Documentation
- README now covers append-mode multi-member semantics, ISIZE caveat (+`strict_size`), `max_decompressed_size`, and the concurrency result.

### Tooling
- `scripts/check_py38_compat.py` pre-commit hook guards the declared Python 3.8+ support since mypy ≥ 1.15 no longer targets 3.8.
- `/release-prep` skill refuses to run with unmerged local commits ahead of `origin/main`.

## Test plan

- [x] 317 tests passing locally (`pytest -q`)
- [x] Repo benchmarks: single-stream at parity, concurrent I/O +313%
- [x] pre-commit hooks green (ruff, mypy, ty, python38-compat, markdownlint)
- [ ] CI green

## Follow-up

After merge: run `/release-tag` to tag `v1.4.0` and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)