### PR TITLE
Prepare release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-06-01
+
 ### Added
 
 - Optional `aiogzip[fast]` extra that installs [`zlib-ng`](https://pypi.org/project/zlib-ng/). When present, **decompression** automatically uses zlib-ng, which is faster (~1.6–2x on typical data) and produces byte-identical output to stdlib `zlib`. Set the environment variable `AIOGZIP_ENGINE=stdlib` to force stdlib regardless of what is installed. When the extra is not installed, aiogzip remains pure-Python and behaves exactly as before.
 - `fast_compress=True` option on `AsyncGzipBinaryFile`, `AsyncGzipTextFile`, and the `AsyncGzipFile` factory to opt into zlib-ng for **compression** (~1.2–1.4x). Compression stays on stdlib `zlib` by default because zlib-ng's compressed output is not byte-identical — installing the extra alone does not change produced `.gz` bytes. If `fast_compress=True` is requested without zlib-ng installed, it warns once and falls back to stdlib. zlib-ng output remains valid gzip readable by any decompressor.
+
+### Performance
+
+- Line iteration in `AsyncGzipTextFile` (`async for` / `readline()`) is faster for the single-character newline modes (`None`, `"\n"`, `"\r"`): each decoded chunk's complete lines are bulk-split in one pass and served from a batch instead of scanned one at a time. ~1.3x for `async for` and ~1.16x for `readline()` loops; the batch is capped per refill so a large `chunk_size` does not increase peak memory unboundedly.
 
 ## [1.6.0] - 2026-05-28
 

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -19,7 +19,7 @@ from ._common import (
 )
 from ._text import AsyncGzipTextFile
 
-__version__ = "1.6.0"
+__version__ = "1.7.0"
 
 
 def AsyncGzipFile(


### PR DESCRIPTION
Release **v1.7.0** (minor — backward-compatible additions).

## Changelog

### Added
- **Optional `aiogzip[fast]` extra** (zlib-ng): when installed, **decompression** uses zlib-ng automatically — faster (~1.6–2x typical) with byte-identical output. `AIOGZIP_ENGINE=stdlib` forces stdlib; pure-Python without the extra.
- **`fast_compress=True`** on the file classes / factory: opt into zlib-ng for **compression** (~1.2–1.4x). Off by default (zlib-ng's compressed bytes differ from stdlib's, so default `.gz` output is unchanged); warns once and falls back if zlib-ng is absent.

### Performance
- **Batched line iteration** in `AsyncGzipTextFile` for the single-character newline modes (`None`/`"\n"`/`"\r"`): ~1.3x `async for`, ~1.16x `readline()`. Batch is capped per refill so peak memory stays bounded regardless of `chunk_size`.

## Notes
- Pure-Python default preserved; default compressed output is byte-stable.
- Python 3.8–3.14; full suite (484 tests) green on both engine paths in PR #18.

After CI passes and this merges, run `/release-tag` to tag and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)