### PR TITLE
Replay only the forward delta in _seek_to_plain_position

### DIFF
--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -547,12 +547,30 @@ class AsyncGzipTextFile:
         )
 
     async def _seek_to_plain_position(self, offset: int) -> None:
-        """Restore a plain text position by replaying bytes from the stream start."""
+        """Restore a plain text position by replaying decoded bytes forward.
+
+        Fast path: when the stream is already at a plain position at or behind
+        the target (and not at EOF), replay only the bytes between the current
+        binary position and ``offset`` instead of restarting from the beginning.
+        The incremental decoder and the newline tracker compose, so feeding the
+        delta onto the live state reaches the same decoder/newline state a full
+        replay-from-zero would. Otherwise reset and replay from the start.
+        """
         if self._binary_file is None:
             raise ValueError("File not opened. Use async context manager.")
 
-        await self._reset_to_start()
-        remaining = offset
+        if (
+            not self._binary_file._eof
+            and offset >= self._binary_file._position
+            and self._can_use_plain_position(self._decoder.getstate())
+        ):
+            # Already a plain position at/behind the target: replay only the
+            # forward delta, keeping the live decoder and newline state.
+            remaining = offset - self._binary_file._position
+        else:
+            await self._reset_to_start()
+            remaining = offset
+
         while remaining > 0:
             raw_chunk = await self._binary_file.read(min(self._chunk_size, remaining))
             if not raw_chunk:
@@ -931,10 +949,21 @@ class AsyncGzipTextFile:
         # Track newline types using C-speed string operations
         need = 7 & ~seen  # 7 == _SEEN_CR | _SEEN_LF | _SEEN_CRLF
         if need:
-            scan = text[:-1] if pending_trailing_cr else text
+            # A leading '\n' completing a CRLF split across the chunk boundary
+            # was already recorded above; drop it so the bare-LF scan does not
+            # double-count it. A trailing '\r' is likewise held for the next
+            # chunk rather than scanned here.
+            body = text[1:] if (trailing_cr and text[0] == "\n") else text
+            scan = body[:-1] if pending_trailing_cr else body
 
-            has_crlf = "\r\n" in scan if need & 4 else False
-            if has_crlf:
+            # Whether *this* chunk contains a CRLF pair. Computed unconditionally
+            # (not just when CRLF is still unseen) because the bare-CR / bare-LF
+            # disambiguation below must strip CRLF pairs regardless of which
+            # types earlier chunks already recorded. Skipping it once CRLF was
+            # seen would mis-count the \r and \n of a \r\n pair as a bare CR and
+            # a bare LF.
+            has_crlf = "\r\n" in scan
+            if need & 4 and has_crlf:
                 seen |= self._SEEN_CRLF
 
             if need & 2 and "\n" in scan:

--- a/tests/test_newline_detection.py
+++ b/tests/test_newline_detection.py
@@ -1,0 +1,90 @@
+"""Newline-type tracking (the ``newlines`` property) is chunk-size independent.
+
+Regression tests for a bug where ``_apply_newline_decoding`` mis-counted the
+``\\r`` and ``\\n`` of a ``\\r\\n`` pair as a bare CR and a bare LF once the CRLF
+type had already been recorded — so a pure-CRLF file read across multiple chunks
+wrongly reported ``('\\r', '\\n', '\\r\\n')`` instead of ``'\\r\\n'``. The result
+must match the stdlib ``io.TextIOWrapper`` for every chunk size.
+"""
+
+import gzip
+import io
+
+import pytest
+
+from aiogzip import AsyncGzipTextFile
+
+CHUNK_SIZES = [1, 2, 3, 7, 16, 64, 1 << 20]
+
+
+# Raw decompressed payloads exercising every newline combination, with the
+# patterns repeated enough to span many chunk boundaries at small chunk sizes.
+def _payloads():
+    return {
+        "crlf_only": b"".join(b"item%d\r\n" % i for i in range(60)),
+        "lf_only": b"".join(b"row%d\n" % i for i in range(60)),
+        "cr_only": b"".join(b"row%d\r" % i for i in range(60)),
+        "lf_and_crlf": b"".join(b"a%d\nb%d\r\n" % (i, i) for i in range(60)),
+        "cr_and_crlf": b"".join(b"a%d\rb%d\r\n" % (i, i) for i in range(60)),
+        "all_three": b"".join(b"a%d\nb%d\rc%d\r\n" % (i, i, i) for i in range(60)),
+        # Adjacent terminators stress split handling across boundaries.
+        "adjacent": b"\r\n\n\r\r\n\n\r\n\r" * 30,
+    }
+
+
+def _stdlib_newlines(raw):
+    wrapper = io.TextIOWrapper(io.BytesIO(raw))
+    wrapper.read()
+    return wrapper.newlines
+
+
+def _normalize(newlines):
+    if newlines is None:
+        return frozenset()
+    if isinstance(newlines, str):
+        return frozenset([newlines])
+    return frozenset(newlines)
+
+
+def _write(path, raw):
+    with gzip.open(path, "wb") as f:
+        f.write(raw)
+
+
+@pytest.mark.parametrize("name", list(_payloads()))
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZES)
+@pytest.mark.asyncio
+async def test_newlines_match_stdlib_via_read(temp_file, name, chunk_size):
+    raw = _payloads()[name]
+    _write(temp_file, raw)
+    expected = _normalize(_stdlib_newlines(raw))
+
+    async with AsyncGzipTextFile(temp_file, "rt", chunk_size=chunk_size) as f:
+        await f.read()
+        assert _normalize(f.newlines) == expected
+
+
+@pytest.mark.parametrize("name", list(_payloads()))
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZES)
+@pytest.mark.asyncio
+async def test_newlines_match_stdlib_via_iteration(temp_file, name, chunk_size):
+    raw = _payloads()[name]
+    _write(temp_file, raw)
+    expected = _normalize(_stdlib_newlines(raw))
+
+    async with AsyncGzipTextFile(temp_file, "rt", chunk_size=chunk_size) as f:
+        async for _ in f:
+            pass
+        assert _normalize(f.newlines) == expected
+
+
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZES)
+@pytest.mark.asyncio
+async def test_pure_crlf_never_reports_bare_terminators(temp_file, chunk_size):
+    """The original bug: a pure-CRLF file must report only '\\r\\n'."""
+    raw = b"".join(b"line%d\r\n" % i for i in range(100))
+    _write(temp_file, raw)
+
+    async with AsyncGzipTextFile(temp_file, "rt", chunk_size=chunk_size) as f:
+        await f.read()
+        assert f.newlines == "\r\n"

--- a/tests/test_seek_plain_fast.py
+++ b/tests/test_seek_plain_fast.py
@@ -1,0 +1,184 @@
+"""Forward plain-offset seek fast path in AsyncGzipTextFile.
+
+_seek_to_plain_position replays only the forward delta when the stream is
+already at a plain position at/behind the target, instead of restarting the
+decode from byte 0. These tests assert that the fast path lands at the same
+position and yields the same subsequent read() output and ``newlines`` property
+as a genuine replay-from-zero (the reset fallback), including a CRLF that
+straddles the seek target and multi-byte UTF-8 around the target.
+"""
+
+import gzip
+from unittest.mock import patch
+
+import pytest
+
+from aiogzip import AsyncGzipTextFile
+
+
+def _write_raw(path, raw):
+    """Write exact decompressed bytes so byte offsets are under our control."""
+    with gzip.open(path, "wb") as f:
+        f.write(raw)
+
+
+async def _stepped_forward(path, p1, p2, **kwargs):
+    """Reach a plain position at p1, then forward-seek to p2 (fast path)."""
+    async with AsyncGzipTextFile(path, "rt", **kwargs) as f:
+        await f.seek(p1)
+        # tell() == p1 confirms p1 is a plain position, so the subsequent
+        # forward seek exercises the fast path rather than falling back.
+        staged_plain = (await f.tell()) == p1
+        ret = await f.seek(p2)
+        newlines = f.newlines
+        rest = await f.read()
+        return ret, newlines, rest, staged_plain
+
+
+async def _replay_from_zero(path, p2, **kwargs):
+    """Reference: force the reset path by seeking after draining to EOF."""
+    async with AsyncGzipTextFile(path, "rt", **kwargs) as f:
+        await f.read()  # drain to EOF so _eof is set -> fast path is bypassed
+        ret = await f.seek(p2)
+        newlines = f.newlines
+        rest = await f.read()
+        return ret, newlines, rest
+
+
+async def _assert_matches(path, p1, p2, **kwargs):
+    fast_ret, fast_nl, fast_rest, staged_plain = await _stepped_forward(
+        path, p1, p2, **kwargs
+    )
+    ref_ret, ref_nl, ref_rest = await _replay_from_zero(path, p2, **kwargs)
+
+    assert staged_plain, "p1 was not a plain position; fast path not exercised"
+    assert fast_ret == ref_ret == p2
+    assert fast_rest == ref_rest
+    assert fast_nl == ref_nl
+    return fast_rest, fast_nl
+
+
+def _line_offsets(lines):
+    """Return cumulative byte offsets at the start of each line."""
+    offsets = [0]
+    for line in lines:
+        offsets.append(offsets[-1] + len(line))
+    return offsets
+
+
+@pytest.mark.asyncio
+async def test_forward_plain_seek_lf(temp_file):
+    """Forward seek between LF line boundaries matches replay-from-zero."""
+    lines = [b"row%d\n" % i for i in range(200)]
+    raw = b"".join(lines)
+    _write_raw(temp_file, raw)
+    offsets = _line_offsets(lines)
+
+    p1, p2 = offsets[50], offsets[120]
+    rest, nl = await _assert_matches(temp_file, p1, p2)
+    # Sanity: the tail decodes from p2 onward.
+    assert rest == raw[p2:].decode("utf-8")
+    assert nl == "\n"
+
+
+@pytest.mark.asyncio
+async def test_forward_plain_seek_to_clean_crlf_boundary(temp_file):
+    """Forward seek landing exactly on a CRLF boundary stays plain."""
+    lines = [b"item%d\r\n" % i for i in range(100)]
+    raw = b"".join(lines)
+    _write_raw(temp_file, raw)
+    offsets = _line_offsets(lines)
+
+    p1, p2 = offsets[10], offsets[40]
+    rest, nl = await _assert_matches(temp_file, p1, p2)
+    assert rest == raw[p2:].decode("utf-8").replace("\r\n", "\n")
+    assert nl == "\r\n"
+
+
+@pytest.mark.asyncio
+async def test_forward_plain_seek_straddling_crlf(temp_file):
+    """Forward seek whose target falls between \\r and \\n matches reference."""
+    lines = [b"item%d\r\n" % i for i in range(100)]
+    raw = b"".join(lines)
+    _write_raw(temp_file, raw)
+    offsets = _line_offsets(lines)
+
+    p1 = offsets[10]
+    # The \n of line 39's CRLF: [.., p2) ends with the bare \r.
+    p2 = offsets[40] - 1
+    assert raw[p2 - 1 : p2 + 1] == b"\r\n"
+
+    rest, nl = await _assert_matches(temp_file, p1, p2)
+    # Reading resumes at the pending-\r boundary; the \n completes the CRLF.
+    assert rest == raw[p2 + 1 :].decode("utf-8").replace("\r\n", "\n")
+
+
+@pytest.mark.asyncio
+async def test_forward_plain_seek_around_multibyte_utf8(temp_file):
+    """Forward seek near/inside multi-byte UTF-8 sequences matches reference."""
+    unit = "héllo wörld 日本語\n"
+    raw = (unit * 50).encode("utf-8")
+    _write_raw(temp_file, raw)
+    unit_len = len(unit.encode("utf-8"))
+
+    # Byte offset of "日" within a unit (a 3-byte sequence).
+    ni_byte = len(unit[: unit.index("日")].encode("utf-8"))
+
+    p1 = unit_len * 5  # clean unit boundary
+    # Target inside the 3-byte "日": one byte past its start.
+    p2 = unit_len * 20 + ni_byte + 1
+    await _assert_matches(temp_file, p1, p2, encoding="utf-8")
+
+    # Also target exactly after a multi-byte char (clean boundary).
+    p2_clean = unit_len * 20 + ni_byte + 3
+    await _assert_matches(temp_file, p1, p2_clean, encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_forward_plain_seek_no_translation_newline_mode(temp_file):
+    r"""With newline='' the fast path preserves seen-newline tracking."""
+    lines = [b"a%d\r\nb%d\rc%d\n" % (i, i, i) for i in range(50)]
+    raw = b"".join(lines)
+    _write_raw(temp_file, raw)
+    offsets = _line_offsets(lines)
+
+    p1, p2 = offsets[5], offsets[30]
+    fast = await _stepped_forward(temp_file, p1, p2, newline="")
+    ref = await _replay_from_zero(temp_file, p2, newline="")
+    assert fast[3], "p1 not plain"
+    assert fast[0] == ref[0] == p2
+    assert fast[2] == ref[2]  # rest, untranslated
+    assert fast[1] == ref[1]  # newlines property
+    assert set(fast[1]) == {"\r", "\n", "\r\n"}
+
+
+@pytest.mark.asyncio
+async def test_forward_plain_seek_skips_reset_backward_does_not(temp_file):
+    """The forward fast path avoids _reset_to_start; a backward seek uses it."""
+    lines = [b"row%d\n" % i for i in range(200)]
+    raw = b"".join(lines)
+    _write_raw(temp_file, raw)
+    offsets = _line_offsets(lines)
+    p1, p2 = offsets[50], offsets[120]
+
+    orig_reset = AsyncGzipTextFile._reset_to_start
+    with patch.object(
+        AsyncGzipTextFile, "_reset_to_start", autospec=True
+    ) as mock_reset:
+
+        async def _call_through(self):
+            return await orig_reset(self)
+
+        mock_reset.side_effect = _call_through
+
+        async with AsyncGzipTextFile(temp_file, "rt") as f:
+            await f.seek(p1)
+            assert (await f.tell()) == p1
+            calls_before = mock_reset.call_count
+
+            await f.seek(p2)  # forward from a plain position -> no reset
+            assert mock_reset.call_count == calls_before
+
+            await f.seek(p1)  # backward -> must reset and replay from zero
+            assert mock_reset.call_count == calls_before + 1
+            assert (await f.tell()) == p1


### PR DESCRIPTION
## Summary

A forward plain-offset seek (`AsyncGzipTextFile.seek(offset)`, `offset >= 0`) restarted decoding from byte 0 every time, so repeated forward seeks were O(offset). When the stream is already at a plain position at/behind the target (and not at EOF), this replays only the bytes between the current binary position and the target instead.

The incremental decoder and the newline tracker compose, so feeding the delta `[current, offset)` onto the live state reaches the same decoder/newline state a full replay-from-zero would. Backward targets, buffered (non-plain) state, or EOF fall back to the existing reset-and-replay path.

### Benchmark

19 MB text file, 59 consecutive forward plain seeks (lines 5k…295k), min of 3:

| | time |
|---|---|
| old (replay-from-zero) | 490 ms |
| new (forward delta) | 16 ms |

~31× on this pattern; the win grows with file size since old work is O(offset) per seek.

## Latent newline bug this surfaced (also fixed)

The fast path begins the delta decode with `seen_newline_types` already populated, which exposed a pre-existing, chunk-size-dependent bug in `_apply_newline_decoding`: the `\r` and `\n` of a `\r\n` pair were mis-counted as a bare CR and a bare LF (1) once the CRLF type was already recorded, and (2) when a `\r\n` split across a chunk boundary. A pure-CRLF file read with a small `chunk_size` reported `('\r','\n','\r\n')` instead of `'\r\n'` — reachable from normal `read()`/iteration, not just seeking.

Fix: compute "does this chunk contain `\r\n`" unconditionally and use it for the bare-CR/LF disambiguation, and drop a leading `\n` that completes a split CRLF from the bare-LF scan. `newlines` now matches `io.TextIOWrapper` for every chunk size.

## Test plan

- `tests/test_seek_plain_fast.py`: forward seek from a plain position matches the replay-from-zero path (position, subsequent `read()`, `newlines`), incl. a CRLF straddling the target, multi-byte UTF-8 around the target, and `newline=''` mode; plus a check that the fast path skips `_reset_to_start` while a backward seek still uses it.
- `tests/test_newline_detection.py`: `newlines` matches the stdlib across chunk sizes `{1,2,3,7,16,64,1 MiB}` for every newline mix, via `read()` and iteration.
- Full suite: 580 passed, 7 skipped. `ruff`, `ruff format`, mypy, and the py38-compat hook all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)