### PR TITLE
Optional zlib-ng codec + batched line iteration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,35 @@ jobs:
         run: |
           pytest --cov --cov-report=term-missing --cov-report=xml --cov-fail-under=85
 
+  # The main matrix above installs only [dev,csv], so it exercises the
+  # pure-Python default (stdlib zlib, zlib-ng absent) — the common
+  # `pip install aiogzip` install — across the full version/OS sweep. This
+  # job adds the [fast] extra so the zlib-ng decompression and opt-in
+  # compression paths are exercised on one representative version.
+  fast-engine:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies (with fast extra)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev,csv,fast]
+
+      - name: Run tests with zlib-ng active
+        run: |
+          pytest --cov --cov-report=term-missing --cov-fail-under=85
+
+      - name: Run tests with stdlib forced (zlib-ng installed but disabled)
+        run: |
+          AIOGZIP_ENGINE=stdlib pytest -q
+
   coverage-comment:
     runs-on: ubuntu-latest
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Optional `aiogzip[fast]` extra that installs [`zlib-ng`](https://pypi.org/project/zlib-ng/). When present, **decompression** automatically uses zlib-ng, which is faster (~1.6–2x on typical data) and produces byte-identical output to stdlib `zlib`. Set the environment variable `AIOGZIP_ENGINE=stdlib` to force stdlib regardless of what is installed. When the extra is not installed, aiogzip remains pure-Python and behaves exactly as before.
+
 ## [1.6.0] - 2026-05-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Optional `aiogzip[fast]` extra that installs [`zlib-ng`](https://pypi.org/project/zlib-ng/). When present, **decompression** automatically uses zlib-ng, which is faster (~1.6–2x on typical data) and produces byte-identical output to stdlib `zlib`. Set the environment variable `AIOGZIP_ENGINE=stdlib` to force stdlib regardless of what is installed. When the extra is not installed, aiogzip remains pure-Python and behaves exactly as before.
+- `fast_compress=True` option on `AsyncGzipBinaryFile`, `AsyncGzipTextFile`, and the `AsyncGzipFile` factory to opt into zlib-ng for **compression** (~1.2–1.4x). Compression stays on stdlib `zlib` by default because zlib-ng's compressed output is not byte-identical — installing the extra alone does not change produced `.gz` bytes. If `fast_compress=True` is requested without zlib-ng installed, it warns once and falls back to stdlib. zlib-ng output remains valid gzip readable by any decompressor.
 
 ## [1.6.0] - 2026-05-28
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - **Reproducible Archives**: Control gzip `mtime` and embedded filenames.
 - **Type-Safe**: Distinct `AsyncGzipBinaryFile` and `AsyncGzipTextFile`.
 - **`aiocsv` Ready**: Seamless integration for CSV pipelines.
+- **Optional faster codec**: Install `aiogzip[fast]` to use [`zlib-ng`](https://pypi.org/project/zlib-ng/) for decompression automatically (byte-identical output) and, with `fast_compress=True`, for compression.
 - **Predictable Performance**: Backward seeks rewind the stream and re-decompress data (same as `gzip.GzipFile`), so treat random access as O(n) and prefer forward-only patterns when possible.
 
 ### Append mode and large files
@@ -36,7 +37,16 @@
 
 ```bash
 pip install aiogzip
+
+# Optional: faster compression/decompression via zlib-ng
+pip install "aiogzip[fast]"
 ```
+
+When `aiogzip[fast]` is installed, decompression transparently uses `zlib-ng`
+(its output is byte-identical to stdlib `zlib`). Compression stays on stdlib by
+default so produced `.gz` bytes are unchanged; opt in per file with
+`fast_compress=True`. Set `AIOGZIP_ENGINE=stdlib` to force stdlib regardless of
+what is installed.
 
 ```python
 import asyncio

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ async with AsyncGzipFile(
 - **Text I/O**: Often ~2-3x faster than standard `gzip` in bulk text workflows.
 - **Binary I/O**: Near parity with `gzip` for bulk writes, with fast bulk reads (a full `read(-1)` of compressible data runs at several hundred MB/s); can be slower for very small chunk sizes.
 - **Concurrency**: CPU-heavy `zlib` compress/decompress calls run in the default executor above a 256 KiB threshold, so multiple gzip streams on the same event loop compress and decompress in parallel instead of serializing on the loop thread. The repo's concurrent-I/O benchmark runs ~4x faster on 1.4.0 than on 1.3.x as a result; single-stream throughput stays at parity.
+- **Line Iteration**: For the single-character newline modes (`None`, `"\n"`, `"\r"`), lines are bulk-split per chunk and served from a batch, making `async for`/`readline()` roughly ~1.2–1.3x faster (~4M lines/sec).
+- **Optional faster codec**: With `aiogzip[fast]` installed, decompression uses `zlib-ng` automatically (~1.2x typical, up to ~10x on compressible data; byte-identical output), and `fast_compress=True` gives ~1.5x compression. See the [Performance Guide](https://geoff-davis.github.io/aiogzip/performance/).
 - **Memory**: Optimized buffer management for stable memory usage.
 - **JSONL**: For large gzipped JSONL files, prefer `AsyncGzipTextFile(..., newline="\n", chunk_size=512 * 1024)` to reduce line-iteration overhead.
 

--- a/benchmarks/bench_compression.py
+++ b/benchmarks/bench_compression.py
@@ -5,10 +5,11 @@ Tests compression ratios and format compatibility.
 """
 
 import gzip
+import time
 
 from bench_common import BenchmarkBase, format_size
 
-from aiogzip import AsyncGzipBinaryFile
+from aiogzip import AsyncGzipBinaryFile, _engine
 
 
 class CompressionBenchmarks(BenchmarkBase):
@@ -53,6 +54,54 @@ class CompressionBenchmarks(BenchmarkBase):
                 gzip_ratio=f"{gzip_ratio:.2f}x",
             )
 
+    async def _time_compress(self, data, fast, reps=5):
+        """Return (best_seconds, output_size) for compressing ``data``."""
+        best = float("inf")
+        size = 0
+        for _ in range(reps):
+            path = self.temp_mgr.get_path(f"fc_{fast}.gz")
+            start = time.perf_counter()
+            async with AsyncGzipBinaryFile(
+                path, "wb", mtime=0, fast_compress=fast
+            ) as f:
+                await f.write(data)
+            best = min(best, time.perf_counter() - start)
+            size = path.stat().st_size
+        return best, size
+
+    async def benchmark_fast_compress(self):
+        """Compare default (stdlib) compression to fast_compress=True (zlib-ng).
+
+        Exercises the Phase 2 opt-in path: throughput gain plus the output-size
+        delta (zlib-ng's compressed bytes differ from stdlib's).
+        """
+        if not _engine.have_fast_engine():
+            self.add_result(
+                "Compression: fast_compress",
+                "compression",
+                0.0,
+                status="skipped (install aiogzip[fast] / unset AIOGZIP_ENGINE)",
+            )
+            return
+
+        data = self.data_gen.generate_text(self.data_size_mb).encode()
+        mb = len(data) / (1024 * 1024)
+        std_t, std_sz = await self._time_compress(data, fast=False)
+        fast_t, fast_sz = await self._time_compress(data, fast=True)
+
+        self.add_result(
+            "Compression: fast_compress (text)",
+            "compression",
+            fast_t,
+            stdlib_throughput=f"{mb / std_t:.1f} MB/s",
+            fast_throughput=f"{mb / fast_t:.1f} MB/s",
+            speedup=f"{std_t / fast_t:.2f}x",
+            stdlib_size=format_size(std_sz),
+            fast_size=format_size(fast_sz),
+            size_vs_stdlib=f"{100 * fast_sz / std_sz:.1f}%",
+        )
+
     async def run_all(self):
         """Run all compression benchmarks."""
         await self.benchmark_compression_ratios()
+        await self.benchmark_fast_compress()

--- a/benchmarks/bench_micro.py
+++ b/benchmarks/bench_micro.py
@@ -43,16 +43,17 @@ class MicroBenchmarks(BenchmarkBase):
         )
 
     async def benchmark_line_iteration(self):
-        """Benchmark line-by-line iteration."""
+        """Benchmark line-by-line iteration (async for)."""
         text_file = self.temp_mgr.get_path("micro_text.gz")
 
-        # Write text data with 10,000 lines
-        lines = [f"This is line number {i}\n" for i in range(10000)]
+        # 100K lines (~2.4 MB) so the per-line cost dominates per-file overhead
+        # and the measurement is stable rather than sub-millisecond noise.
+        n_lines = 100_000
+        lines = [f"This is line number {i}\n" for i in range(n_lines)]
         async with AsyncGzipTextFile(text_file, "wt") as f:
             await f.write("".join(lines))
 
-        # Benchmark line iteration - 100 iterations
-        iterations = 100
+        iterations = 30
         total_time = 0
         for _ in range(iterations):
             start = time.perf_counter()
@@ -65,24 +66,24 @@ class MicroBenchmarks(BenchmarkBase):
         avg_time = total_time / iterations
 
         self.add_result(
-            "Line iteration - 10K lines",
+            "Line iteration - 100K lines",
             "micro",
             avg_time,
             iterations=iterations,
             avg_time_ms=f"{avg_time * 1000:.3f}ms",
+            lines_per_sec=f"{n_lines / avg_time:.0f}",
         )
 
     async def benchmark_readline_loop(self):
         """Benchmark readline() in a loop."""
         text_file = self.temp_mgr.get_path("micro_readline.gz")
 
-        # Write text data with 10,000 lines
-        lines = [f"This is line number {i}\n" for i in range(10000)]
+        n_lines = 100_000
+        lines = [f"This is line number {i}\n" for i in range(n_lines)]
         async with AsyncGzipTextFile(text_file, "wt") as f:
             await f.write("".join(lines))
 
-        # Benchmark readline loop - 100 iterations
-        iterations = 100
+        iterations = 30
         total_time = 0
         for _ in range(iterations):
             start = time.perf_counter()
@@ -98,11 +99,12 @@ class MicroBenchmarks(BenchmarkBase):
         avg_time = total_time / iterations
 
         self.add_result(
-            "readline() loop - 10K lines",
+            "readline() loop - 100K lines",
             "micro",
             avg_time,
             iterations=iterations,
             avg_time_ms=f"{avg_time * 1000:.3f}ms",
+            lines_per_sec=f"{n_lines / avg_time:.0f}",
         )
 
     async def benchmark_small_writes(self):

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ It is designed for high-performance I/O operations, especially for text-based da
 - **Separate Binary and Text Modes**: `AsyncGzipBinaryFile` and `AsyncGzipTextFile` provide clear, type-safe handling of data.
 - **Excellent Compression Quality**: Achieves compression ratios nearly identical to the standard `gzip` module.
 - **`aiocsv` Integration**: Read and write compressed CSV files effortlessly.
+- **Optional Faster Codec**: Install `aiogzip[fast]` to use [`zlib-ng`](https://pypi.org/project/zlib-ng/) for faster decompression automatically (byte-identical output) and, with `fast_compress=True`, for compression. See the [Performance Guide](performance.md).
 
 ---
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -14,9 +14,9 @@ All benchmarks were conducted on standard hardware using Python 3.12+.
 |-----------|---------|-------------|---------|
 | **Bulk Text Read/Write** | ~37 MB/s | ~13 MB/s | **~2.9x Faster** |
 | **JSONL Processing** | - | - | **~1.8x Faster** |
-| **Line Iteration** | ~1.35M lines/sec | - | - |
+| **Line Iteration** | ~4.2M lines/sec | - | - |
 
-**Why?** `aiogzip` uses optimized UTF-8 decoding strategies (using `codecs.getincrementaldecoder`) and manages buffers efficiently to minimize encoding/decoding overhead.
+**Why?** `aiogzip` uses optimized UTF-8 decoding strategies (using `codecs.getincrementaldecoder`) and manages buffers efficiently to minimize encoding/decoding overhead. For the single-character newline modes (`None`, `"\n"`, `"\r"`), each decoded chunk's lines are bulk-split in one pass and served from a batch, which makes `async for` line iteration roughly **1.3x** faster than per-line scanning.
 
 ### Binary Operations (Tie)
 
@@ -37,6 +37,34 @@ When processing multiple files, especially where I/O latency (disk/network) is i
 - **Mixed read/write workload**: **~1.5x faster**.
 - CPU-bound `zlib` work above a 256 KiB chunk is offloaded to a thread, so multiple streams compress/decompress in parallel instead of serializing on the loop.
 - Allows the main thread to remain responsive (e.g., for a web server) while processing heavy compression tasks.
+
+### Optional Faster Codec (`aiogzip[fast]` / zlib-ng)
+
+Installing the optional extra pulls in [`zlib-ng`](https://pypi.org/project/zlib-ng/),
+a drop-in deflate implementation that is faster than stdlib `zlib`:
+
+```bash
+pip install "aiogzip[fast]"
+```
+
+- **Decompression** uses zlib-ng automatically whenever it is installed. Its
+  output is **byte-identical** to stdlib `zlib`, so this is transparent. Measured
+  read-throughput gains range from ~**1.2x** on typical data to **~7-10x** on
+  highly compressible data and bulk `read(-1)`.
+- **Compression** stays on stdlib `zlib` by default, because zlib-ng's compressed
+  *bytes* are not identical to stdlib's — installing the extra alone must not
+  change produced `.gz` output. Opt in per file with `fast_compress=True` for a
+  ~**1.5x** compression speedup; the output is valid gzip readable by any
+  decompressor, just not byte-for-byte identical to stdlib.
+
+  ```python
+  async with AsyncGzipBinaryFile("out.gz", "wb", fast_compress=True) as f:
+      await f.write(payload)
+  ```
+
+- Set `AIOGZIP_ENGINE=stdlib` to force stdlib everywhere (e.g. for reproducible
+  output or debugging). When the extra is not installed, `aiogzip` remains
+  pure-Python and behaves exactly as before.
 
 ## Optimization Tips
 

--- a/plans/ENGINE_AND_READLINE_PLAN.md
+++ b/plans/ENGINE_AND_READLINE_PLAN.md
@@ -1,0 +1,254 @@
+# Engine Abstraction + zlib-ng + Batched Readline Plan
+
+## Context
+
+A benchmark/profiling spike (2026-06-01) asked whether aiogzip's throughput
+could be raised via a faster codec (zlib-ng / isal) or a native (Rust/Cython)
+rewrite. Findings:
+
+- **Bulk binary compress/decompress is ~99% native zlib C time** — the Python
+  orchestration is a rounding error, so a native rewrite of those paths gains
+  nothing. The only lever is a faster codec.
+- **zlib-ng** gives ~1.2–1.4x compress and ~1.6–2x decompress on realistic
+  data at level 6, with output-size parity. Decompressed bytes are
+  **byte-identical** across engines; compressed bytes are **not**.
+- **isal** is faster still but worse ratio and capped at level ≤3 → shelved.
+- **Text line-iteration is ~90% Python** (per-line function-call overhead), and
+  a batched `splitlines`-style approach measured **~2.8x** (153 → 430 MB/s) on
+  16 MiB, in pure Python with no new dependency. Realistically ~2–2.5x once
+  full incremental decode + newline translation are preserved.
+
+This plan implements three changes that share one engine-abstraction
+foundation:
+
+1. **zlib-ng for decompression, automatic when installed** (lossless, no output
+   change — decompressed bytes are identical regardless of engine).
+2. **zlib-ng for compression, explicit opt-in** via an `aiogzip[fast]` extra +
+   per-file flag (compressed bytes differ, so never silent).
+3. **Pure-Python batched readline** for the text path (~2–2.5x line iteration).
+
+Goal: keep aiogzip pure-Python-installable (zlib-ng is a *soft* dependency,
+never required), keep default `.gz` output byte-stable, and preserve all
+existing newline / Unicode / error-handling guarantees (see `CLAUDE.md`).
+
+## Critical gotcha (applies to 1 & 2)
+
+`zlib_ng.error` and `isal_zlib.error` are **not** `zlib.error` and **not**
+subclasses of it (verified). The library wraps `except zlib.error` → `OSError`
+at `_binary.py:658, 832, 885, 1071`. If decompression silently uses zlib-ng,
+a corrupt stream would raise `zlib_ng.error`, bypass those handlers, and leak
+an unwrapped foreign exception instead of the documented `OSError`. **Every**
+`except zlib.error` site must catch a tuple that includes the active engine's
+error type. Corrupt-input tests must run against the zlib-ng path.
+
+---
+
+## Phase 1 — Engine abstraction + zlib-ng decompression (default when present)
+
+### New module: `src/aiogzip/_engine.py`
+
+Single source of truth for codec selection. Soft-detects zlib-ng at import:
+
+```python
+import os
+import zlib
+from typing import Optional, Tuple
+
+try:
+    from zlib_ng import zlib_ng as _zng  # type: ignore
+except ImportError:  # pragma: no cover - exercised by env without the extra
+    _zng = None
+
+# Escape hatch: AIOGZIP_ENGINE=stdlib forces stdlib everywhere (repro/debug).
+_FORCE_STDLIB = os.environ.get("AIOGZIP_ENGINE", "").lower() == "stdlib"
+_HAVE_ZNG = _zng is not None and not _FORCE_STDLIB
+
+# Errors to catch around decompress/compress/flush calls.
+ZLIB_ERRORS: Tuple[type, ...] = (
+    (zlib.error,) + ((_zng.error,) if _zng is not None else ())
+)
+
+# crc32 stays on stdlib: engine-independent result, avoids any surprise.
+crc32 = zlib.crc32
+MAX_WBITS = zlib.MAX_WBITS
+Z_SYNC_FLUSH = zlib.Z_SYNC_FLUSH
+
+
+def decompressobj(wbits: int):
+    """zlib-ng when available (identical output), else stdlib."""
+    return (_zng if _HAVE_ZNG else zlib).decompressobj(wbits=wbits)
+
+
+def compressobj(level: int, wbits: int, fast: bool = False):
+    """stdlib by default; zlib-ng only when fast=True AND available.
+
+    Installing the [fast] extra alone must NOT change compressed output, so
+    compression stays on stdlib unless the caller explicitly opts in.
+    """
+    engine = _zng if (fast and _HAVE_ZNG) else zlib
+    return engine.compressobj(level=level, wbits=wbits)
+
+
+def decompress_engine_name() -> str:
+    return "zlib-ng" if _HAVE_ZNG else "stdlib"
+```
+
+Notes:
+
+- Keep `Tuple` from `typing` (Python 3.8 — see `CLAUDE.md`).
+- `crc32`/`MAX_WBITS`/`Z_SYNC_FLUSH` re-exported so `_binary.py` has a single
+  import surface.
+
+### Edits to `src/aiogzip/_binary.py`
+
+- Replace `import zlib` usage with `from . import _engine` (keep `import zlib`
+  only if still needed for bare constants; prefer routing through `_engine`).
+- `_binary.py:239, 874, 957` (`zlib.decompressobj(wbits=GZIP_WBITS)`)
+  → `_engine.decompressobj(GZIP_WBITS)`.
+- `_binary.py:225-226` (compressobj) → `_engine.compressobj(self._compresslevel,
+  -_engine.MAX_WBITS, fast=self._fast_compress)` — `_fast_compress` wired in
+  Phase 2; default `False` so Phase 1 is behavior-neutral for compression.
+- `_binary.py:658, 832, 885, 1071` (`except zlib.error`) →
+  `except _engine.ZLIB_ERRORS`. Preserve the `raise OSError(...) from e`
+  chaining (CLAUDE.md).
+- `_binary.py:675` `zlib.crc32` → `_engine.crc32`.
+- `_binary.py:1061` `zlib.Z_SYNC_FLUSH` → `_engine.Z_SYNC_FLUSH`.
+
+### Tests (`tests/`)
+
+- New `tests/test_engine.py`: engine selection (present/absent/forced),
+  `ZLIB_ERRORS` membership, cross-engine inflate equals stdlib output.
+- Parametrize existing decompression + corrupt-stream tests over engine using
+  `AIOGZIP_ENGINE` (or by monkeypatching `_engine._HAVE_ZNG`) so the zlib-ng
+  decode path and its error wrapping are both exercised. Especially the
+  decompression-bomb / `max_decompressed_size` / `strict_size` paths — they
+  operate on output bytes so should be engine-independent; assert that.
+
+### Packaging (`pyproject.toml`)
+
+- Add optional extra: `[project.optional-dependencies] fast = ["zlib-ng>=0.4"]`.
+  Core install stays pure-Python (no new required deps).
+
+---
+
+## Phase 2 — Opt-in zlib-ng compression (`aiogzip[fast]`)
+
+Builds directly on Phase 1's `_engine.compressobj(..., fast=...)`.
+
+### Opt-in mechanism
+
+- Add `fast_compress: bool = False` to `AsyncGzipBinaryFile.__init__`
+  (`_binary.py:133`) and `AsyncGzipTextFile.__init__` (`_text.py:104`), and
+  thread it through the `AsyncGzipFile` factory `**kwargs` (already pass-through
+  at `__init__.py:25`). Store as `self._fast_compress`.
+- Only consulted in write/append modes; ignored for read modes.
+- If `fast_compress=True` but zlib-ng is absent, fall back to stdlib silently
+  and emit a one-time `warnings.warn(...)` (so behavior stays correct without
+  the extra; the warning tells users to `pip install aiogzip[fast]`).
+
+### Why a flag and not just "use zlib-ng if installed"
+
+Decompression auto-uses zlib-ng because output is identical. Compression must
+stay opt-in because compressed bytes differ from stdlib — anyone hashing or
+content-addressing `.gz` output must get byte-stable defaults unless they ask
+otherwise.
+
+### Tests
+
+- Round-trip with `fast_compress=True` under zlib-ng → `gzip.decompress` reads
+  it back identically (interop holds; bytes need not match stdlib).
+- `fast_compress=True` without zlib-ng → falls back, warns once, still correct.
+- Confirm default (`fast_compress=False`) output is byte-identical to current
+  stdlib output (regression guard on determinism).
+
+### Docs
+
+- README/CHANGELOG: document the extra, the ~1.2–1.4x expectation (not "4x"),
+  and the explicit non-byte-identical-output caveat.
+
+---
+
+## Phase 3 — Batched pure-Python readline (text path)
+
+Most delicate; **no new dependency**, gated behind the full text suite.
+
+### Current shape (`src/aiogzip/_text.py`)
+
+Per-line: `__anext__` (972) → `_readline_fast` (926) → `_find_line_terminator`
+(789) + `_consume_buffer` (436), with `_apply_newline_decoding` (850) handling
+universal-newline translation and `_trailing_cr` (CRLF-across-chunk) state.
+~266k calls each per 16 MiB → the overhead the profile flagged.
+
+### Approach
+
+Maintain a pre-split line buffer (e.g. `self._pending_lines: List[str]` +
+index, or a `collections.deque`). `_readline_fast`/`__anext__` pop from it;
+when empty, decode the next chunk via the existing `_decode_next_chunk` (657)
+
+- `_apply_newline_decoding` (850), then split the translated text into lines in
+one batch and carry the trailing partial line forward.
+
+### Correctness constraints (do NOT regress)
+
+- **Do not use `str.splitlines()`** — it splits on the full Unicode line-
+  boundary set (`\v`, `\f`, `\x1c`, `\x85`, …). Text-file readline must split
+  only on the terminators `_find_line_terminator` recognizes (`\n`, and `\r` /
+  `\r\n` per `newline` mode). The spike's `splitlines` ceiling matched counts
+  only because the ASCII test data had no such chars. The real split must
+  mirror `_find_line_terminator`'s terminator set (e.g. `text.split("\n")` with
+  keepends reconstruction after universal translation, or an explicit
+  terminator-aware batch splitter reusing the existing helper).
+- Preserve `newline` semantics for all of `None` (universal), `""`, `"\n"`,
+  `"\r"`, `"\r\n"`, and the `_trailing_cr` / `_buffer_origin_trailing_cr` state
+  across chunk boundaries.
+- Preserve `readline(limit=...)` and `readlines(hint=...)` semantics
+  (`_text.py:1000, 1063`).
+- Keep incremental UTF-8/multibyte decoding via the existing
+  `codecs.getincrementaldecoder` decoder (175) so multibyte chars split across
+  chunks still work.
+
+### Tests
+
+- The entire text suite must stay green, especially `TestNewlineHandlingBugs`
+  and the text-cookie / partial-line cases.
+- Add data with embedded `\v`/`\f`/`\x85` to prove we did *not* introduce
+  `splitlines`-style over-splitting.
+- Add a benchmark assertion-free check (or a `benchmarks/` entry) showing the
+  line-iteration speedup, to document the gain.
+
+---
+
+## Cross-cutting
+
+- **Python 3.8**: use `typing.Tuple/List/Optional`; no PEP 585/604. Run the
+  `grep` checks from `CLAUDE.md` before committing.
+- **CI**: add a job (or matrix axis) that installs `.[fast]` so both the
+  stdlib and zlib-ng paths are tested. zlib-ng wheel availability across
+  3.8–3.14 × {Linux, macOS, Windows} should be confirmed; the soft-dependency
+  design means any version lacking a wheel simply runs on stdlib (acceptable).
+- **Coverage**: keep ≥85% (`--cov-fail-under=85`). New `_engine.py` branches
+  (present/absent/forced) need coverage from both real and monkeypatched runs.
+- **Determinism**: a regression test asserting default compressed output equals
+  the current stdlib bytes guards against accidental engine bleed-through.
+
+## Ordering / rollout
+
+1. **Phase 1** first — self-contained, behavior-neutral for compression, ships
+   the highest-value/lowest-risk win (free decompression speedup) and lays the
+   `_engine.py` plumbing. The error-tuple fix is mandatory here.
+2. **Phase 2** next — small delta on top of Phase 1 (one flag + extra + docs).
+3. **Phase 3** last and independently — no dependency on 1/2; highest test risk;
+   ship only behind a fully green text suite. Can be deferred/dropped without
+   affecting 1–2.
+
+## Verification
+
+- `pytest --cov --cov-report=term-missing` green at ≥85%, run **twice**: once
+  with zlib-ng absent (or `AIOGZIP_ENGINE=stdlib`) and once with `.[fast]`
+  installed.
+- `python -c "from aiogzip._engine import decompress_engine_name; print(decompress_engine_name())"`
+  reports `zlib-ng` when the extra is installed, `stdlib` otherwise.
+- Interop: for both engines, `gzip.decompress(aiogzip_output) == original` and
+  aiogzip reads stdlib-`gzip.compress` output back identically.
+- Re-run the codec + readline benchmarks (recreate the spike scripts) to
+  confirm the measured ~2x decompress and ~2–2.5x line-iteration gains land.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
 csv = [
     "aiocsv>=1.2.0",
 ]
+fast = [
+    "zlib-ng>=0.4.0",
+]
 docs = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.5.0",

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -4,6 +4,7 @@ import asyncio
 import gzip
 import io
 import os
+import warnings
 from pathlib import Path
 from typing import Any, Callable, Iterable, List, Optional, Union, cast
 
@@ -115,6 +116,7 @@ class AsyncGzipBinaryFile:
         "_max_decompressed_size",
         "_decompressed_total",
         "_strict_size",
+        "_fast_compress",
     )
 
     # 256 KiB balances bulk-read throughput against per-file memory. Below it
@@ -146,6 +148,7 @@ class AsyncGzipBinaryFile:
         max_decompressed_size: Optional[int] = None,
         max_rewind_cache_size: Optional[int] = _MAX_CHUNK_SIZE,
         strict_size: bool = False,
+        fast_compress: bool = False,
     ) -> None:
         # Validate inputs using shared validation functions
         _validate_filename(filename, fileobj)
@@ -169,6 +172,18 @@ class AsyncGzipBinaryFile:
         self._writing_mode = mode_op in {"w", "a", "x"}
         if self._writing_mode:
             _validate_compresslevel(compresslevel)
+        self._fast_compress = bool(fast_compress)
+        if (
+            self._writing_mode
+            and self._fast_compress
+            and not _engine.have_fast_engine()
+        ):
+            warnings.warn(
+                "fast_compress=True requested but zlib-ng is not available; "
+                "falling back to stdlib zlib. Install the extra with "
+                "'pip install aiogzip[fast]' to enable faster compression.",
+                stacklevel=2,
+            )
         self._chunk_size = chunk_size
         self._compresslevel = compresslevel
         self._header_mtime = _normalize_mtime(mtime)
@@ -223,7 +238,9 @@ class AsyncGzipBinaryFile:
             # Initialize compression/decompression engine based on mode
             if self._writing_mode:
                 self._engine = _engine.compressobj(
-                    self._compresslevel, -_engine.MAX_WBITS
+                    self._compresslevel,
+                    -_engine.MAX_WBITS,
+                    fast=self._fast_compress,
                 )
                 header = _build_gzip_header(
                     _derive_header_filename(

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -4,12 +4,12 @@ import asyncio
 import gzip
 import io
 import os
-import zlib
 from pathlib import Path
 from typing import Any, Callable, Iterable, List, Optional, Union, cast
 
 import aiofiles
 
+from . import _engine
 from ._common import (
     _MAX_CHUNK_SIZE,
     GZIP_WBITS,
@@ -222,8 +222,8 @@ class AsyncGzipBinaryFile:
 
             # Initialize compression/decompression engine based on mode
             if self._writing_mode:
-                self._engine = zlib.compressobj(
-                    level=self._compresslevel, wbits=-zlib.MAX_WBITS
+                self._engine = _engine.compressobj(
+                    self._compresslevel, -_engine.MAX_WBITS
                 )
                 header = _build_gzip_header(
                     _derive_header_filename(
@@ -236,7 +236,7 @@ class AsyncGzipBinaryFile:
                 self._crc = 0
                 self._input_size = 0
             else:  # read mode
-                self._engine = zlib.decompressobj(wbits=GZIP_WBITS)
+                self._engine = _engine.decompressobj(GZIP_WBITS)
                 self._position = 0
                 self._mtime = None
                 self._header_probe_buffer.clear()
@@ -655,7 +655,7 @@ class AsyncGzipBinaryFile:
                 compressed = await _run_zlib_in_thread(self._engine.compress, payload)
             else:
                 compressed = self._engine.compress(buffer)
-        except zlib.error as e:
+        except _engine.ZLIB_ERRORS as e:
             raise OSError(f"Error compressing data: {e}") from e
         except Exception as e:
             raise OSError(f"Unexpected error during compression: {e}") from e
@@ -672,7 +672,7 @@ class AsyncGzipBinaryFile:
         # Only credit the input once both stages succeed, and mask the CRC
         # to 32 bits so tell()/the trailer always see the same uint32 zlib
         # would have produced.
-        self._crc = zlib.crc32(buffer, self._crc) & 0xFFFFFFFF
+        self._crc = _engine.crc32(buffer, self._crc) & 0xFFFFFFFF
         self._input_size += length
         self._position = self._input_size
 
@@ -829,7 +829,7 @@ class AsyncGzipBinaryFile:
             self._eof = True
             try:
                 remaining = self._engine.flush()
-            except zlib.error as e:
+            except _engine.ZLIB_ERRORS as e:
                 raise gzip.BadGzipFile(
                     f"Error finalizing gzip decompression: {e}"
                 ) from e
@@ -871,7 +871,7 @@ class AsyncGzipBinaryFile:
                 if not unused:
                     break
 
-                self._engine = zlib.decompressobj(wbits=GZIP_WBITS)
+                self._engine = _engine.decompressobj(GZIP_WBITS)
                 if len(unused) >= _ZLIB_OFFLOAD_THRESHOLD:
                     decompressed = await _run_zlib_in_thread(
                         self._engine.decompress, unused
@@ -882,7 +882,7 @@ class AsyncGzipBinaryFile:
                     self._account_decompressed(len(decompressed))
                     pieces.append(decompressed)
                 unused = self._engine.unused_data
-        except zlib.error as e:
+        except _engine.ZLIB_ERRORS as e:
             raise gzip.BadGzipFile(f"Error decompressing gzip data: {e}") from e
         except OSError:
             # Preserve OSErrors raised deliberately by helpers (e.g., the
@@ -954,7 +954,7 @@ class AsyncGzipBinaryFile:
             self._replay_offset = 0
         else:
             raise OSError("Underlying file is not seekable")
-        self._engine = zlib.decompressobj(wbits=GZIP_WBITS)
+        self._engine = _engine.decompressobj(GZIP_WBITS)
         del self._buffer[:]
         self._buffer_offset = 0
         self._eof = False
@@ -1058,7 +1058,7 @@ class AsyncGzipBinaryFile:
             # Flush any buffered compressed data (but not the final trailer)
             # Using Z_SYNC_FLUSH allows us to flush without ending the stream
             try:
-                flushed_data = self._engine.flush(zlib.Z_SYNC_FLUSH)
+                flushed_data = self._engine.flush(_engine.Z_SYNC_FLUSH)
                 if flushed_data:
                     await self._file.write(flushed_data)
 
@@ -1068,7 +1068,7 @@ class AsyncGzipBinaryFile:
                     result = flush_method()
                     if hasattr(result, "__await__"):
                         await result
-            except zlib.error as e:
+            except _engine.ZLIB_ERRORS as e:
                 raise OSError(f"Error flushing compressed data: {e}") from e
             except OSError:
                 raise

--- a/src/aiogzip/_engine.py
+++ b/src/aiogzip/_engine.py
@@ -1,0 +1,96 @@
+"""Codec engine selection for aiogzip.
+
+Single source of truth for which deflate implementation backs compression and
+decompression. ``zlib-ng`` is a *soft* dependency: when the ``aiogzip[fast]``
+extra is installed it is used automatically for **decompression** (its output
+is byte-identical to stdlib ``zlib``, so this is transparent) and, only when a
+caller explicitly opts in, for **compression** (its compressed bytes differ
+from stdlib, so it is never selected silently). When ``zlib-ng`` is not
+installed every path falls back to stdlib ``zlib`` and aiogzip stays
+pure-Python.
+
+Set ``AIOGZIP_ENGINE=stdlib`` to force stdlib everywhere (useful for
+reproducible error behaviour or debugging).
+"""
+
+import importlib
+import os
+import zlib
+from typing import Any, Tuple, Type
+
+from ._common import ZlibEngine
+
+
+def _load_zng() -> Any:
+    """Return the zlib-ng module, or None if the extra is not installed.
+
+    Imported dynamically and typed as Any so neither mypy nor ty objects to the
+    stub-less module; behaviour is identical to ``from zlib_ng import zlib_ng``.
+    """
+    try:
+        return importlib.import_module("zlib_ng.zlib_ng")
+    except ImportError:  # pragma: no cover - exercised in environments without it
+        return None
+
+
+_zng: Any = _load_zng()
+
+# Whether stdlib has been forced via the environment escape hatch.
+_FORCE_STDLIB = os.environ.get("AIOGZIP_ENGINE", "").strip().lower() == "stdlib"
+
+# Whether zlib-ng is available *and* permitted as the active engine.
+_HAVE_ZNG = _zng is not None and not _FORCE_STDLIB
+
+# Errors raised by the deflate engines. zlib-ng's (and isal's) error type is
+# NOT zlib.error nor a subclass of it, so callers that mean to catch decode
+# failures must catch this tuple — otherwise a corrupt stream decoded by
+# zlib-ng would leak an unwrapped foreign exception. zlib-ng's error is
+# included whenever the module is importable (regardless of the force flag),
+# since including an extra type in an ``except`` is harmless.
+ZLIB_ERRORS: Tuple[Type[BaseException], ...]
+if _zng is not None:
+    ZLIB_ERRORS = (zlib.error, _zng.error)
+else:
+    ZLIB_ERRORS = (zlib.error,)
+
+# crc32 stays on stdlib: the result is engine-independent, and pinning it
+# avoids any surprise from a divergent implementation.
+crc32 = zlib.crc32
+
+# Re-export the constants _binary.py needs so it has a single import surface.
+MAX_WBITS = zlib.MAX_WBITS
+Z_SYNC_FLUSH = zlib.Z_SYNC_FLUSH
+
+
+def decompressobj(wbits: int) -> ZlibEngine:
+    """Return a decompressor: zlib-ng when available, else stdlib zlib.
+
+    Decompressed output is byte-identical across engines, so this selection is
+    transparent to callers.
+    """
+    if _HAVE_ZNG:
+        return _zng.decompressobj(wbits=wbits)
+    return zlib.decompressobj(wbits=wbits)
+
+
+def compressobj(level: int, wbits: int, fast: bool = False) -> ZlibEngine:
+    """Return a compressor.
+
+    Stdlib ``zlib`` by default. ``zlib-ng`` is used only when ``fast`` is True
+    *and* it is available, because its compressed output is not byte-identical
+    to stdlib — installing the extra alone must not change produced ``.gz``
+    bytes.
+    """
+    if fast and _HAVE_ZNG:
+        return _zng.compressobj(level=level, wbits=wbits)
+    return zlib.compressobj(level=level, wbits=wbits)
+
+
+def have_fast_engine() -> bool:
+    """True when zlib-ng is available and not disabled via the env escape hatch."""
+    return _HAVE_ZNG
+
+
+def decompress_engine_name() -> str:
+    """Name of the engine backing decompression: ``"zlib-ng"`` or ``"stdlib"``."""
+    return "zlib-ng" if _HAVE_ZNG else "stdlib"

--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -115,6 +115,12 @@ class AsyncGzipTextFile:
     # than the binary buffer because each char can cost 1-4 bytes of
     # internal storage.
     _TEXT_COMPACTION_THRESHOLD = 16384
+    # Upper bound on how many characters of complete lines are bulk-split into
+    # _pending_lines per refill. Without it, a large chunk_size (up to the
+    # 128 MiB max) full of tiny lines would materialize millions of line
+    # strings at once. 256 KiB matches the default chunk_size, so the common
+    # case still splits a whole chunk in a single pass.
+    _LINE_BATCH_CHARS = 256 * 1024
 
     def __init__(
         self,
@@ -978,6 +984,10 @@ class AsyncGzipTextFile:
         Advancing ``_text_buffer_offset`` exactly as ``_consume_buffer`` would
         keeps tell()/seek() bookkeeping identical to consuming one line at a
         time. Returns None when ``_pending_lines`` is exhausted.
+
+        This is the canonical implementation; ``__anext__`` and
+        ``_readline_fast`` inline the same logic in their hot paths (a per-line
+        method call costs ~7% throughput). Keep all three in sync.
         """
         idx = self._pending_idx
         pending = self._pending_lines
@@ -1007,10 +1017,19 @@ class AsyncGzipTextFile:
         # only reached in those modes.
         assert term is not None and split_re is not None
 
-        # Bulk-split every complete line in the buffered remainder at once.
+        # Bulk-split the complete lines in the buffered remainder, but only up
+        # to a bounded window so a huge chunk_size full of tiny lines does not
+        # materialize the whole chunk's lines at once.
         buf = self._text_buffer
         start = self._text_buffer_offset
-        last = buf.rfind(term)
+        window_end = min(len(buf), start + self._LINE_BATCH_CHARS)
+        last = buf.rfind(term, start, window_end)
+        if last < start:
+            # No terminator within the window: either the first line is longer
+            # than the window or there is no complete line at all. find()
+            # returns the first terminator (or -1), so an over-long first line
+            # still yields exactly one line and stays bounded.
+            last = buf.find(term, start)
         if last >= start:
             region = buf[start : last + 1]
             self._pending_lines = split_re.findall(region)
@@ -1036,16 +1055,12 @@ class AsyncGzipTextFile:
                         first_line = "".join(prefix) + text[: i + 1]
                     else:
                         first_line = text[: i + 1]
+                    # Keep the whole chunk buffered (its replay origin stays
+                    # valid) with the offset past this line; the next call
+                    # bulk-splits the rest of the chunk via the windowed path
+                    # above.
                     self._set_buffer(text)
                     self._text_buffer_offset = i + 1
-                    # Pre-split any further complete lines in this chunk so the
-                    # next calls serve them without re-scanning.
-                    rest_last = text.rfind(term)
-                    if rest_last > i:
-                        self._pending_lines = split_re.findall(
-                            text[i + 1 : rest_last + 1]
-                        )
-                        self._pending_idx = 0
                     return first_line
                 prefix.append(text)
             if not more:
@@ -1058,9 +1073,9 @@ class AsyncGzipTextFile:
         Returns "" at end of input. Only valid when
         ``self._line_term is not None``.
         """
-        # Serve a pre-split line inline (mirroring __anext__) so repeated
-        # readline() calls do not pay an extra coroutine hop per line; only
-        # refill through the coroutine when the batch is drained.
+        # Inlined pending-line pop (canonical copy: _take_pending_line). Kept
+        # inline in the two hot read paths because a per-line method call
+        # measurably (~7%) lowers iteration throughput; keep the copies in sync.
         idx = self._pending_idx
         pending = self._pending_lines
         if idx < len(pending):
@@ -1081,8 +1096,8 @@ class AsyncGzipTextFile:
             raise StopAsyncIteration
 
         if self._line_term is not None:
-            # Serve a pre-split line inline to avoid a coroutine hop per line;
-            # only fall back to the refill coroutine when the batch is drained.
+            # Inlined pending-line pop (canonical copy: _take_pending_line);
+            # kept inline in this hot path for throughput. Keep copies in sync.
             idx = self._pending_idx
             pending = self._pending_lines
             if idx < len(pending):

--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -3,6 +3,7 @@
 import codecs
 import io
 import os
+import re
 import secrets
 import struct
 from pathlib import Path
@@ -21,6 +22,15 @@ from ._common import (
     _validate_filename,
     _validate_original_filename,
 )
+
+# Keepends line splitters for the single-character terminator modes. Each match
+# consumes a run of non-terminator characters up to and including one terminator,
+# so ``"".join(pattern.findall(region)) == region`` whenever ``region`` ends on a
+# terminator. NOTE: this deliberately does NOT use ``str.splitlines()``, which
+# also breaks on \v, \f, \x1c-\x1e, \x85, U+2028, and U+2029 -- characters a
+# text-file readline must treat as ordinary content, not line breaks.
+_LINE_RE_LF = re.compile(r"[^\n]*\n")
+_LINE_RE_CR = re.compile(r"[^\r]*\r")
 
 
 class AsyncGzipTextFile:
@@ -85,6 +95,10 @@ class AsyncGzipTextFile:
         "_max_rewind_cache_size",
         "_strict_size",
         "_fast_compress",
+        "_line_term",
+        "_line_split_re",
+        "_pending_lines",
+        "_pending_idx",
     )
 
     # Bit flags tracking which newline *styles* the stream has emitted so
@@ -192,6 +206,25 @@ class AsyncGzipTextFile:
         self._max_rewind_cache_size: Optional[int] = max_rewind_cache_size
         self._strict_size: bool = bool(strict_size)
         self._fast_compress: bool = bool(fast_compress)
+
+        # Batched line iteration: for the single-character terminator modes we
+        # bulk-split a decoded chunk into whole lines once (C-speed) and serve
+        # them from _pending_lines, advancing _text_buffer_offset per line so
+        # tell()/seek() bookkeeping stays identical to consuming one at a time.
+        # `_line_term` is None for the modes that need cross-boundary handling
+        # ('' look-ahead, '\r\n'), which keep the per-line buffer-scan path.
+        if newline in self._FAST_READLINE_NEWLINES:
+            self._line_term: Optional[str] = "\r" if newline == "\r" else "\n"
+            # Unsubscripted re.Pattern: re.Pattern[str] is not subscriptable at
+            # runtime on Python 3.8, and an attribute annotation is evaluated.
+            self._line_split_re: Optional[re.Pattern] = (
+                _LINE_RE_CR if newline == "\r" else _LINE_RE_LF
+            )
+        else:
+            self._line_term = None
+            self._line_split_re = None
+        self._pending_lines: List[str] = []
+        self._pending_idx: int = 0
 
     async def __aenter__(self) -> "AsyncGzipTextFile":
         """Enter the async context manager and initialize resources."""
@@ -426,6 +459,11 @@ class AsyncGzipTextFile:
         """Replace the unread decoded text buffer."""
         self._text_buffer = text
         self._text_buffer_offset = 0
+        # Any pre-split lines were views into the old buffer/offset; drop them
+        # so a later iteration step re-splits from the new buffer state.
+        if self._pending_lines:
+            self._pending_lines = []
+            self._pending_idx = 0
 
     def _append_buffer(self, text: str) -> None:
         """Append decoded text, compacting consumed prefix when it grows large."""
@@ -729,6 +767,13 @@ class AsyncGzipTextFile:
         if size == 0:
             return ""
 
+        # read() consumes the buffer by character count; drop any batched
+        # pending lines so they cannot serve stale content afterwards. The
+        # synced offset means the buffer remainder is read correctly regardless.
+        if self._pending_lines:
+            self._pending_lines = []
+            self._pending_idx = 0
+
         if size == -1:
             # Fast path: drain buffer, then read all remaining binary data
             # in one shot to avoid per-chunk buffer append/consume overhead
@@ -927,30 +972,59 @@ class AsyncGzipTextFile:
     # boundaries and stay on the buffer-accumulating path.
     _FAST_READLINE_NEWLINES = frozenset({None, "\n", "\r"})
 
-    async def _readline_fast(self) -> str:
-        """O(n) single-line read for the cross-boundary-safe newline modes.
+    def _take_pending_line(self) -> Optional[str]:
+        """Pop the next pre-split line, advancing the buffer offset by its length.
 
-        Accumulates the line in a local list and joins once, instead of
-        repeatedly growing the str buffer via ``_append_buffer`` (which is
-        O(n^2) for a very long line because CPython cannot extend a slotted
-        str attribute in place). Returns "" at end of input.
-
-        Only valid when ``self._newline in _FAST_READLINE_NEWLINES``.
+        Advancing ``_text_buffer_offset`` exactly as ``_consume_buffer`` would
+        keeps tell()/seek() bookkeeping identical to consuming one line at a
+        time. Returns None when ``_pending_lines`` is exhausted.
         """
-        term = "\r" if self._newline == "\r" else "\n"
+        idx = self._pending_idx
+        pending = self._pending_lines
+        if idx < len(pending):
+            line = pending[idx]
+            self._pending_idx = idx + 1
+            self._text_buffer_offset += len(line)
+            return line
+        return None
 
-        # 1. Satisfy from already-buffered text when it holds a terminator.
+    async def _next_fast_line(self) -> Optional[str]:
+        """Return the next line for a single-character terminator mode.
+
+        Serves from ``_pending_lines`` first; when those run out it bulk-splits
+        the complete lines in the buffered remainder in one C-level pass, or
+        (for a line spanning the chunk boundary or the final unterminated line)
+        accumulates across chunks exactly as the original per-line path did.
+        Returns None at end of input.
+        """
+        line = self._take_pending_line()
+        if line is not None:
+            return line
+
+        term = self._line_term
+        split_re = self._line_split_re
+        # Both are set together for single-char terminator modes; this method is
+        # only reached in those modes.
+        assert term is not None and split_re is not None
+
+        # Bulk-split every complete line in the buffered remainder at once.
         buf = self._text_buffer
         start = self._text_buffer_offset
-        idx = buf.find(term, start)
-        if idx != -1:
-            return self._consume_buffer(idx + 1 - start)
+        last = buf.rfind(term)
+        if last >= start:
+            region = buf[start : last + 1]
+            self._pending_lines = split_re.findall(region)
+            self._pending_idx = 0
+            return self._take_pending_line()
 
-        # 2. The buffered remainder (if any) is part of this line. Pull it out
-        #    and accumulate freshly decoded chunks locally.
-        parts: List[str] = []
+        # The remainder has no terminator: it is the head of a line that
+        # continues into later chunks (or the final unterminated line). Pull it
+        # out and gather decoded chunks until a terminator or EOF, keeping the
+        # whole terminating chunk buffered so its replay origin (captured by
+        # _decode_next_chunk before decoding) stays valid for tell()/seek().
+        prefix: List[str] = []
         if start < len(buf):
-            parts.append(buf[start:] if start else buf)
+            prefix.append(buf[start:] if start else buf)
         self._set_buffer("")
 
         while True:
@@ -958,16 +1032,44 @@ class AsyncGzipTextFile:
             if text:
                 i = text.find(term)
                 if i != -1:
-                    parts.append(text[: i + 1])
-                    # Keep the whole chunk buffered so the residual's replay
-                    # origin (captured by _decode_next_chunk before decoding
-                    # it) stays valid for tell()/seek().
+                    if prefix:
+                        first_line = "".join(prefix) + text[: i + 1]
+                    else:
+                        first_line = text[: i + 1]
                     self._set_buffer(text)
                     self._text_buffer_offset = i + 1
-                    return "".join(parts)
-                parts.append(text)
+                    # Pre-split any further complete lines in this chunk so the
+                    # next calls serve them without re-scanning.
+                    rest_last = text.rfind(term)
+                    if rest_last > i:
+                        self._pending_lines = split_re.findall(
+                            text[i + 1 : rest_last + 1]
+                        )
+                        self._pending_idx = 0
+                    return first_line
+                prefix.append(text)
             if not more:
-                return "".join(parts)
+                tail = "".join(prefix)
+                return tail if tail else None
+
+    async def _readline_fast(self) -> str:
+        """Single-line read for the single-character terminator modes.
+
+        Returns "" at end of input. Only valid when
+        ``self._line_term is not None``.
+        """
+        # Serve a pre-split line inline (mirroring __anext__) so repeated
+        # readline() calls do not pay an extra coroutine hop per line; only
+        # refill through the coroutine when the batch is drained.
+        idx = self._pending_idx
+        pending = self._pending_lines
+        if idx < len(pending):
+            line = pending[idx]
+            self._pending_idx = idx + 1
+            self._text_buffer_offset += len(line)
+            return line
+        refilled = await self._next_fast_line()
+        return refilled if refilled is not None else ""
 
     def __aiter__(self) -> "AsyncGzipTextFile":
         """Make AsyncGzipTextFile iterable for line-by-line reading."""
@@ -978,11 +1080,20 @@ class AsyncGzipTextFile:
         if self._is_closed:
             raise StopAsyncIteration
 
-        if self._newline in self._FAST_READLINE_NEWLINES:
-            line = await self._readline_fast()
-            if line == "":
+        if self._line_term is not None:
+            # Serve a pre-split line inline to avoid a coroutine hop per line;
+            # only fall back to the refill coroutine when the batch is drained.
+            idx = self._pending_idx
+            pending = self._pending_lines
+            if idx < len(pending):
+                line = pending[idx]
+                self._pending_idx = idx + 1
+                self._text_buffer_offset += len(line)
+                return line
+            refilled = await self._next_fast_line()
+            if refilled is None:
                 raise StopAsyncIteration
-            return line
+            return refilled
 
         search_from = 0
         while True:
@@ -1033,11 +1144,17 @@ class AsyncGzipTextFile:
         if limit == 0:
             return ""
 
-        # Unbounded reads in a cross-boundary-safe newline mode use the O(n)
-        # local-accumulation path. Bounded reads (limit != -1) cap the work at
-        # `limit` characters anyway, so they stay on the buffer path below.
-        if limit == -1 and self._newline in self._FAST_READLINE_NEWLINES:
+        # Unbounded reads in a single-character terminator mode use the batched
+        # pending-line path. Bounded reads (limit != -1) cap the work at `limit`
+        # characters anyway, so they stay on the buffer path below.
+        if limit == -1 and self._line_term is not None:
             return await self._readline_fast()
+
+        # Bounded reads consume the buffer by character count, which would leave
+        # any batched pending lines pointing at stale offsets; drop them first.
+        if self._pending_lines:
+            self._pending_lines = []
+            self._pending_idx = 0
 
         # Try to get a line from our buffer using newline-aware search
         search_from = 0

--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -84,6 +84,7 @@ class AsyncGzipTextFile:
         "_max_decompressed_size",
         "_max_rewind_cache_size",
         "_strict_size",
+        "_fast_compress",
     )
 
     # Bit flags tracking which newline *styles* the stream has emitted so
@@ -119,6 +120,7 @@ class AsyncGzipTextFile:
         max_decompressed_size: Optional[int] = None,
         max_rewind_cache_size: Optional[int] = _MAX_CHUNK_SIZE,
         strict_size: bool = False,
+        fast_compress: bool = False,
     ) -> None:
         # Validate inputs using shared validation functions
         _validate_filename(filename, fileobj)
@@ -189,6 +191,7 @@ class AsyncGzipTextFile:
         self._max_decompressed_size: Optional[int] = max_decompressed_size
         self._max_rewind_cache_size: Optional[int] = max_rewind_cache_size
         self._strict_size: bool = bool(strict_size)
+        self._fast_compress: bool = bool(fast_compress)
 
     async def __aenter__(self) -> "AsyncGzipTextFile":
         """Enter the async context manager and initialize resources."""
@@ -205,6 +208,7 @@ class AsyncGzipTextFile:
             max_decompressed_size=self._max_decompressed_size,
             max_rewind_cache_size=self._max_rewind_cache_size,
             strict_size=self._strict_size,
+            fast_compress=self._fast_compress,
         )
         try:
             await self._binary_file.__aenter__()

--- a/tests/test_batched_readline.py
+++ b/tests/test_batched_readline.py
@@ -153,6 +153,54 @@ class TestTellSeekDuringIteration:
             assert await f.__anext__() == "row10\n"
 
 
+class TestBatchWindowing:
+    """The pending batch is capped at _LINE_BATCH_CHARS per refill so a large
+    chunk_size full of tiny lines does not materialize the whole chunk at once.
+    A tiny cap forces many windowed refills within one buffered chunk."""
+
+    @pytest.mark.asyncio
+    async def test_many_small_lines_across_windows(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(AsyncGzipTextFile, "_LINE_BATCH_CHARS", 16)
+        text = "".join(f"{i}\n" for i in range(5000))
+        path = tmp_path / "win.gz"
+        path.write_bytes(gzip.compress(text.encode("utf-8")))
+        # chunk_size far larger than the cap so one buffer holds many windows.
+        async with AsyncGzipTextFile(path, "rt", newline="\n", chunk_size=1 << 20) as f:
+            lines = [line async for line in f]
+        assert lines == oracle_lines(path, "\n")
+
+    @pytest.mark.asyncio
+    async def test_line_longer_than_window(self, tmp_path, monkeypatch):
+        # A line longer than the batch window must still be emitted whole
+        # (exercises the find()-fallback when the window holds no terminator).
+        monkeypatch.setattr(AsyncGzipTextFile, "_LINE_BATCH_CHARS", 8)
+        text = ("x" * 500) + "\n" + "short\n" + ("y" * 300) + "\n"
+        path = tmp_path / "longwin.gz"
+        path.write_bytes(gzip.compress(text.encode("utf-8")))
+        async with AsyncGzipTextFile(path, "rt", newline="\n", chunk_size=1 << 20) as f:
+            lines = [line async for line in f]
+        assert lines == ["x" * 500 + "\n", "short\n", "y" * 300 + "\n"]
+
+
+class TestBoundedReadlineInterleaving:
+    @pytest.mark.asyncio
+    async def test_bounded_readline_clears_pending_batch(self, tmp_path):
+        """A bounded readline(limit) after iteration has populated the batch
+        must not let stale pre-split lines be served on the next iteration."""
+        text = "abcdefgh\nij\nklmno\npqr\n"
+        path = tmp_path / "bnd.gz"
+        path.write_bytes(gzip.compress(text.encode("utf-8")))
+        async with AsyncGzipTextFile(path, "rt", newline="\n") as f:
+            first = await f.__anext__()  # populates the pending batch
+            mid = await f.readline(3)  # bounded -> must drop the batch
+            nxt = await f.__anext__()  # must be the real next line, not stale
+            tail = await f.read()
+        assert first == "abcdefgh\n"
+        assert mid == "ij\n"
+        assert nxt == "klmno\n"
+        assert tail == "pqr\n"
+
+
 class TestLongLineSpanningChunks:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("newline", [None, "\n", "\r"])

--- a/tests/test_batched_readline.py
+++ b/tests/test_batched_readline.py
@@ -1,0 +1,167 @@
+"""Tests for the batched line-iteration path in AsyncGzipTextFile.
+
+The fast path bulk-splits a decoded chunk into whole lines in one pass. These
+tests guard the two things most likely to break: (1) it must split on the SAME
+terminators as Python's text-mode readline (NOT str.splitlines, which also
+breaks on \\v, \\f, \\x1c-\\x1e, \\x85, U+2028, U+2029), and (2) tell()/seek()
+and read() must stay correct when interleaved with iteration.
+
+stdlib ``gzip.open(..., 'rt')`` is used as the oracle for line splitting.
+"""
+
+import gzip
+
+import pytest
+
+from aiogzip import AsyncGzipTextFile
+
+# Rich text exercising: blank lines, no trailing newline, every newline style,
+# multibyte UTF-8, and the control/Unicode chars that str.splitlines would
+# wrongly treat as line breaks but text-mode readline must keep inline.
+SPECIALS = "\x0b\x0c\x1c\x1d\x1e\x85  "
+RICH_TEXT = (
+    "héllo\n"
+    "wörld\r\n"
+    "café\r"
+    "\n"  # blank line
+    f"specials {SPECIALS} stay inline\n"
+    "ünïcode line that is fairly long " * 4 + "\n"
+    "last line without newline"
+)
+
+
+@pytest.fixture
+def rich_gz(tmp_path):
+    path = tmp_path / "rich.gz"
+    path.write_bytes(gzip.compress(RICH_TEXT.encode("utf-8")))
+    return path
+
+
+def oracle_lines(path, newline):
+    with gzip.open(path, "rt", encoding="utf-8", newline=newline) as f:
+        return f.readlines()
+
+
+@pytest.mark.parametrize("newline", [None, "\n", "\r", "\r\n", ""])
+@pytest.mark.parametrize("chunk_size", [4, 7, 64, 1 << 20])
+class TestMatchesStdlibOracle:
+    @pytest.mark.asyncio
+    async def test_async_iteration_matches_oracle(self, rich_gz, newline, chunk_size):
+        expected = oracle_lines(rich_gz, newline)
+        async with AsyncGzipTextFile(
+            rich_gz, "rt", newline=newline, chunk_size=chunk_size
+        ) as f:
+            got = [line async for line in f]
+        assert got == expected
+
+    @pytest.mark.asyncio
+    async def test_readline_loop_matches_oracle(self, rich_gz, newline, chunk_size):
+        expected = oracle_lines(rich_gz, newline)
+        got = []
+        async with AsyncGzipTextFile(
+            rich_gz, "rt", newline=newline, chunk_size=chunk_size
+        ) as f:
+            while True:
+                line = await f.readline()
+                if not line:
+                    break
+                got.append(line)
+        assert got == expected
+
+
+class TestNoOverSplitting:
+    """The control/Unicode chars in SPECIALS must NOT create line breaks."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("newline", [None, "\n", "\r"])
+    async def test_specials_stay_inline(self, tmp_path, newline):
+        # Use the mode's own terminator so there are exactly two lines, with the
+        # specials sitting inside the first one (never used as a separator).
+        term = "\r" if newline == "\r" else "\n"
+        text = f"before {SPECIALS} after{term}second{term}"
+        path = tmp_path / "sp.gz"
+        path.write_bytes(gzip.compress(text.encode("utf-8")))
+        async with AsyncGzipTextFile(path, "rt", newline=newline, chunk_size=5) as f:
+            lines = [line async for line in f]
+        assert lines == [f"before {SPECIALS} after{term}", f"second{term}"]
+        # And it agrees with the stdlib oracle.
+        assert lines == oracle_lines(path, newline)
+
+
+class TestInterleavedReadAndIterate:
+    @pytest.mark.asyncio
+    async def test_read_after_partial_iteration(self, rich_gz):
+        """read() after consuming some lines returns exactly the remainder."""
+        expected_all = "".join(oracle_lines(rich_gz, None))
+        async with AsyncGzipTextFile(rich_gz, "rt", newline=None, chunk_size=8) as f:
+            first = await f.__anext__()
+            second = await f.__anext__()
+            rest = await f.read()
+        assert first + second + rest == expected_all
+
+    @pytest.mark.asyncio
+    async def test_iterate_then_read_sized_then_iterate(self, tmp_path):
+        text = "".join(f"line {i}\n" for i in range(200))
+        path = tmp_path / "many.gz"
+        path.write_bytes(gzip.compress(text.encode("utf-8")))
+        async with AsyncGzipTextFile(path, "rt", newline="\n", chunk_size=16) as f:
+            a = await f.__anext__()  # "line 0\n"
+            mid = await f.read(5)  # next 5 chars: "line "
+            b = await f.__anext__()  # rest of the partial line: "1\n"
+            tail = await f.read()
+        assert a == "line 0\n"
+        assert mid == "line "
+        assert b == "1\n"
+        assert tail == "".join(f"line {i}\n" for i in range(2, 200))
+
+
+class TestTellSeekDuringIteration:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("chunk_size", [8, 64])
+    async def test_tell_seek_roundtrip_midstream(self, rich_gz, chunk_size):
+        async with AsyncGzipTextFile(
+            rich_gz, "rt", newline=None, chunk_size=chunk_size
+        ) as f:
+            consumed = ""
+            consumed += await f.__anext__()
+            consumed += await f.__anext__()
+            cookie = await f.tell()
+            remainder_first = await f.read()
+
+            await f.seek(cookie)
+            remainder_again = await f.read()
+
+        assert remainder_first == remainder_again
+        assert consumed + remainder_first == RICH_TEXT.replace("\r\n", "\n").replace(
+            "\r", "\n"
+        )
+
+    @pytest.mark.asyncio
+    async def test_tell_at_start_of_each_line_seekable(self, tmp_path):
+        text = "".join(f"row{i}\n" for i in range(50))
+        path = tmp_path / "rows.gz"
+        path.write_bytes(gzip.compress(text.encode("utf-8")))
+        async with AsyncGzipTextFile(path, "rt", newline="\n", chunk_size=16) as f:
+            # Read 10 lines, snapshot position, then verify seeking back there
+            # re-reads the exact same next line.
+            for _ in range(10):
+                await f.__anext__()
+            cookie = await f.tell()
+            next_line = await f.__anext__()
+            assert next_line == "row10\n"
+            await f.seek(cookie)
+            assert await f.__anext__() == "row10\n"
+
+
+class TestLongLineSpanningChunks:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("newline", [None, "\n", "\r"])
+    async def test_single_line_longer_than_chunk(self, tmp_path, newline):
+        term = "\r" if newline == "\r" else "\n"
+        long_line = "x" * 10_000 + term
+        text = long_line + "short" + term
+        path = tmp_path / "long.gz"
+        path.write_bytes(gzip.compress(text.encode("utf-8")))
+        async with AsyncGzipTextFile(path, "rt", newline=newline, chunk_size=64) as f:
+            lines = [line async for line in f]
+        assert lines == ["x" * 10_000 + term, "short" + term]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,147 @@
+"""Tests for the codec engine abstraction (aiogzip._engine).
+
+Covers engine selection, the zlib-ng decompression default, the compression
+opt-in boundary, and — critically — that corrupt streams are wrapped into
+OSError/BadGzipFile under *both* engines, since zlib-ng's error type is not
+zlib.error.
+"""
+
+import gzip
+import importlib
+import zlib
+
+import pytest
+
+from aiogzip import AsyncGzipBinaryFile, _engine
+from aiogzip._common import GZIP_WBITS
+
+ZNG_AVAILABLE = _engine._zng is not None
+
+# Engine states to exercise end-to-end: stdlib always; zlib-ng when installed.
+ENGINE_PARAMS = [False]
+if ZNG_AVAILABLE:
+    ENGINE_PARAMS.append(True)
+
+
+@pytest.fixture(params=ENGINE_PARAMS, ids=lambda v: "zlib-ng" if v else "stdlib")
+def active_engine(request, monkeypatch):
+    """Force the active decompression engine on and off for each test."""
+    monkeypatch.setattr(_engine, "_HAVE_ZNG", request.param)
+    return request.param
+
+
+class TestEngineSelection:
+    def test_zlib_errors_includes_stdlib(self):
+        assert zlib.error in _engine.ZLIB_ERRORS
+
+    @pytest.mark.skipif(not ZNG_AVAILABLE, reason="zlib-ng not installed")
+    def test_zlib_errors_includes_zlib_ng(self):
+        # The whole point of the abstraction: zlib-ng's error is NOT zlib.error.
+        assert _engine._zng.error in _engine.ZLIB_ERRORS
+        assert not issubclass(_engine._zng.error, zlib.error)
+
+    def test_decompress_engine_name_tracks_availability(self, active_engine):
+        expected = "zlib-ng" if active_engine else "stdlib"
+        assert _engine.decompress_engine_name() == expected
+        assert _engine.have_fast_engine() is active_engine
+
+    def test_crc32_is_stdlib(self):
+        assert _engine.crc32 is zlib.crc32
+
+
+class TestEnvEscapeHatch:
+    def test_force_stdlib_via_env(self, monkeypatch):
+        """AIOGZIP_ENGINE=stdlib disables zlib-ng even when importable."""
+        monkeypatch.setenv("AIOGZIP_ENGINE", "stdlib")
+        reloaded = importlib.reload(_engine)
+        try:
+            assert reloaded.have_fast_engine() is False
+            assert reloaded.decompress_engine_name() == "stdlib"
+        finally:
+            # Restore module state (and the _binary reference to it) for other tests.
+            monkeypatch.delenv("AIOGZIP_ENGINE", raising=False)
+            importlib.reload(_engine)
+
+
+class TestCrossEngineDecompress:
+    @pytest.mark.parametrize(
+        "data",
+        [b"", b"hello world", b"A" * 100_000, bytes(range(256)) * 500],
+        ids=["empty", "short", "compressible-100k", "binary-128k"],
+    )
+    def test_inflate_matches_stdlib(self, active_engine, data):
+        """Decompressing a stdlib-produced stream yields identical bytes."""
+        compressed = gzip.compress(data)
+        obj = _engine.decompressobj(GZIP_WBITS)
+        out = obj.decompress(compressed) + obj.flush()
+        assert out == data
+
+
+class TestCompressionOptIn:
+    def test_default_compression_is_stdlib_bytes(self, monkeypatch):
+        """fast=False must produce byte-identical output to stdlib zlib,
+        even when zlib-ng is available (installing the extra alone must not
+        change produced .gz bytes)."""
+        monkeypatch.setattr(_engine, "_HAVE_ZNG", ZNG_AVAILABLE)
+        data = b"the quick brown fox jumps over the lazy dog " * 500
+        ours = _engine.compressobj(6, -_engine.MAX_WBITS, fast=False)
+        ref = zlib.compressobj(6, wbits=-_engine.MAX_WBITS)
+        assert ours.compress(data) + ours.flush() == ref.compress(data) + ref.flush()
+
+    @pytest.mark.skipif(not ZNG_AVAILABLE, reason="zlib-ng not installed")
+    def test_fast_compression_differs_but_roundtrips(self, monkeypatch):
+        monkeypatch.setattr(_engine, "_HAVE_ZNG", True)
+        data = b"the quick brown fox jumps over the lazy dog " * 500
+        fast = _engine.compressobj(6, -_engine.MAX_WBITS, fast=True)
+        std = zlib.compressobj(6, wbits=-_engine.MAX_WBITS)
+        fast_bytes = fast.compress(data) + fast.flush()
+        std_bytes = std.compress(data) + std.flush()
+        # Different compressor, generally different bytes...
+        assert fast_bytes != std_bytes
+        # ...but still valid raw deflate that inflates to the original.
+        assert zlib.decompress(fast_bytes, wbits=-_engine.MAX_WBITS) == data
+
+    def test_fast_falls_back_when_unavailable(self, monkeypatch):
+        """fast=True without zlib-ng falls back to stdlib bytes silently."""
+        monkeypatch.setattr(_engine, "_HAVE_ZNG", False)
+        data = b"payload" * 1000
+        ours = _engine.compressobj(6, -_engine.MAX_WBITS, fast=True)
+        ref = zlib.compressobj(6, wbits=-_engine.MAX_WBITS)
+        assert ours.compress(data) + ours.flush() == ref.compress(data) + ref.flush()
+
+
+class TestEndToEndUnderEngines:
+    @pytest.mark.asyncio
+    async def test_roundtrip(self, active_engine, tmp_path):
+        path = tmp_path / "rt.gz"
+        payload = b"end to end payload " * 10_000  # exceeds offload threshold
+        async with AsyncGzipBinaryFile(path, "wb") as f:
+            await f.write(payload)
+        async with AsyncGzipBinaryFile(path, "rb") as f:
+            assert await f.read() == payload
+
+    @pytest.mark.asyncio
+    async def test_interop_with_stdlib_gzip(self, active_engine, tmp_path):
+        """aiogzip reads a stdlib-written .gz back identically under any engine."""
+        path = tmp_path / "interop.gz"
+        payload = bytes(range(256)) * 2000
+        with gzip.open(path, "wb") as f:
+            f.write(payload)
+        async with AsyncGzipBinaryFile(path, "rb") as f:
+            assert await f.read() == payload
+
+    @pytest.mark.asyncio
+    async def test_corrupt_stream_wrapped(self, active_engine, tmp_path):
+        """A corrupted deflate body must raise BadGzipFile (OSError subclass)
+        under both engines — the regression guard for zlib-ng's foreign error
+        type bypassing the except handlers."""
+        path = tmp_path / "corrupt.gz"
+        good = gzip.compress(b"some content that will be corrupted " * 100)
+        # Corrupt bytes inside the deflate body (past the 10-byte header).
+        corrupt = bytearray(good)
+        for i in range(15, 40):
+            corrupt[i] ^= 0xFF
+        path.write_bytes(bytes(corrupt))
+        with pytest.raises(OSError):  # gzip.BadGzipFile is an OSError subclass
+            async with AsyncGzipBinaryFile(path, "rb") as f:
+                await f.read()

--- a/tests/test_fast_compress.py
+++ b/tests/test_fast_compress.py
@@ -1,0 +1,129 @@
+"""Tests for the opt-in fast_compress flag (zlib-ng compression).
+
+Decompression auto-uses zlib-ng (covered in test_engine.py); compression only
+uses it when the caller passes fast_compress=True AND zlib-ng is available.
+Installing the extra alone must not change default compressed output.
+"""
+
+import gzip
+import warnings
+
+import pytest
+
+from aiogzip import AsyncGzipBinaryFile, AsyncGzipFile, AsyncGzipTextFile, _engine
+
+ZNG_AVAILABLE = _engine._zng is not None
+
+PAYLOAD = b"the quick brown fox jumps over the lazy dog " * 5000
+
+
+async def _read_back(path):
+    async with AsyncGzipBinaryFile(path, "rb") as f:
+        return await f.read()
+
+
+class TestDefaultCompressionUnchanged:
+    @pytest.mark.asyncio
+    async def test_installing_extra_does_not_change_default_output(
+        self, monkeypatch, tmp_path
+    ):
+        """fast_compress defaults to False, so output must be byte-identical
+        whether or not zlib-ng is available."""
+
+        # Same path/name both times: the gzip header embeds the original
+        # filename, so differing names would mask a true body comparison.
+        path = tmp_path / "default.gz"
+
+        async def write_with(have_zng):
+            monkeypatch.setattr(_engine, "_HAVE_ZNG", have_zng)
+            async with AsyncGzipBinaryFile(path, "wb", mtime=0) as f:
+                await f.write(PAYLOAD)
+            return path.read_bytes()
+
+        with_zng = await write_with(True)
+        without_zng = await write_with(False)
+        assert with_zng == without_zng
+
+
+@pytest.mark.skipif(not ZNG_AVAILABLE, reason="zlib-ng not installed")
+class TestFastCompressEnabled:
+    @pytest.mark.asyncio
+    async def test_roundtrip_binary(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(_engine, "_HAVE_ZNG", True)
+        path = tmp_path / "fast.gz"
+        async with AsyncGzipBinaryFile(path, "wb", fast_compress=True) as f:
+            await f.write(PAYLOAD)
+        assert await _read_back(path) == PAYLOAD
+
+    @pytest.mark.asyncio
+    async def test_readable_by_stdlib_gzip(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(_engine, "_HAVE_ZNG", True)
+        path = tmp_path / "fast_interop.gz"
+        async with AsyncGzipBinaryFile(path, "wb", fast_compress=True) as f:
+            await f.write(PAYLOAD)
+        with gzip.open(path, "rb") as f:
+            assert f.read() == PAYLOAD
+
+    @pytest.mark.asyncio
+    async def test_fast_output_differs_from_default(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(_engine, "_HAVE_ZNG", True)
+        # Same path/name and mtime so only the deflate body can differ.
+        path = tmp_path / "same.gz"
+        async with AsyncGzipBinaryFile(path, "wb", mtime=0) as f:
+            await f.write(PAYLOAD)
+        default_bytes = path.read_bytes()
+        async with AsyncGzipBinaryFile(path, "wb", mtime=0, fast_compress=True) as f:
+            await f.write(PAYLOAD)
+        fast_bytes = path.read_bytes()
+        # Identical header (same name + mtime); body differs because a
+        # different deflate implementation produced it.
+        assert default_bytes != fast_bytes
+
+    @pytest.mark.asyncio
+    async def test_roundtrip_text(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(_engine, "_HAVE_ZNG", True)
+        path = tmp_path / "fast.txt.gz"
+        text = "héllo wörld\nsecond line\n" * 5000
+        async with AsyncGzipTextFile(path, "wt", fast_compress=True) as f:
+            await f.write(text)
+        async with AsyncGzipTextFile(path, "rt") as f:
+            assert await f.read() == text
+
+    @pytest.mark.asyncio
+    async def test_factory_threads_flag(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(_engine, "_HAVE_ZNG", True)
+        path = tmp_path / "factory.gz"
+        async with AsyncGzipFile(path, "wb", fast_compress=True) as f:
+            await f.write(PAYLOAD)
+        assert await _read_back(path) == PAYLOAD
+
+
+class TestFastCompressFallback:
+    def test_warns_when_unavailable(self, monkeypatch, tmp_path):
+        """fast_compress=True without zlib-ng warns once at construction."""
+        monkeypatch.setattr(_engine, "_HAVE_ZNG", False)
+        with pytest.warns(UserWarning, match="zlib-ng is not available"):
+            AsyncGzipBinaryFile(tmp_path / "x.gz", "wb", fast_compress=True)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_and_roundtrips(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(_engine, "_HAVE_ZNG", False)
+        path = tmp_path / "fallback.gz"
+        with pytest.warns(UserWarning):
+            cm = AsyncGzipBinaryFile(path, "wb", fast_compress=True)
+        async with cm as f:
+            await f.write(PAYLOAD)
+        assert await _read_back(path) == PAYLOAD
+
+    def test_no_warning_in_read_mode(self, monkeypatch, tmp_path):
+        """fast_compress is meaningless for reads and must not warn there."""
+        monkeypatch.setattr(_engine, "_HAVE_ZNG", False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            AsyncGzipBinaryFile(tmp_path / "r.gz", "rb", fast_compress=True)
+
+    def test_no_warning_when_not_requested(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(_engine, "_HAVE_ZNG", False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            AsyncGzipBinaryFile(tmp_path / "n.gz", "wb")


### PR DESCRIPTION
## Summary

Three independent performance improvements, each in its own commit, plus docs and benchmark coverage.

**1. Optional zlib-ng engine for decompression** (`7270841`)
New `aiogzip._engine` abstraction that soft-detects the optional `aiogzip[fast]` extra. When `zlib-ng` is installed, **decompression uses it automatically** — output is byte-identical to stdlib `zlib`, so it's transparent. Without the extra, aiogzip stays pure-Python. `AIOGZIP_ENGINE=stdlib` forces stdlib.

The key correctness detail: `zlib-ng`'s error type is **not** `zlib.error` nor a subclass, so every `except` site now catches `_engine.ZLIB_ERRORS` — otherwise a corrupt stream decoded by zlib-ng would leak an unwrapped exception past the `OSError` wrapping.

**2. Opt-in `fast_compress` for compression** (`cd64117`)
`fast_compress=True` on the file classes / factory uses zlib-ng for compression (~1.5x). It stays **off by default even when zlib-ng is installed**, because zlib-ng's compressed *bytes* differ from stdlib's — installing the extra must not change produced `.gz` output. Requesting it without zlib-ng warns once and falls back.

**3. Batched line iteration** (`fc06ee6`, refined in `d4af353`)
For the single-character newline modes (`None`/`"\n"`/`"\r"`), each chunk's lines are bulk-split in one regex pass (`[^\n]*\n` — **not** `str.splitlines()`, which would over-split on `\v`, `\f`, `\x1c`–`\x1e`, `\x85`, U+2028/9) and served inline. ~1.34x on `async for`, ~1.16x on `readline()`. Each line advances `_text_buffer_offset` exactly as `_consume_buffer` would, so `tell()`/`seek()`/cookies and the incremental-decode + newline state are unchanged. The split is capped per refill so a large `chunk_size` full of tiny lines can't materialize millions of strings at once.

Docs (`ee93759`) and benchmarks (`9c76fa8`) document and measure all three.

## Measured (with vs without zlib-ng, 8 MiB)

| Path | Gain |
|---|---|
| Decompression (read-all, compressible) | ~10x |
| Decompression (`read(-1)`) | ~7x |
| Decompression (typical reads) | ~1.2–2.4x |
| `fast_compress` compression | ~1.5x |
| Line iteration (`async for` / `readline`) | ~1.34x / ~1.16x |

## Compatibility

- Pure-Python by default; `zlib-ng` is a soft, optional dependency.
- Default `.gz` output is byte-stable (regression-guarded).
- Python 3.8–3.14; mypy + ty clean.

## Testing

- **484 tests pass** on both engines (zlib-ng active and `AIOGZIP_ENGINE=stdlib`).
- CI gains a `fast-engine` job: the main matrix runs the pure-Python default across the full version/OS sweep; the new job exercises both engine paths.
- New suites: `test_engine.py`, `test_fast_compress.py`, `test_batched_readline.py` (oracle-compared against `gzip.open`, including the over-splitting guard, tell/seek-during-iteration, and bounded-readline interleaving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)