### PR TITLE
Edge improvements: stale docs, CI breadth, coverage gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,21 @@ permissions:
 jobs:
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    # Defines a build matrix for your tests
+    runs-on: ${{ matrix.os }}
+    # Defines a build matrix for your tests. Linux runs the full Python
+    # version sweep; Windows and macOS run a single version each to guard
+    # platform-specific paths (e.g. os.linesep newline translation in text
+    # mode, path handling) without multiplying CI cost across the matrix.
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          - os: windows-latest
+            python-version: "3.12"
+          - os: macos-latest
+            python-version: "3.12"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -68,9 +78,12 @@ jobs:
           python scripts/check_py38_compat.py src/aiogzip/*.py
 
       # Step 9: Run tests with pytest and coverage
+      # --cov-fail-under gates against silent coverage regressions. The
+      # threshold sits a couple points below the current ~87% to absorb
+      # benign per-platform branch differences without nuisance failures.
       - name: Run tests with pytest and coverage
         run: |
-          pytest --cov --cov-report=term-missing --cov-report=xml
+          pytest --cov --cov-report=term-missing --cov-report=xml --cov-fail-under=85
 
   coverage-comment:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Before committing code changes, verify:
    pytest --cov --cov-report=term-missing
    ```
 
-   Ensure all 209+ tests pass with good coverage.
+   Ensure all 329+ tests pass with good coverage.
 
 3. **Check imports:**
 
@@ -88,8 +88,9 @@ Before committing code changes, verify:
 
 ## Test Coverage Best Practices
 
-- **Current coverage:** 86.74% (173 tests)
-- **Target:** Maintain or improve coverage
+- **Current coverage:** 87.27% (329 tests)
+- **Target:** Maintain or improve coverage. CI enforces a floor via
+  `--cov-fail-under=85`.
 - Always add tests for new features
 - Document edge cases with descriptive test names
 
@@ -108,12 +109,13 @@ Tests are organized by priority:
 
 - CRLF sequences can split across chunk boundaries
 - Must track `_trailing_cr` state to prevent `\r\n` → `\n\n`
-- Use `_get_line_terminator_pos()` helper for newline-aware searching
+- Use `_find_line_terminator()` helper for newline-aware searching
 
 ### Unicode Handling
 
 - Multibyte characters can split across buffers
-- Use `_safe_decode_with_remainder()` to handle incomplete sequences
+- Decoding uses an incremental codec (`codecs.getincrementaldecoder`) that
+  retains incomplete trailing bytes between chunks
 - Different encodings have different max incomplete byte counts
 
 ### Error Handling
@@ -124,7 +126,9 @@ Tests are organized by priority:
 
 ## CI/CD Notes
 
-The project uses GitHub Actions which tests against Python 3.8, 3.9, 3.10, 3.11, 3.12, and 3.13.
+The project uses GitHub Actions which tests against Python 3.8 through 3.14.
+Linux runs the full version sweep; Windows and macOS each run one version to
+guard platform-specific paths (e.g. `os.linesep` newline translation).
 
 **Any Python 3.9+ only syntax will fail CI!**
 
@@ -173,9 +177,11 @@ Always include:
 ## Version History
 
 - **0.3** - Major refactoring, binary/text separation
-- **Current (Unreleased)** - Bug fixes, test improvements, Python 3.8 compatibility
+- **1.5.0 (current)** - See `CHANGELOG.md` for the full release history. Recent
+  work includes the rewind cache for non-seekable streams, decompression-bomb
+  guards (`max_decompressed_size`), `strict_size`, and zlib executor offload.
 
 ---
 
-**Last Updated:** 2024-11-14
+**Last Updated:** 2026-05-28
 **Maintainer Notes:** Keep this file updated with new gotchas and best practices!

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - **Non-seekable input streams use a bounded rewind cache**. By default, up to 128 MiB of compressed input is retained so backward seeks can replay the stream; pass `max_rewind_cache_size=<bytes>` to tune this, or `None` to allow an unbounded cache.
 - **Writes past 4 GiB of uncompressed data** produce a gzip trailer whose `ISIZE` field wraps to `size & 0xFFFFFFFF` (this matches the gzip format spec and `gzip.open()`). Pass `strict_size=True` to refuse writes that would exceed the limit instead.
 - **Guard against decompression bombs** by passing `max_decompressed_size=<bytes>` when reading untrusted files; the decompressor aborts with `OSError` once the cap is exceeded.
+- **Use one file object per task.** An open `aiogzip` file is not safe for concurrent use by multiple `asyncio` tasks — its internal buffers and decoder/compressor state are mutated without locking, the same contract as standard-library file objects. Give each task its own file object, or serialize access behind your own lock.
 
 ## Quickstart
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,4 +88,6 @@ For `AsyncGzipTextFile`, `tell()` returns an opaque cookie value for the current
 
 Backward seeks restart decompression from the beginning of the gzip stream. For non-seekable `fileobj` inputs, `aiogzip` keeps a bounded compressed-input replay cache so rewind can work without loading unbounded data; tune it with `max_rewind_cache_size` or set it to `None` for the previous unbounded behavior.
 
+**Concurrency:** An open `aiogzip` file is not safe for concurrent use by multiple `asyncio` tasks. Its internal buffers and decoder/compressor state are mutated without locking — the same contract as standard-library file objects. Give each task its own file object, or serialize access behind your own lock.
+
 **Note:** `aiogzip` focuses on file-based operations and does not currently support in-memory compression/decompression (e.g., `gzip.compress`/`gzip.decompress`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,11 @@ ignore = ["E501"]  # Line too long (handled by formatter usually, but good to ig
 "src/aiogzip/__init__.py" = ["E402"]
 
 [tool.mypy]
-# mypy >= 1.15 no longer accepts python_version = "3.8"; the
-# pre-commit `python38-compat` hook guards the PEP 585/604 syntax.
-python_version = "3.9"
+# Newer mypy releases keep dropping support for older python_version values
+# (1.15 dropped 3.8; later releases dropped 3.9 — "must be 3.10 or higher").
+# This only sets the type-checking semantics; the real 3.8 floor is enforced
+# by the test matrix and the pre-commit `python38-compat` hook (PEP 585/604).
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -616,6 +616,11 @@ class AsyncGzipBinaryFile:
                 "the gzip member is unusable"
             )
 
+        # Declared explicitly so the two assignments share one type: the
+        # bytes/bytearray fast path and the coerced memoryview path would
+        # otherwise infer incompatible types under newer mypy (which treats
+        # memoryview as generic, memoryview[int]).
+        buffer: Union[bytes, bytearray, memoryview]
         if isinstance(data, (bytes, bytearray)):
             buffer = data
         else:

--- a/tests/test_binary_io.py
+++ b/tests/test_binary_io.py
@@ -115,6 +115,41 @@ class TestAsyncGzipBinaryFile:
             assert await f.read() == b"abcdef"
 
     @pytest.mark.asyncio
+    async def test_binary_accepts_noncontiguous_and_multibyte_buffers(self, temp_file):
+        """write() must coerce buffer-protocol inputs that are not already a
+        flat, single-byte, contiguous view.
+
+        Exercises the _coerce_byteslike branches for:
+        - a memoryview with itemsize != 1 (cast to bytes),
+        - a non-contiguous memoryview (copied via tobytes()),
+        - a generic buffer object that is not a memoryview (array).
+        """
+        from array import array
+
+        int_view = memoryview(array("i", [1, 2, 3]))  # itemsize 4 memoryview
+        noncontiguous = memoryview(bytearray(b"abcdef"))[::2]  # -> b"ace"
+        int_array = array("i", [4, 5, 6])  # generic buffer, itemsize 4
+        byte_array = array("b", [104, 105])  # generic itemsize-1 buffer -> b"hi"
+
+        assert not noncontiguous.contiguous  # guard the branch we mean to hit
+
+        expected = (
+            array("i", [1, 2, 3]).tobytes()
+            + b"ace"
+            + array("i", [4, 5, 6]).tobytes()
+            + b"hi"
+        )
+
+        async with AsyncGzipBinaryFile(temp_file, "wb") as f:
+            assert await f.write(int_view) == len(array("i", [1, 2, 3]).tobytes())
+            assert await f.write(noncontiguous) == 3
+            assert await f.write(int_array) == len(array("i", [4, 5, 6]).tobytes())
+            assert await f.write(byte_array) == 2
+
+        async with AsyncGzipBinaryFile(temp_file, "rb") as f:
+            assert await f.read() == expected
+
+    @pytest.mark.asyncio
     async def test_binary_interoperability_with_gzip(self, temp_file, sample_data):
         """Test interoperability with gzip.open for binary data."""
         async with AsyncGzipBinaryFile(temp_file, "wb") as f:

--- a/tests/test_binary_io.py
+++ b/tests/test_binary_io.py
@@ -407,11 +407,12 @@ class TestAsyncGzipBinaryFile:
             "inner1.txt": "alpha\nbeta",
             "inner2.txt": "gamma",
         }
-        # newline="" prevents Path.write_text from translating "\n" to
-        # os.linesep on Windows, so the on-disk bytes (and info.size) match
-        # the literal contents on every platform.
-        file1.write_text(contents["inner1.txt"], encoding="utf-8", newline="")
-        file2.write_text(contents["inner2.txt"], encoding="utf-8", newline="")
+        # write_bytes (not write_text) so "\n" is never translated to
+        # os.linesep on Windows; the on-disk bytes and info.size then match
+        # the literal contents on every platform. (write_text's newline=
+        # parameter is Python 3.10+, so it cannot be used here.)
+        file1.write_bytes(contents["inner1.txt"].encode("utf-8"))
+        file2.write_bytes(contents["inner2.txt"].encode("utf-8"))
         with tarfile.open(tar_path, "w:gz") as tar:
             tar.add(file1, arcname="inner1.txt")
             tar.add(file2, arcname="inner2.txt")

--- a/tests/test_binary_io.py
+++ b/tests/test_binary_io.py
@@ -407,8 +407,11 @@ class TestAsyncGzipBinaryFile:
             "inner1.txt": "alpha\nbeta",
             "inner2.txt": "gamma",
         }
-        file1.write_text(contents["inner1.txt"], encoding="utf-8")
-        file2.write_text(contents["inner2.txt"], encoding="utf-8")
+        # newline="" prevents Path.write_text from translating "\n" to
+        # os.linesep on Windows, so the on-disk bytes (and info.size) match
+        # the literal contents on every platform.
+        file1.write_text(contents["inner1.txt"], encoding="utf-8", newline="")
+        file2.write_text(contents["inner2.txt"], encoding="utf-8", newline="")
         with tarfile.open(tar_path, "w:gz") as tar:
             tar.add(file1, arcname="inner1.txt")
             tar.add(file2, arcname="inner2.txt")

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -749,6 +749,43 @@ class TestMediumPriorityEdgeCases:
         assert calls, "large decompress should have been offloaded"
 
     @pytest.mark.asyncio
+    async def test_large_subsequent_member_offloaded_to_executor(self, temp_file):
+        """A large second member, surfaced as unused_data after the first
+        member ends, must also be offloaded to the executor rather than
+        decompressed inline on the event loop."""
+        import gzip as _gzip
+        import os as _os
+        from unittest.mock import patch
+
+        from aiogzip import _binary
+
+        small = b"first member"
+        large = _os.urandom(2 * 1024 * 1024)  # incompressible second member
+        # Two concatenated gzip members.
+        with open(temp_file, "wb") as fh:
+            fh.write(_gzip.compress(small))
+            fh.write(_gzip.compress(large))
+
+        calls = []
+        original = _binary._run_zlib_in_thread
+
+        async def tracking(method, data):
+            calls.append(len(data))
+            return await original(method, data)
+
+        # A chunk_size large enough to read both members in one read, so the
+        # second member arrives as unused_data on the first decompressor.
+        with patch.object(_binary, "_run_zlib_in_thread", tracking):
+            async with AsyncGzipBinaryFile(
+                temp_file, "rb", chunk_size=8 * 1024 * 1024
+            ) as f:
+                got = await f.read()
+        assert got == small + large
+        assert any(n >= _binary._ZLIB_OFFLOAD_THRESHOLD for n in calls), (
+            "large subsequent member should have been offloaded"
+        )
+
+    @pytest.mark.asyncio
     async def test_strict_size_rejects_write_past_4gib(self, temp_file):
         """With strict_size=True, a write that would push _input_size past
         the gzip ISIZE field's 4 GiB cap must raise rather than silently

--- a/tests/test_text_io.py
+++ b/tests/test_text_io.py
@@ -255,7 +255,10 @@ class TestAsyncGzipTextFile:
     async def test_text_seek_cur_and_end_zero(self, temp_file):
         """Text seek should support zero-offset SEEK_CUR and SEEK_END."""
         text = "abc\ndef"
-        async with AsyncGzipTextFile(temp_file, "wt") as f:
+        # newline="" avoids translating "\n" to os.linesep on write (which is
+        # "\r\n" on Windows), so the byte position from SEEK_END matches
+        # len(text) on every platform.
+        async with AsyncGzipTextFile(temp_file, "wt", newline="") as f:
             await f.write(text)
 
         async with AsyncGzipTextFile(temp_file, "rt") as f:


### PR DESCRIPTION
Follow-up to a thorough project review. No `src/aiogzip/` behavior changes — these are documentation, CI, and test-coverage improvements at the edges. The review found no correctness bugs.

## Changes

### Refresh stale metadata + broaden CI (`958e5d5`)
- `CLAUDE.md` was ~18 months stale: claimed "Unreleased / 86.74% / 173 tests" (and elsewhere "209+ tests") when the project is at v1.5.0 with 329 tests at 87.27% coverage. Refreshed version/date/counts/CI range, and corrected two "Gotchas" references to helpers that have since been renamed/removed (`_get_line_terminator_pos` → `_find_line_terminator`; `_safe_decode_with_remainder` → the incremental codec).
- CI ran only on `ubuntu-latest`. Text write mode translates `\n` → `os.linesep` (a no-op on Linux, `\r\n` on Windows), so that path was never exercised. Added `windows-latest` + `macos-latest` legs (one Python version each) alongside the full Linux sweep, with `fail-fast: false`.
- Added `--cov-fail-under=85` so coverage can't silently regress (floor set a couple points below current ~87% to absorb benign per-platform branch differences).

### Tests for uncovered branches (`d0ed22f`)
- `_coerce_byteslike` non-bytes paths: memoryview with itemsize ≠ 1, non-contiguous memoryview, and generic buffer-protocol objects (`array`). Prior coverage only passed a flat bytes-backed memoryview, which short-circuits before those branches.
- The executor offload inside the multi-member `unused_data` loop (single-member large decompression was already tested; a large *second* member was not).
- Coverage 87.27% → 87.91%, 329 → 331 tests.

### Document the concurrency contract (`062fbee`)
- An open `aiogzip` file mutates its buffers and decoder/compressor state without locking, so it is not safe for concurrent use by multiple asyncio tasks (same contract as stdlib file objects). Added a note to the README caveats and the docs Compatibility section.
- Removed a stray empty untracked `.codex` file. (No `.gitignore` change for `.mypy_cache` — like `.ruff_cache` it self-ignores.)

## Verification
- `pytest` → 331 passing.
- `pytest --cov --cov-fail-under=85` → 87.91%, gate passes.
- `mkdocs build --strict` → succeeds; API page renders all public classes plus the `max_decompressed_size` / `strict_size` / `max_rewind_cache_size` params.
- Pre-commit hooks green on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)