### PR TITLE
Increase default chunk_size to 256 KiB

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,11 @@ ignore = ["E501"]  # Line too long (handled by formatter usually, but good to ig
 "src/aiogzip/__init__.py" = ["E402"]
 
 [tool.mypy]
-# mypy >= 1.15 no longer accepts python_version = "3.8"; the
-# pre-commit `python38-compat` hook guards the PEP 585/604 syntax.
-python_version = "3.9"
+# Newer mypy releases keep dropping support for older python_version values
+# (1.15 dropped 3.8; later releases dropped 3.9 — "must be 3.10 or higher").
+# This only sets the type-checking semantics; the real 3.8 floor is enforced
+# by the test matrix and the pre-commit `python38-compat` hook (PEP 585/604).
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -117,11 +117,17 @@ class AsyncGzipBinaryFile:
         "_strict_size",
     )
 
-    DEFAULT_CHUNK_SIZE = 64 * 1024  # 64 KB
+    # 256 KiB balances bulk-read throughput against per-file memory. Below it
+    # (e.g. the former 64 KiB) read-all throughput drops ~35-60% on large
+    # files from per-chunk overhead, and decompression never reaches the
+    # _ZLIB_OFFLOAD_THRESHOLD so it cannot offload to the executor. Larger
+    # sizes give little extra while costing proportionally more memory per
+    # open file. Callers can still pass any chunk_size explicitly.
+    DEFAULT_CHUNK_SIZE = 256 * 1024  # 256 KiB
     # When the read buffer's head offset crosses this, drop the consumed
     # prefix so the bytearray does not grow unbounded while reads march
     # forward. Matches DEFAULT_CHUNK_SIZE so a full typical chunk fits.
-    BUFFER_COMPACTION_THRESHOLD = 64 * 1024
+    BUFFER_COMPACTION_THRESHOLD = 256 * 1024
     # Reusable zero-chunk size for write-mode forward seek() filler.
     _SEEK_ZERO_CHUNK_SIZE = 1024
 

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -616,6 +616,11 @@ class AsyncGzipBinaryFile:
                 "the gzip member is unusable"
             )
 
+        # Declared explicitly so the two assignments share one type: the
+        # bytes/bytearray fast path and the coerced memoryview path would
+        # otherwise infer incompatible types under newer mypy (which treats
+        # memoryview as generic, memoryview[int]).
+        buffer: Union[bytes, bytearray, memoryview]
         if isinstance(data, (bytes, bytearray)):
             buffer = data
         else:

--- a/tests/test_factory_api.py
+++ b/tests/test_factory_api.py
@@ -262,7 +262,7 @@ class TestAsyncGzipFile:
     @pytest.mark.asyncio
     async def test_default_chunk_size(self):
         """Test default chunk size."""
-        assert AsyncGzipBinaryFile.DEFAULT_CHUNK_SIZE == 64 * 1024
+        assert AsyncGzipBinaryFile.DEFAULT_CHUNK_SIZE == 256 * 1024
 
     @pytest.mark.asyncio
     async def test_interoperability_with_gzip_binary(self, temp_file, sample_data):


### PR DESCRIPTION
Bumps the default read/write `chunk_size` from **64 KiB to 256 KiB**. **Stacked on #11** (the mypy fix) for green CI — retarget to `main` once #11 merges.

## Why
Measured read-all throughput on a 64 MB file (best of 7) climbs sharply with larger chunks:

| chunk_size | incompressible | compressible |
|---|---|---|
| 64 KiB (old default) | 946 MB/s | 1068 MB/s |
| **256 KiB (new default)** | **1286 MB/s** | **1686 MB/s** |
| 512 KiB | 1488 MB/s | 1659 MB/s |

256 KiB captures most of the gain (~1.35× incompressible, ~1.6× compressible) at modest cost (~+192 KiB of buffers per open file vs 64 KiB), and is the point where a decompressed chunk reaches `_ZLIB_OFFLOAD_THRESHOLD`, so decompression can offload to the executor by default. `BUFFER_COMPACTION_THRESHOLD` is bumped in step to preserve its "a full typical chunk fits before compaction" invariant.

## Behavior change
Larger default buffers per open file. Callers needing the old footprint can pass `chunk_size=64*1024`. `AsyncGzipTextFile` inherits the default automatically. Warrants a **minor version bump**; the changelog entry will be generated from this commit at release time.

## Verification
- Full suite: 329 passing (updated the `DEFAULT_CHUNK_SIZE == 64*1024` assertion in `test_factory_api.py`).
- `mypy src` clean; py38-compat clean.

Derived from the #4/#5 measurement pass; #4 (crc32 loop-block) was measured at ≤~1 ms even for 8 MB writes and intentionally **not** pursued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)