### PR TITLE
Fix mypy config and type error for newer mypy releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,11 @@ ignore = ["E501"]  # Line too long (handled by formatter usually, but good to ig
 "src/aiogzip/__init__.py" = ["E402"]
 
 [tool.mypy]
-# mypy >= 1.15 no longer accepts python_version = "3.8"; the
-# pre-commit `python38-compat` hook guards the PEP 585/604 syntax.
-python_version = "3.9"
+# Newer mypy releases keep dropping support for older python_version values
+# (1.15 dropped 3.8; later releases dropped 3.9 — "must be 3.10 or higher").
+# This only sets the type-checking semantics; the real 3.8 floor is enforced
+# by the test matrix and the pre-commit `python38-compat` hook (PEP 585/604).
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -616,6 +616,11 @@ class AsyncGzipBinaryFile:
                 "the gzip member is unusable"
             )
 
+        # Declared explicitly so the two assignments share one type: the
+        # bytes/bytearray fast path and the coerced memoryview path would
+        # otherwise infer incompatible types under newer mypy (which treats
+        # memoryview as generic, memoryview[int]).
+        buffer: Union[bytes, bytearray, memoryview]
         if isinstance(data, (bytes, bytearray)):
             buffer = data
         else:


### PR DESCRIPTION
Newer mypy releases drop support for older `python_version` values and tighten `memoryview` typing, which breaks `mypy src` (and CI, which installs unpinned `mypy>=1.0.0`).

## Changes

- **`pyproject.toml`**: bump `[tool.mypy] python_version` from `3.9` to `3.10`. Recent mypy rejects 3.9 outright: *"python_version: Python 3.9 is not supported (must be 3.10 or higher)."* This only sets type-checking semantics — the real 3.8 runtime floor is still enforced by the test matrix and the `python38-compat` pre-commit hook.
- **`src/aiogzip/_binary.py`**: under ≥3.10 semantics, newer mypy treats `memoryview` as generic (`memoryview[int]`) and flags `write()`'s `buffer` variable, which is assigned both a `bytes | bytearray` (fast path) and the coerced `bytes | bytearray | memoryview` (slow path), as an incompatible assignment. Declare `buffer` explicitly as `Union[bytes, bytearray, memoryview]`.

## Verification
- `mypy src` → clean.
- `python scripts/check_py38_compat.py src/aiogzip/*.py` → clean (bare `memoryview`, no subscript).
- Full test suite → 329 passing. No runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)