### PR TITLE
Tests: cover gzip header-field parsing and validation branches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,11 @@ ignore = ["E501"]  # Line too long (handled by formatter usually, but good to ig
 "src/aiogzip/__init__.py" = ["E402"]
 
 [tool.mypy]
-# mypy >= 1.15 no longer accepts python_version = "3.8"; the
-# pre-commit `python38-compat` hook guards the PEP 585/604 syntax.
-python_version = "3.9"
+# Newer mypy releases keep dropping support for older python_version values
+# (1.15 dropped 3.8; later releases dropped 3.9 — "must be 3.10 or higher").
+# This only sets the type-checking semantics; the real 3.8 floor is enforced
+# by the test matrix and the pre-commit `python38-compat` hook (PEP 585/604).
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -616,6 +616,11 @@ class AsyncGzipBinaryFile:
                 "the gzip member is unusable"
             )
 
+        # Declared explicitly so the two assignments share one type: the
+        # bytes/bytearray fast path and the coerced memoryview path would
+        # otherwise infer incompatible types under newer mypy (which treats
+        # memoryview as generic, memoryview[int]).
+        buffer: Union[bytes, bytearray, memoryview]
         if isinstance(data, (bytes, bytearray)):
             buffer = data
         else:


### PR DESCRIPTION
Test-only PR. **No source changes.** Targets genuinely-uncovered, real logic (not defensive one-liners). Includes the mypy fix commit as a base (like #12/#13); that commit drops out once #11 merges.

## What it covers
- **gzip header parsing** (`_common.py`'s `_try_parse_gzip_header_mtime`): the optional **FEXTRA / FNAME / FCOMMENT / FHCRC** fields, which Python's `gzip` module never emits and which had **zero coverage**. A hand-built member sets all four flags; reading it with a tiny `chunk_size` delivers the header a few bytes at a time, exercising both the incomplete-header early returns and the completed parse. Lifts `_common.py` from **~88% → 98%** (only the `Protocol` method stubs remain).
- **constructor validation**: `mtime` type/range and `original_filename` type errors.
- **close-path**: `close()` propagating an underlying `close()` failure (owned writer, `closefd=True`, no prior write error), and binary `__anext__` on a closed file raising `StopAsyncIteration`.

## Notes
- 7 new tests, all green locally; `mypy`/py38-compat clean.
- `max_decompressed_size` was *not* expanded — it already has thorough coverage (18 existing references).
- The new tests are platform-agnostic (raw bytes, no `os.linesep` assumptions — the lesson from #10's Windows leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)