### PR TITLE
Add typing overloads to AsyncGzipFile (narrow return by mode)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "mypy>=1.0.0",
     "ty>=0.0.1a16",
     "types-aiofiles",
+    "typing_extensions",
     "pre-commit",
 ]
 [project.urls]

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -1,7 +1,7 @@
 """Async gzip file reader/writer public API."""
 
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Literal, Optional, Union, overload
 
 from ._binary import AsyncGzipBinaryFile
 from ._common import (
@@ -21,9 +21,146 @@ from ._text import AsyncGzipTextFile
 
 __version__ = "1.7.0"
 
+# Mode strings that select a text stream (they contain a 't'). The factory
+# parses modes character-by-character and is permutation-tolerant, so these
+# enumerate the conventional spellings (mirroring typeshed's open/gzip.open
+# overloads); unusual permutations fall through to the str fallback overload.
+_TextMode = Literal[
+    "rt",
+    "wt",
+    "at",
+    "xt",
+    "tr",
+    "tw",
+    "ta",
+    "tx",
+    "rt+",
+    "wt+",
+    "at+",
+    "xt+",
+    "tr+",
+    "tw+",
+    "ta+",
+    "tx+",
+    "r+t",
+    "w+t",
+    "a+t",
+    "x+t",
+    "t+r",
+    "t+w",
+    "t+a",
+    "t+x",
+    "+rt",
+    "+wt",
+    "+at",
+    "+xt",
+    "+tr",
+    "+tw",
+    "+ta",
+    "+tx",
+]
+
+# Mode strings that select a binary stream (no 't'); the 'b' is optional.
+_BinaryMode = Literal[
+    "r",
+    "w",
+    "a",
+    "x",
+    "rb",
+    "wb",
+    "ab",
+    "xb",
+    "br",
+    "bw",
+    "ba",
+    "bx",
+    "r+",
+    "w+",
+    "a+",
+    "x+",
+    "+r",
+    "+w",
+    "+a",
+    "+x",
+    "rb+",
+    "wb+",
+    "ab+",
+    "xb+",
+    "br+",
+    "bw+",
+    "ba+",
+    "bx+",
+    "r+b",
+    "w+b",
+    "a+b",
+    "x+b",
+    "b+r",
+    "b+w",
+    "b+a",
+    "b+x",
+    "+rb",
+    "+wb",
+    "+ab",
+    "+xb",
+    "+br",
+    "+bw",
+    "+ba",
+    "+bx",
+]
+
+_Filename = Union[str, bytes, Path, None]
+_FileObj = Optional[Union[WithAsyncRead, WithAsyncWrite, WithAsyncReadWrite]]
+
+
+@overload
+def AsyncGzipFile(
+    filename: _Filename,
+    mode: _TextMode,
+    *,
+    chunk_size: int = ...,
+    encoding: Optional[str] = ...,
+    errors: Optional[str] = ...,
+    newline: Optional[str] = ...,
+    compresslevel: int = ...,
+    mtime: Optional[Union[int, float]] = ...,
+    original_filename: Optional[Union[str, bytes]] = ...,
+    fileobj: _FileObj = ...,
+    closefd: Optional[bool] = ...,
+    max_decompressed_size: Optional[int] = ...,
+    max_rewind_cache_size: Optional[int] = ...,
+    strict_size: bool = ...,
+    fast_compress: bool = ...,
+) -> AsyncGzipTextFile: ...
+
+
+@overload
+def AsyncGzipFile(
+    filename: _Filename,
+    mode: _BinaryMode = ...,
+    *,
+    chunk_size: int = ...,
+    compresslevel: int = ...,
+    mtime: Optional[Union[int, float]] = ...,
+    original_filename: Optional[Union[str, bytes]] = ...,
+    fileobj: _FileObj = ...,
+    closefd: Optional[bool] = ...,
+    max_decompressed_size: Optional[int] = ...,
+    max_rewind_cache_size: Optional[int] = ...,
+    strict_size: bool = ...,
+    fast_compress: bool = ...,
+) -> AsyncGzipBinaryFile: ...
+
+
+@overload
+def AsyncGzipFile(
+    filename: _Filename,
+    mode: str,
+    **kwargs: Any,
+) -> Union[AsyncGzipBinaryFile, AsyncGzipTextFile]: ...
+
 
 def AsyncGzipFile(
-    filename: Union[str, bytes, Path, None], mode: str = "rb", **kwargs: Any
+    filename: _Filename, mode: str = "rb", **kwargs: Any
 ) -> Union[AsyncGzipBinaryFile, AsyncGzipTextFile]:
     """
     Factory function that returns the appropriate AsyncGzip class based on mode.

--- a/tests/test_factory_typing.py
+++ b/tests/test_factory_typing.py
@@ -1,0 +1,37 @@
+"""Static-typing test: the AsyncGzipFile factory narrows its return by mode.
+
+Runs ``mypy --strict`` over ``tests/typing/check_factory_overloads.py``, whose
+``assert_type`` calls fail the type check unless the overloads resolve a text
+mode to ``AsyncGzipTextFile`` (``read() -> str``) and a binary mode to
+``AsyncGzipBinaryFile`` (``read() -> bytes``).
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CHECK_FILE = Path(__file__).parent / "typing" / "check_factory_overloads.py"
+
+
+def _mypy_available() -> bool:
+    try:
+        import mypy  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not _mypy_available(), reason="mypy is not installed")
+def test_factory_overloads_typecheck():
+    result = subprocess.run(
+        [sys.executable, "-m", "mypy", "--strict", str(CHECK_FILE)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "mypy --strict reported errors on the factory-overload assertions:\n"
+        + result.stdout
+        + result.stderr
+    )

--- a/tests/typing/check_factory_overloads.py
+++ b/tests/typing/check_factory_overloads.py
@@ -1,0 +1,60 @@
+"""Static-typing assertions for the ``AsyncGzipFile`` factory overloads.
+
+This module is not run as a test (``assert_type`` is a no-op at runtime); it is
+type-checked with ``mypy --strict`` by ``tests/test_factory_typing.py``. Each
+``assert_type`` fails the type check if the factory does not narrow its return
+type by mode.
+"""
+
+from pathlib import Path
+from typing import Union
+
+from typing_extensions import assert_type
+
+from aiogzip import AsyncGzipBinaryFile, AsyncGzipFile, AsyncGzipTextFile
+
+p = Path("data.gz")
+
+# --- Text modes narrow to AsyncGzipTextFile ---------------------------------
+assert_type(AsyncGzipFile(p, "rt"), AsyncGzipTextFile)
+assert_type(AsyncGzipFile(p, "wt"), AsyncGzipTextFile)
+assert_type(AsyncGzipFile(p, "at"), AsyncGzipTextFile)
+assert_type(AsyncGzipFile(p, "xt"), AsyncGzipTextFile)
+assert_type(AsyncGzipFile(p, "tr"), AsyncGzipTextFile)
+assert_type(AsyncGzipFile(p, "rt+"), AsyncGzipTextFile)
+assert_type(AsyncGzipFile(p, "r+t"), AsyncGzipTextFile)
+# Text-only keyword arguments autocomplete and type-check.
+assert_type(
+    AsyncGzipFile(p, "wt", encoding="utf-8", errors="strict", newline="\n"),
+    AsyncGzipTextFile,
+)
+
+# --- Binary modes narrow to AsyncGzipBinaryFile -----------------------------
+assert_type(AsyncGzipFile(p), AsyncGzipBinaryFile)  # default mode "rb"
+assert_type(AsyncGzipFile(p, "rb"), AsyncGzipBinaryFile)
+assert_type(AsyncGzipFile(p, "wb"), AsyncGzipBinaryFile)
+assert_type(AsyncGzipFile(p, "ab"), AsyncGzipBinaryFile)
+assert_type(AsyncGzipFile(p, "xb"), AsyncGzipBinaryFile)
+assert_type(AsyncGzipFile(p, "r"), AsyncGzipBinaryFile)
+assert_type(AsyncGzipFile(p, "w"), AsyncGzipBinaryFile)
+assert_type(AsyncGzipFile(p, "a"), AsyncGzipBinaryFile)
+assert_type(AsyncGzipFile(p, "x"), AsyncGzipBinaryFile)
+assert_type(AsyncGzipFile(p, "rb+"), AsyncGzipBinaryFile)
+
+
+# --- read() return types follow the mode ------------------------------------
+async def _check_reads() -> None:
+    async with AsyncGzipFile(p, "rt") as text_file:
+        assert_type(text_file, AsyncGzipTextFile)
+        assert_type(await text_file.read(), str)
+    async with AsyncGzipFile(p, "rb") as binary_file:
+        assert_type(binary_file, AsyncGzipBinaryFile)
+        assert_type(await binary_file.read(), bytes)
+
+
+# --- A non-literal (dynamic) mode falls back to the union -------------------
+def _dynamic(mode: str) -> None:
+    assert_type(
+        AsyncGzipFile(p, mode),
+        Union[AsyncGzipBinaryFile, AsyncGzipTextFile],
+    )


### PR DESCRIPTION
## Summary

`AsyncGzipFile(...)` returned `Union[AsyncGzipBinaryFile, AsyncGzipTextFile]`, so callers had to cast/assert to get a mode-specific type (and `read()` returned `str | bytes`). This adds `typing.overload` definitions — mirroring typeshed's `open`/`gzip.open` — keyed on `Literal` mode strings:

- **Text modes** (contain `t`: `"rt"/"wt"/"at"/"xt"`, reversed `"tr"…`, and `+` spellings) → `AsyncGzipTextFile`, with explicit **keyword-only** `encoding`/`errors`/`newline` (and the other constructor params) so IDEs autocomplete them.
- **Binary modes** (no `t`: `"rb"/"wb"/"ab"/"xb"`, bare `"r"/"w"/"a"/"x"`, and `+` spellings) → `AsyncGzipBinaryFile`.
- **`str` fallback** → the original `Union`, for dynamically-typed modes.

The factory parses modes character-by-character (permutation-tolerant), so the overloads enumerate the conventional spellings and unusual permutations fall through to the `str` overload. The keyword-only marker matches the runtime, which forwards extra args via `**kwargs` (passable only by keyword). `Literal` is imported from `typing` (3.8+); no PEP 604/585 syntax, so the 3.8 floor holds. **The runtime implementation is unchanged.**

## Test plan

- `tests/typing/check_factory_overloads.py` asserts the narrowing with `typing_extensions.assert_type` (text → `AsyncGzipTextFile`/`read()->str`, binary → `AsyncGzipBinaryFile`/`read()->bytes`, default mode → binary, dynamic `str` → union).
- `tests/test_factory_typing.py` runs `mypy --strict` over it (skips if mypy is absent). Confirmed a deliberately-wrong `assert_type` fails the check, so the test has teeth.
- `mypy src` and `ty check src` both accept the overloads (no overlap warnings); `ruff check .`/`ruff format --check .` and the py38-compat hook pass. Full suite: 726 passed, 7 skipped.
- Adds `typing_extensions` to the `dev` extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)