### PR TITLE
Prepare release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-04-23
+
 ### Added
 
 - Add `max_rewind_cache_size` to `AsyncGzipBinaryFile` and `AsyncGzipTextFile`. Non-seekable read streams now retain at most 128 MiB of compressed input by default for backward-seek replay; pass a byte limit to tune the cap or `None` to preserve the previous unbounded cache behavior.

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -19,7 +19,7 @@ from ._common import (
 )
 from ._text import AsyncGzipTextFile
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 
 def AsyncGzipFile(


### PR DESCRIPTION
## Summary

Release 1.5.0 bundles the review-driven correctness fixes and robustness improvements from PR #8 plus one new public kwarg.

### Added
- `max_rewind_cache_size` on `AsyncGzipBinaryFile` / `AsyncGzipTextFile` — non-seekable read streams now cap the backward-seek replay buffer at 128 MiB by default; pass an int to tune, or `None` for the previous unbounded behavior.

### Fixed
- `AsyncGzipTextFile.close()` no longer finalizes partially-read decoder state (previously could raise `UnicodeDecodeError` or skip closing the underlying binary stream).
- `AsyncGzipBinaryFile.close()` still closes owned / `closefd=True` file objects when the final flush or trailer write fails.
- Reject embedded NUL bytes in `original_filename` instead of writing malformed, unreadable headers.
- Reset `max_decompressed_size` accounting on rewind so re-reading a legal archive after `seek(0)` no longer trips the cap.
- Treat `seekable() == False` file objects as non-seekable even when they expose a `seek()` method — fall back to replay caching.

### Changed
- Keep underscore-prefixed implementation helpers out of `aiogzip.__all__`.
- Broaden `fileobj` constructor typing to accept read-only objects in read mode and write-only in write mode.
- Use `asyncio.get_running_loop()` for zlib executor dispatch.

### Documentation
- Document bounded rewind-cache behavior for non-seekable streams.

### Tooling
- Run the Python 3.8 syntax-compatibility guard in CI (not only pre-commit).
- `twine check dist/*` now runs in the publish workflow before upload.

## Test plan

- [x] Full suite: 329 passed
- [x] `scripts/check_py38_compat.py` passes
- [ ] CI green across Python 3.8–3.14

After merge, run `/release-tag` to tag and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)