### PR TITLE
Faster bulk read(-1) and large text read(size)

### DIFF
--- a/benchmarks/bench_io.py
+++ b/benchmarks/bench_io.py
@@ -335,6 +335,101 @@ class IoBenchmarks(BenchmarkBase):
             lines_per_sec=f"{len(lines) / duration:.0f}",
         )
 
+    async def benchmark_read_all_isolated(self):
+        """Full-read throughput with the write excluded from the timed region.
+
+        Isolates ``read(-1)`` so the cost of copying decompressed output shows
+        up directly (the bulk benchmark folds write+compression into its
+        totals). Uses highly compressible data, where decompression is cheap
+        and the output copy is the dominant cost; larger ``--size`` makes the
+        signal cleaner.
+        """
+        payload = self.data_gen.generate_compressible(self.data_size_mb)
+        aiogzip_file = self.temp_mgr.get_path("readall_isolated.gz")
+        gzip_file = self.temp_mgr.get_path("readall_isolated_gzip.gz")
+
+        # Write outside the timed region.
+        async with AsyncGzipBinaryFile(aiogzip_file, "wb") as f:
+            await f.write(payload)
+        with gzip.open(gzip_file, "wb") as f:
+            f.write(payload)
+
+        chunk_size = 512 * 1024
+        aiogzip_times = []
+        for _ in range(5):
+            start = time.perf_counter()
+            async with AsyncGzipBinaryFile(
+                aiogzip_file, "rb", chunk_size=chunk_size
+            ) as f:
+                await f.read()
+            aiogzip_times.append(time.perf_counter() - start)
+        aiogzip_best = min(aiogzip_times)
+
+        gzip_times = []
+        for _ in range(5):
+            start = time.perf_counter()
+            with gzip.open(gzip_file, "rb") as f:
+                f.read()
+            gzip_times.append(time.perf_counter() - start)
+        gzip_best = min(gzip_times)
+
+        mb = len(payload) / (1024 * 1024)
+        self.add_result(
+            "Read-all isolated (compressible, read-only timing)",
+            "io",
+            aiogzip_best,
+            aiogzip_read_best=f"{aiogzip_best * 1000:.2f}ms",
+            gzip_read_best=f"{gzip_best * 1000:.2f}ms",
+            aiogzip_throughput=f"{mb / aiogzip_best:.1f} MB/s"
+            if aiogzip_best > 0
+            else "N/A",
+            speedup=format_speedup(aiogzip_best, gzip_best),
+        )
+
+    async def benchmark_text_large_reads(self):
+        """Large single ``read(size)`` and a single very long line.
+
+        Both paths previously accumulated text via repeated ``str +=`` (O(n^2));
+        this records their throughput so a regression to quadratic scaling is
+        visible. Uses a no-newline blob so ``read(size)`` and ``readline()``
+        must accumulate across many chunks.
+        """
+        n = self.data_size_mb * 1024 * 1024
+        blob = "x" * n
+        path = self.temp_mgr.get_path("text_large_reads.gz")
+        async with AsyncGzipTextFile(path, "wt") as f:
+            await f.write(blob)
+
+        chunk_size = 64 * 1024
+
+        sized_times = []
+        for _ in range(5):
+            start = time.perf_counter()
+            async with AsyncGzipTextFile(path, "rt", chunk_size=chunk_size) as f:
+                _ = await f.read(n)
+            sized_times.append(time.perf_counter() - start)
+        sized_best = min(sized_times)
+
+        line_times = []
+        for _ in range(5):
+            start = time.perf_counter()
+            async with AsyncGzipTextFile(path, "rt", chunk_size=chunk_size) as f:
+                _ = await f.readline()
+            line_times.append(time.perf_counter() - start)
+        line_best = min(line_times)
+
+        mchars = n / (1024 * 1024)
+        self.add_result(
+            "Text large reads (sized read + long line, O(n) accumulation)",
+            "io",
+            sized_best,
+            read_size_best=f"{sized_best * 1000:.2f}ms",
+            readline_long_best=f"{line_best * 1000:.2f}ms",
+            read_size_throughput=f"{mchars / sized_best:.1f} Mchar/s"
+            if sized_best > 0
+            else "N/A",
+        )
+
     async def run_all(self):
         """Run all I/O benchmarks."""
         await self.benchmark_binary_small_chunks()
@@ -344,3 +439,5 @@ class IoBenchmarks(BenchmarkBase):
         await self.benchmark_line_iteration()
         await self.benchmark_flush_operations()
         await self.benchmark_readline()
+        await self.benchmark_read_all_isolated()
+        await self.benchmark_text_large_reads()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,11 @@ ignore = ["E501"]  # Line too long (handled by formatter usually, but good to ig
 "src/aiogzip/__init__.py" = ["E402"]
 
 [tool.mypy]
-# mypy >= 1.15 no longer accepts python_version = "3.8"; the
-# pre-commit `python38-compat` hook guards the PEP 585/604 syntax.
-python_version = "3.9"
+# Newer mypy releases keep dropping support for older python_version values
+# (1.15 dropped 3.8; later releases dropped 3.9 — "must be 3.10 or higher").
+# This only sets the type-checking semantics; the real 3.8 floor is enforced
+# by the test matrix and the pre-commit `python38-compat` hook (PEP 585/604).
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -739,12 +739,14 @@ class AsyncGzipBinaryFile:
             del buf[:]
             self._buffer_offset = 0
 
+            # Append decompressor output directly to the join list. Each piece
+            # is already a distinct bytes object, so this avoids copying every
+            # byte through self._buffer (extend + bytes()) only to copy again
+            # in the final join — the dominant cost for large read-all calls.
             while not self._eof:
-                await self._fill_buffer()
-                if self._buffer:
-                    chunks.append(bytes(self._buffer))
-                    total_read += len(self._buffer)
-                    del self._buffer[:]
+                for piece in await self._decompress_next():
+                    chunks.append(piece)
+                    total_read += len(piece)
 
             self._position += total_read
             return b"".join(chunks)
@@ -788,14 +790,22 @@ class AsyncGzipBinaryFile:
 
             return data_to_return
 
-    async def _fill_buffer(self) -> None:
-        """Internal helper to read a compressed chunk and decompress it.
+    async def _decompress_next(self) -> List[bytes]:
+        """Read the next compressed chunk and return its decompressed pieces.
 
-        Handles multi-member gzip archives (created by append mode) by detecting
-        when one member ends and starting a new decompressor for the next member.
+        This is the shared decompression core. It advances EOF state, parses
+        the gzip header mtime, walks multi-member archives (created by append
+        mode), performs end-of-stream finalization/validation, and enforces
+        ``max_decompressed_size``.
+
+        Each decompressor call already returns a fresh ``bytes`` object, so the
+        pieces are handed back as-is: ``read(-1)`` appends them straight to its
+        join list (avoiding a round-trip through ``self._buffer``), while
+        ``_fill_buffer`` extends the buffer with them for the partial-read
+        paths. Returns an empty list at or after EOF.
         """
         if self._eof or self._file is None:
-            return
+            return []
 
         compressed_chunk = await self._read_compressed_chunk()
 
@@ -813,13 +823,14 @@ class AsyncGzipBinaryFile:
             self._eof = True
             try:
                 remaining = self._engine.flush()
-                if remaining:
-                    self._buffer.extend(remaining)
-                    self._account_decompressed(len(remaining))
             except zlib.error as e:
                 raise gzip.BadGzipFile(
                     f"Error finalizing gzip decompression: {e}"
                 ) from e
+            pieces: List[bytes] = []
+            if remaining:
+                self._account_decompressed(len(remaining))
+                pieces.append(remaining)
             # After the underlying file is drained, the decompressor must
             # have consumed a complete gzip member — otherwise the file
             # was truncated mid-stream and silently ignoring that would
@@ -830,9 +841,10 @@ class AsyncGzipBinaryFile:
                     "the member trailer was read; the file is truncated "
                     "or incomplete"
                 )
-            return
+            return pieces
 
         # Decompress the chunk
+        pieces = []
         try:
             if len(compressed_chunk) >= _ZLIB_OFFLOAD_THRESHOLD:
                 decompressed = await _run_zlib_in_thread(
@@ -840,8 +852,9 @@ class AsyncGzipBinaryFile:
                 )
             else:
                 decompressed = self._engine.decompress(compressed_chunk)
-            self._buffer.extend(decompressed)
-            self._account_decompressed(len(decompressed))
+            if decompressed:
+                self._account_decompressed(len(decompressed))
+                pieces.append(decompressed)
 
             # Handle multi-member gzip archives (created by append mode).
             # CPython's gzip reader ignores zero padding between/after members,
@@ -859,8 +872,9 @@ class AsyncGzipBinaryFile:
                     )
                 else:
                     decompressed = self._engine.decompress(unused)
-                self._buffer.extend(decompressed)
-                self._account_decompressed(len(decompressed))
+                if decompressed:
+                    self._account_decompressed(len(decompressed))
+                    pieces.append(decompressed)
                 unused = self._engine.unused_data
         except zlib.error as e:
             raise gzip.BadGzipFile(f"Error decompressing gzip data: {e}") from e
@@ -870,6 +884,17 @@ class AsyncGzipBinaryFile:
             raise
         except Exception as e:
             raise OSError(f"Unexpected error during decompression: {e}") from e
+        return pieces
+
+    async def _fill_buffer(self) -> None:
+        """Decompress the next compressed chunk into the read buffer.
+
+        Thin wrapper over :meth:`_decompress_next` used by the partial-read
+        paths (``read(size)``, ``readline``, ``peek``, ``seek``) that need the
+        decoded bytes accumulated in ``self._buffer``.
+        """
+        for piece in await self._decompress_next():
+            self._buffer.extend(piece)
 
     def _account_decompressed(self, n: int) -> None:
         """Track total decompressed output and enforce max_decompressed_size.

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -616,6 +616,11 @@ class AsyncGzipBinaryFile:
                 "the gzip member is unusable"
             )
 
+        # Declared explicitly so the two assignments share one type: the
+        # bytes/bytearray fast path and the coerced memoryview path would
+        # otherwise infer incompatible types under newer mypy (which treats
+        # memoryview as generic, memoryview[int]).
+        buffer: Union[bytes, bytearray, memoryview]
         if isinstance(data, (bytes, bytearray)):
             buffer = data
         else:

--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -915,6 +915,56 @@ class AsyncGzipTextFile:
             self._seen_newline_types |= self._SEEN_CR
             self._trailing_cr = False
 
+    # Newline modes whose line terminator is a single character that cannot
+    # span a chunk boundary, so each decoded chunk can be searched on its own:
+    #   - None: CR/CRLF were already folded to '\n' at decode time;
+    #   - '\n' / '\r': single-character terminators with no translation.
+    # '\r\n' (two chars) and '' (trailing-CR look-ahead) can straddle chunk
+    # boundaries and stay on the buffer-accumulating path.
+    _FAST_READLINE_NEWLINES = frozenset({None, "\n", "\r"})
+
+    async def _readline_fast(self) -> str:
+        """O(n) single-line read for the cross-boundary-safe newline modes.
+
+        Accumulates the line in a local list and joins once, instead of
+        repeatedly growing the str buffer via ``_append_buffer`` (which is
+        O(n^2) for a very long line because CPython cannot extend a slotted
+        str attribute in place). Returns "" at end of input.
+
+        Only valid when ``self._newline in _FAST_READLINE_NEWLINES``.
+        """
+        term = "\r" if self._newline == "\r" else "\n"
+
+        # 1. Satisfy from already-buffered text when it holds a terminator.
+        buf = self._text_buffer
+        start = self._text_buffer_offset
+        idx = buf.find(term, start)
+        if idx != -1:
+            return self._consume_buffer(idx + 1 - start)
+
+        # 2. The buffered remainder (if any) is part of this line. Pull it out
+        #    and accumulate freshly decoded chunks locally.
+        parts: List[str] = []
+        if start < len(buf):
+            parts.append(buf[start:] if start else buf)
+        self._set_buffer("")
+
+        while True:
+            text, more = await self._decode_next_chunk()
+            if text:
+                i = text.find(term)
+                if i != -1:
+                    parts.append(text[: i + 1])
+                    # Keep the whole chunk buffered so the residual's replay
+                    # origin (captured by _decode_next_chunk before decoding
+                    # it) stays valid for tell()/seek().
+                    self._set_buffer(text)
+                    self._text_buffer_offset = i + 1
+                    return "".join(parts)
+                parts.append(text)
+            if not more:
+                return "".join(parts)
+
     def __aiter__(self) -> "AsyncGzipTextFile":
         """Make AsyncGzipTextFile iterable for line-by-line reading."""
         return self
@@ -923,6 +973,12 @@ class AsyncGzipTextFile:
         """Return the next line from the file."""
         if self._is_closed:
             raise StopAsyncIteration
+
+        if self._newline in self._FAST_READLINE_NEWLINES:
+            line = await self._readline_fast()
+            if line == "":
+                raise StopAsyncIteration
+            return line
 
         search_from = 0
         while True:
@@ -972,6 +1028,12 @@ class AsyncGzipTextFile:
             limit = -1
         if limit == 0:
             return ""
+
+        # Unbounded reads in a cross-boundary-safe newline mode use the O(n)
+        # local-accumulation path. Bounded reads (limit != -1) cap the work at
+        # `limit` characters anyway, so they stay on the buffer path below.
+        if limit == -1 and self._newline in self._FAST_READLINE_NEWLINES:
+            return await self._readline_fast()
 
         # Try to get a line from our buffer using newline-aware search
         search_from = 0

--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -654,6 +654,46 @@ class AsyncGzipTextFile:
 
         return True
 
+    async def _decode_next_chunk(self) -> Tuple[str, bool]:
+        """Decode the next binary chunk into newline-translated text.
+
+        Mirrors :meth:`_read_chunk_and_decode` but returns the translated text
+        instead of appending it to the buffer, so callers can accumulate it in
+        a local list (avoiding the quadratic ``str +=`` for large reads).
+        Captures the replay origin when the buffer is empty, exactly as the
+        append path does, so ``tell()``/``seek()`` cookies stay valid.
+
+        Returns:
+            (text, more): ``text`` is the translated text decoded this round
+            (may be empty when a chunk decoded to nothing yet, e.g. an
+            incomplete multibyte sequence); ``more`` is False once the input
+            is exhausted.
+        """
+        bf = self._binary_file
+        if bf is None:
+            return "", False
+
+        if bf._eof:
+            self._finalize_pending_newline_state()
+            return "", False
+
+        if len(self._text_buffer) == self._text_buffer_offset:
+            self._capture_buffer_origin()
+
+        raw_chunk = await bf.read(self._chunk_size)
+        if not raw_chunk:
+            final_decoded = self._decoder.decode(b"", final=True)
+            translated = (
+                self._apply_newline_decoding(final_decoded) if final_decoded else ""
+            )
+            self._finalize_pending_newline_state()
+            return translated, False
+
+        decoded_chunk = self._decoder.decode(raw_chunk, final=False)
+        if decoded_chunk:
+            return self._apply_newline_decoding(decoded_chunk), True
+        return "", True
+
     async def read(self, size: int = -1) -> str:
         """
         Reads and decodes text data from the file.
@@ -713,14 +753,38 @@ class AsyncGzipTextFile:
 
             return "".join(chunks)
         else:
-            # Check if we have enough data in our text buffer
-            while self._buffered_text_len() < size:
-                has_more = await self._read_chunk_and_decode()
-                if not has_more:
+            # Serve from already-buffered text first, then pull freshly decoded
+            # chunks into a local list and join once. Appending each chunk to
+            # the str buffer via _append_buffer is O(n^2) for large sized reads
+            # (CPython can't do in-place += on a slotted attribute); local
+            # accumulation keeps this O(n).
+            result_parts: List[str] = []
+            need = size
+
+            buffered = self._buffered_text_len()
+            if buffered:
+                take = min(need, buffered)
+                result_parts.append(self._consume_buffer(take))
+                need -= take
+
+            while need > 0:
+                text, more = await self._decode_next_chunk()
+                if text:
+                    if len(text) <= need:
+                        result_parts.append(text)
+                        need -= len(text)
+                    else:
+                        # Keep the whole chunk in the buffer so its replay
+                        # origin stays valid for tell()/seek(), then consume
+                        # exactly `need` characters from it.
+                        self._set_buffer(text)
+                        result_parts.append(self._consume_buffer(need))
+                        need = 0
+                        break
+                if not more:
                     break
 
-            # Return the requested number of characters
-            return self._consume_buffer(size)
+            return "".join(result_parts)
 
     def _find_line_terminator(self, search_from: int = 0) -> Tuple[int, int]:
         """Find position of next line terminator in the buffered text.

--- a/tests/test_readline_longline.py
+++ b/tests/test_readline_longline.py
@@ -1,0 +1,139 @@
+# pyrefly: ignore
+# pyrefly: disable=all
+"""Correctness tests for the O(n) readline/iteration fast path.
+
+These exercise the local-accumulation path added for long lines, and verify it
+matches stdlib gzip's TextIOWrapper line splitting across newline modes, chunk
+sizes, and boundary conditions (CRLF split across chunks, trailing CR, last
+line without a terminator). The fallback modes ('\\r\\n', '') and limited
+readline are covered too.
+"""
+
+import gzip
+import os
+import tempfile
+
+import pytest
+
+from aiogzip import AsyncGzipTextFile
+
+# Content deliberately mixes terminator styles, includes a multi-chunk-long
+# line, a CRLF straddling a likely chunk boundary, a trailing standalone CR,
+# empty lines, and a final line with no terminator.
+CONTENT = (
+    "alpha\n"
+    "beta\r\n"
+    "gamma\rdelta\n"
+    "\n"
+    + ("x" * 200_000)  # one very long line -> spans many small chunks
+    + "\n"
+    + "y" * 4093
+    + "\r\n"  # CRLF positioned to straddle a 4096-char chunk boundary
+    + "epsilon\r"
+    + "zeta_no_terminator"
+)
+
+NEWLINE_MODES = [None, "", "\n", "\r", "\r\n"]
+CHUNK_SIZES = [64, 4096, 64 * 1024]
+
+
+def _write(path: str) -> None:
+    # Write exact bytes so terminators are preserved verbatim.
+    with gzip.open(path, "wb") as f:
+        f.write(CONTENT.encode("utf-8"))
+
+
+@pytest.fixture
+def longline_file():
+    path = tempfile.mktemp(suffix=".gz")
+    _write(path)
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+async def _aiogzip_iter(path, newline, chunk_size):
+    out = []
+    async with AsyncGzipTextFile(
+        path, "rt", newline=newline, chunk_size=chunk_size
+    ) as f:
+        async for line in f:
+            out.append(line)
+    return out
+
+
+async def _aiogzip_readline(path, newline, chunk_size):
+    out = []
+    async with AsyncGzipTextFile(
+        path, "rt", newline=newline, chunk_size=chunk_size
+    ) as f:
+        while True:
+            line = await f.readline()
+            if not line:
+                break
+            out.append(line)
+    return out
+
+
+def _gzip_lines(path, newline):
+    with gzip.open(path, "rt", newline=newline) as f:
+        return list(f)
+
+
+@pytest.mark.parametrize("newline", NEWLINE_MODES)
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZES)
+@pytest.mark.asyncio
+async def test_iteration_matches_gzip(longline_file, newline, chunk_size):
+    expected = _gzip_lines(longline_file, newline)
+    got = await _aiogzip_iter(longline_file, newline, chunk_size)
+    assert got == expected
+
+
+@pytest.mark.parametrize("newline", NEWLINE_MODES)
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZES)
+@pytest.mark.asyncio
+async def test_readline_matches_gzip(longline_file, newline, chunk_size):
+    expected = _gzip_lines(longline_file, newline)
+    got = await _aiogzip_readline(longline_file, newline, chunk_size)
+    assert got == expected
+
+
+@pytest.mark.parametrize("newline", [None, "\n", "\r"])
+@pytest.mark.asyncio
+async def test_single_long_line_no_terminator(newline):
+    """The accumulate-to-EOF branch of the fast path: one line, no terminator."""
+    path = tempfile.mktemp(suffix=".gz")
+    line = "q" * (5 * 1024 * 1024)
+    with gzip.open(path, "wb") as f:
+        f.write(line.encode("utf-8"))
+    try:
+        async with AsyncGzipTextFile(path, "rt", newline=newline, chunk_size=4096) as f:
+            got = await f.readline()
+            assert got == line
+            assert await f.readline() == ""  # EOF
+    finally:
+        os.unlink(path)
+
+
+@pytest.mark.asyncio
+async def test_limit_readline_still_bounded(longline_file):
+    """readline(limit) keeps the existing bounded behaviour (fallback path)."""
+    async with AsyncGzipTextFile(longline_file, "rt", chunk_size=64) as f:
+        first = await f.readline(3)
+        assert first == "alp"  # truncated at limit, no terminator consumed
+        rest = await f.readline()
+        assert rest == "ha\n"
+
+
+@pytest.mark.asyncio
+async def test_tell_seek_around_fast_readline(longline_file):
+    """tell() after a fast-path readline must round-trip through seek()."""
+    async with AsyncGzipTextFile(longline_file, "rt", chunk_size=128) as f:
+        await f.readline()  # alpha\n
+        await f.readline()  # beta\r\n -> normalized
+        cookie = await f.tell()
+        after1 = await f.read()
+        await f.seek(cookie)
+        after2 = await f.read()
+        assert after1 == after2
+        assert after1  # non-empty (long line follows)


### PR DESCRIPTION
Read-path speedups for `AsyncGzip*File`. **Stacked on #11** (the mypy fix) so this branch's CI is green — retarget to `main` once #11 merges. No public API or behavior change; 364 tests pass (35 new) and `mypy src` is clean.

## 1. Binary `read(-1)`: avoid a double copy (`93e45b3`)
`read(-1)` routed every decompressed chunk through `self._buffer` — copied into the bytearray (`extend`), back out (`bytes(self._buffer)`), then a third time in the final `join`. The bytearray round-trip only exists for the partial-read paths.

Extracted the decompression core into `_decompress_next() -> List[bytes]`; `read(-1)` appends pieces straight to its join list, and `_fill_buffer` is now a thin wrapper for the partial-read paths (identical behavior). Isolated 64 MB read-all: compressible binary ~1.8× faster at 512 KB chunks, text `read(-1)` ~1.25×; incompressible neutral.

## 2. Text `read(size)`: O(n²) → O(n) (`d2383e2`)
`read(size)` accumulated via `self._text_buffer += text`; a slotted str attribute can't be extended in place, so each append recopied the whole accumulator. Added `_decode_next_chunk()` (decodes + newline-translates a chunk, capturing the replay origin, without appending); `read(size)` now accumulates in a local list and joins once, keeping only the final partial chunk buffered so `tell()`/`seek()` stays valid. `read(32 MB)`: ~383 ms → ~50 ms (**7.6×**), now linear.

## 3. Long-line `readline()`/iteration: O(n²) → O(n) (`a6b4af4`)
Same `str +=` root cause for a single very long line. Added `_readline_fast()` for newline modes whose terminator can't span a chunk boundary (`None` — CR/CRLF already folded to `\n` at decode time — and single-char `\n`/`\r`): each decoded chunk is searched independently and the line accumulated in a local list. `readline()` uses it only for `limit == -1`; `\r\n` and `''` (terminators that can straddle a boundary) and bounded reads keep the existing path. `readline()` of a 32 MB line: ~368 ms → ~51 ms (**~7.2×**), now linear.

New `tests/test_readline_longline.py` (35 cases) checks iteration and `readline()` against stdlib `gzip` across **all five newline modes** and several chunk sizes, plus the accumulate-to-EOF branch, bounded `readline()`, and `tell()`/`seek()` round-trips.

## Benchmarks (`7fa9e40`)
Folded the scratch probes into `benchmarks/bench_io.py` as permanent cases: "Read-all isolated" (times `read(-1)` with the write excluded) and "Text large reads" (large `read(size)` + long-line `readline()`), so a regression back to O(n²) is visible at larger `--size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
