### PR TITLE
Tests: cover header parsing, validation, and text fallback/newline paths

### DIFF
--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -1,0 +1,147 @@
+# pyrefly: ignore
+# pyrefly: disable=all
+"""Targeted tests for previously-uncovered, real-logic branches.
+
+Covers:
+- gzip header parsing of the optional FEXTRA / FNAME / FCOMMENT / FHCRC fields,
+  including the incomplete-header (split across reads) early-return branches in
+  ``_try_parse_gzip_header_mtime`` (``_common.py``);
+- ``mtime`` / ``original_filename`` constructor validation;
+- the close() path that propagates an underlying ``close()`` failure, and binary
+  ``__anext__`` on an already-closed file.
+"""
+
+import gzip
+import io
+import struct
+import zlib
+
+import pytest
+
+from aiogzip import AsyncGzipBinaryFile
+
+# gzip header flag bits
+_FHCRC = 0x02
+_FEXTRA = 0x04
+_FNAME = 0x08
+_FCOMMENT = 0x10
+
+
+def _gzip_member_with_all_header_fields(body: bytes, mtime: int) -> bytes:
+    """Hand-build a single gzip member whose header sets every optional flag.
+
+    Python's gzip module only ever emits FNAME, so FEXTRA/FCOMMENT/FHCRC have to
+    be constructed by hand to exercise their parsing paths.
+    """
+    flags = _FEXTRA | _FNAME | _FCOMMENT | _FHCRC
+    header = bytearray(b"\x1f\x8b\x08")  # magic + DEFLATE method
+    header.append(flags)
+    header += struct.pack("<I", mtime)
+    header += bytes([0x00, 0xFF])  # XFL, OS=unknown
+
+    # FEXTRA: a single subfield "AB" of length 2 ("xy").
+    extra = b"AB" + struct.pack("<H", 2) + b"xy"
+    header += struct.pack("<H", len(extra)) + extra
+    # FNAME and FCOMMENT: NUL-terminated latin-1 strings.
+    header += b"original.bin\x00"
+    header += b"a header comment\x00"
+    # FHCRC: low 16 bits of the CRC32 of the header bytes so far.
+    header += struct.pack("<H", zlib.crc32(bytes(header)) & 0xFFFF)
+
+    compressor = zlib.compressobj(6, zlib.DEFLATED, -zlib.MAX_WBITS)
+    compressed = compressor.compress(body) + compressor.flush()
+    trailer = struct.pack("<II", zlib.crc32(body) & 0xFFFFFFFF, len(body) & 0xFFFFFFFF)
+    return bytes(header) + compressed + trailer
+
+
+@pytest.mark.asyncio
+async def test_reads_member_with_all_optional_header_fields(tmp_path):
+    """A member with FEXTRA+FNAME+FCOMMENT+FHCRC must decompress and expose mtime.
+
+    Reading with a tiny chunk_size delivers the header a few bytes at a time, so
+    the parser walks every optional field and exercises both the incomplete
+    (return None, False) and the completed branches.
+    """
+    body = b"payload exercising all gzip header fields\n" * 25
+    mtime = 1_700_000_000
+    raw = _gzip_member_with_all_header_fields(body, mtime)
+
+    # Sanity: stdlib agrees the hand-built stream is a valid gzip member.
+    assert gzip.decompress(raw) == body
+
+    target = tmp_path / "all_fields.gz"
+    target.write_bytes(raw)
+
+    # chunk_size=2 also delivers a 10-byte prefix, hitting the FEXTRA
+    # "not enough bytes for xlen yet" early return.
+    async with AsyncGzipBinaryFile(target, "rb", chunk_size=2) as f:
+        assert await f.read() == body
+        assert f.mtime == mtime
+
+
+@pytest.mark.asyncio
+async def test_header_fields_parsed_with_large_single_chunk(tmp_path):
+    """Same member read in one chunk exercises the completed parse path."""
+    body = b"single-chunk body"
+    raw = _gzip_member_with_all_header_fields(body, 42)
+    target = tmp_path / "all_fields_big.gz"
+    target.write_bytes(raw)
+
+    async with AsyncGzipBinaryFile(target, "rb", chunk_size=1 << 20) as f:
+        assert await f.read() == body
+        assert f.mtime == 42
+
+
+def test_mtime_must_be_int_or_float():
+    with pytest.raises(TypeError, match="mtime must be an int or float"):
+        AsyncGzipBinaryFile("x.gz", "wb", mtime="nope")  # type: ignore[arg-type]
+
+
+def test_mtime_must_be_non_negative():
+    with pytest.raises(ValueError, match="mtime must be non-negative"):
+        AsyncGzipBinaryFile("x.gz", "wb", mtime=-1)
+
+
+def test_original_filename_must_be_str_or_bytes():
+    with pytest.raises(TypeError, match="original_filename must be a string or bytes"):
+        AsyncGzipBinaryFile("x.gz", "wb", original_filename=123)  # type: ignore[arg-type]
+
+
+class _CloseFailsWriter:
+    """Async writer whose write() succeeds but close() raises."""
+
+    def __init__(self) -> None:
+        self._buf = io.BytesIO()
+        self.name = "close_fails"
+
+    async def write(self, data) -> int:
+        return self._buf.write(data)
+
+    async def close(self) -> None:
+        raise OSError("underlying close failed")
+
+
+@pytest.mark.asyncio
+async def test_close_propagates_underlying_close_failure():
+    """When the writer is owned (closefd=True) and its close() raises with no
+    prior write failure, close() must surface that error."""
+    writer = _CloseFailsWriter()
+    f = AsyncGzipBinaryFile(None, "wb", fileobj=writer, closefd=True)
+    await f.__aenter__()
+    await f.write(b"some payload")
+    with pytest.raises(OSError, match="underlying close failed"):
+        await f.close()
+
+
+@pytest.mark.asyncio
+async def test_binary_anext_on_closed_file_stops_iteration(tmp_path):
+    """__anext__ on a closed binary stream raises StopAsyncIteration."""
+    target = tmp_path / "lines.gz"
+    async with AsyncGzipBinaryFile(target, "wb") as f:
+        await f.write(b"a\nb\n")
+
+    f = AsyncGzipBinaryFile(target, "rb")
+    await f.__aenter__()
+    await f.close()
+    with pytest.raises(StopAsyncIteration):
+        await f.__anext__()

--- a/tests/test_text_coverage.py
+++ b/tests/test_text_coverage.py
@@ -1,0 +1,199 @@
+# pyrefly: ignore
+# pyrefly: disable=all
+"""Targeted tests for previously-uncovered AsyncGzipTextFile behaviour.
+
+Focus areas (real logic, not defensive guards):
+- the buffer-accumulating readline()/iteration fallback used for the newline
+  modes whose terminator can straddle a chunk boundary ('\\r\\n' and ''),
+- the .newlines property / newline-style tracking (including CRLF split across
+  a chunk boundary),
+- seek-cookie validation and forward plain-position seeking.
+"""
+
+import gzip
+import os
+import tempfile
+
+import pytest
+
+from aiogzip import AsyncGzipTextFile
+
+# Mixed content with every newline style, a CRLF positioned to straddle a small
+# chunk boundary, a trailing standalone CR, an empty line, and a final line with
+# no terminator.
+MIXED = (
+    "alpha\n"
+    "beta\r\n"
+    "gamma\rdelta\n"
+    "\n" + "z" * 300 + "\r\n" + "epsilon\r" + "omega_no_terminator"
+)
+
+
+def _write_raw(path: str, text: str) -> None:
+    with gzip.open(path, "wb") as f:
+        f.write(text.encode("utf-8"))
+
+
+@pytest.fixture
+def mixed_file():
+    path = tempfile.mktemp(suffix=".gz")
+    _write_raw(path, MIXED)
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+# --- fallback newline modes ('\r\n' and '') exercise the non-fast path -------
+
+
+@pytest.mark.parametrize("newline", ["\r\n", ""])
+@pytest.mark.parametrize("chunk_size", [1, 8, 64])
+@pytest.mark.asyncio
+async def test_iteration_fallback_matches_gzip(mixed_file, newline, chunk_size):
+    async with AsyncGzipTextFile(
+        mixed_file, "rt", newline=newline, chunk_size=chunk_size
+    ) as f:
+        got = [line async for line in f]
+    with gzip.open(mixed_file, "rt", newline=newline) as g:
+        expected = list(g)
+    assert got == expected
+
+
+@pytest.mark.parametrize("newline", ["\r\n", ""])
+@pytest.mark.parametrize("chunk_size", [1, 8, 64])
+@pytest.mark.asyncio
+async def test_readline_fallback_matches_gzip(mixed_file, newline, chunk_size):
+    out = []
+    async with AsyncGzipTextFile(
+        mixed_file, "rt", newline=newline, chunk_size=chunk_size
+    ) as f:
+        while True:
+            line = await f.readline()
+            if not line:
+                break
+            out.append(line)
+    with gzip.open(mixed_file, "rt", newline=newline) as g:
+        expected = list(g)
+    assert out == expected
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r"])
+@pytest.mark.asyncio
+async def test_bounded_readline_single_char_newline(tmp_path, newline):
+    """Bounded readline (limit != -1) uses _find_line_terminator even for the
+    single-char newline modes that an unbounded readline would fast-path."""
+    path = tmp_path / "bounded.gz"
+    _write_raw(str(path), f"line-one{newline}line-two{newline}")
+    async with AsyncGzipTextFile(path, "rt", newline=newline) as f:
+        assert await f.readline(100) == f"line-one{newline}"  # terminator within limit
+        assert await f.readline(4) == "line"  # truncated before terminator
+
+
+@pytest.mark.asyncio
+async def test_incomplete_multibyte_at_eof_fallback_mode():
+    """A truncated multibyte sequence at EOF in a fallback newline mode must be
+    handled by the final decode (errors='replace')."""
+    path = tempfile.mktemp(suffix=".gz")
+    # "ok\r\n" then the first 2 bytes of a 4-byte emoji -> incomplete at EOF.
+    with gzip.open(path, "wb") as f:
+        f.write(b"ok\r\n\xf0\x9f")
+    try:
+        async with AsyncGzipTextFile(
+            path, "rt", newline="\r\n", errors="replace", chunk_size=3
+        ) as f:
+            lines = [line async for line in f]
+        assert lines[0] == "ok\r\n"
+        assert lines[-1]  # replacement char(s) for the truncated bytes
+    finally:
+        os.unlink(path)
+
+
+# --- .newlines property / seen-tracking --------------------------------------
+
+
+@pytest.mark.parametrize("chunk_size", [1, 4, 64])
+@pytest.mark.asyncio
+async def test_newlines_property_matches_gzip(mixed_file, chunk_size):
+    """Universal mode should report the same observed newline styles as gzip,
+    including when a CRLF is split across a chunk boundary (chunk_size=1)."""
+    async with AsyncGzipTextFile(mixed_file, "rt", chunk_size=chunk_size) as f:
+        await f.read()
+        got = f.newlines
+    with gzip.open(mixed_file, "rt") as g:
+        g.read()
+        expected = g.newlines
+    assert got == expected
+    # MIXED contains \n, \r\n and \r, so all three styles must be present.
+    assert set(got) == {"\n", "\r", "\r\n"}
+
+
+@pytest.mark.parametrize("chunk_size", [1, 3])
+@pytest.mark.asyncio
+async def test_newlines_tracked_during_universal_iteration(mixed_file, chunk_size):
+    """Iterating in universal mode decodes chunk-by-chunk, exercising the
+    trailing-CR / split-CRLF seen-tracking branches that read(-1) skips."""
+    async with AsyncGzipTextFile(mixed_file, "rt", chunk_size=chunk_size) as f:
+        async for _line in f:
+            pass
+        got = f.newlines
+    with gzip.open(mixed_file, "rt") as g:
+        list(g)
+        expected = g.newlines
+    assert got == expected
+    assert set(got) == {"\n", "\r", "\r\n"}
+
+
+@pytest.mark.asyncio
+async def test_newlines_none_before_any_newline_read(tmp_path):
+    path = tmp_path / "nonl.gz"
+    _write_raw(str(path), "no newline here")
+    async with AsyncGzipTextFile(path, "rt") as f:
+        assert f.newlines is None
+        await f.read()
+        assert f.newlines is None
+
+
+# --- seek cookie validation and forward plain-position seek ------------------
+
+
+@pytest.mark.asyncio
+async def test_seek_invalid_cookie_raises(mixed_file):
+    async with AsyncGzipTextFile(mixed_file, "rt") as f:
+        await f.read(3)
+        with pytest.raises(OSError, match="invalid text cookie"):
+            await f.seek(-987654321)  # negative but not a real cookie
+
+
+@pytest.mark.asyncio
+async def test_seek_cookie_from_other_stream_rejected(tmp_path):
+    """A cookie minted by one open handle must be rejected by another (the
+    per-stream nonce guards against it)."""
+    p1 = tmp_path / "a.gz"
+    p2 = tmp_path / "b.gz"
+    _write_raw(str(p1), "ab\ncd")
+    _write_raw(str(p2), "ab\ncd")
+    async with AsyncGzipTextFile(p1, "rt") as f1:
+        # readline leaves "cd" buffered, so tell() returns an opaque cookie
+        # (not a plain position).
+        await f1.readline()
+        cookie = await f1.tell()
+    assert cookie < 0, "expected an opaque cookie while text is buffered"
+    async with AsyncGzipTextFile(p2, "rt") as f2:
+        with pytest.raises(OSError, match="invalid text cookie"):
+            await f2.seek(cookie)
+
+
+@pytest.mark.asyncio
+async def test_seek_forward_plain_position_then_read(tmp_path):
+    """Forward seek to a plain (ASCII) position replays from the start; covers
+    the peek/EOF branches of _seek_to_plain_position."""
+    text = "0123456789abcdefghijklmnopqrstuvwxyz"
+    path = tmp_path / "ascii.gz"
+    _write_raw(str(path), text)
+    async with AsyncGzipTextFile(path, "rt", chunk_size=4) as f:
+        assert await f.seek(10) == 10
+        assert await f.read() == text[10:]
+    # Seeking to exactly EOF then reading returns "".
+    async with AsyncGzipTextFile(path, "rt", chunk_size=4) as f:
+        assert await f.seek(len(text)) == len(text)
+        assert await f.read() == ""


### PR DESCRIPTION
Test-only PR. **No source changes.** Two suites of targeted tests for genuinely-uncovered real logic.

⚠️ Note: this **also re-includes `tests/test_coverage_gaps.py`**, which was meant for #14 but never actually landed — that PR's commit was silently dropped by a pre-commit reformat, so #14 merged as a no-op re-apply of the mypy fix. Those header-parsing/validation/close tests are bundled here.

## `test_coverage_gaps.py` (→ `_common.py` ~98%)
- `_try_parse_gzip_header_mtime` parsing of the optional **FEXTRA / FNAME / FCOMMENT / FHCRC** header fields (hand-built member; read split and whole).
- `mtime` / `original_filename` constructor validation.
- `close()` propagating an underlying `close()` failure; binary `__anext__` on a closed file.

## `test_text_coverage.py` (→ `_text.py` ~88% → ~91%)
- `readline()`/iteration in the `'\r\n'` and `''` fallback newline modes (terminators that can straddle a chunk boundary), differential vs stdlib `gzip` across chunk sizes.
- bounded `readline(limit)` in `'\n'`/`'\r'` modes (which use `_find_line_terminator`, not the unbounded fast path).
- the `.newlines` property / newline-style tracking, incl. a CRLF split across a 1-byte chunk.
- incomplete multibyte at EOF; seek-cookie validation (bogus + cross-stream) and forward plain-position seek.

## Verification
- 31 new tests; full suite **397 passing**; total coverage **90.75%** (`_common` 98.2%, `_text` 90.8%).
- `ruff`/`mypy`/py38-compat clean. Tests are platform-agnostic (raw bytes, no `os.linesep` assumptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)