### PR TITLE
Add public open() lifecycle method and __repr__ to file classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,27 @@ async with AsyncGzipFile(
     await f.write(b"stable bytes")
 ```
 
+> **Default compression level.** As a drop-in replacement, `aiogzip` matches
+> `gzip.open()`'s API but **defaults to `compresslevel=6`** (the zlib default — a
+> better speed/ratio tradeoff), whereas `gzip.open()` defaults to `9`. Pass
+> `compresslevel=9` for byte-size parity with stdlib defaults:
+>
+> ```python
+> async with AsyncGzipFile("file.gz", "wb", compresslevel=9) as f:
+>     await f.write(b"...")  # same compression level as gzip.open() defaults
+> ```
+
+If you cannot use `async with`, open and close explicitly with try/finally:
+
+```python
+f = AsyncGzipFile("file.gz", "rb")
+await f.open()
+try:
+    data = await f.read()
+finally:
+    await f.close()
+```
+
 ## Performance
 
 - **Text I/O**: Often ~2-3x faster than standard `gzip` in bulk text workflows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,28 @@ async def main():
 asyncio.run(main())
 ```
 
+### Manual lifecycle (`open()` / `close()`)
+
+`async with` is the recommended way to use a file, but when a `with` block is
+impractical you can manage the lifecycle imperatively with `open()` and
+`close()`. Always pair them with `try`/`finally` so the file is closed even if
+an error occurs:
+
+```python
+f = AsyncGzipFile("file.txt.gz", "rt")
+await f.open()        # initializes the stream and returns the file; __aenter__ calls this
+try:
+    async for line in f:
+        print(line.strip())
+finally:
+    await f.close()
+```
+
+`open()` returns the file object. Calling it on an already-open file raises
+`ValueError`, and a closed instance cannot be reopened (it raises `ValueError`,
+matching standard `io` objects) — create a new instance instead. Operations
+before `open()` raise `ValueError("File not opened.")`.
+
 ## Compatibility
 
 `aiogzip` provides comprehensive compatibility with the standard `gzip` module's `GzipFile` API, including:
@@ -84,6 +106,16 @@ asyncio.run(main())
 - ✅ Text and binary mode operations with proper encoding/decoding
 - ✅ Full compatibility with `tarfile` for reading `.tar.gz` archives
 - ✅ Seamless integration with `aiocsv` for CSV processing
+
+> **Default compression level.** `aiogzip` defaults to `compresslevel=6` (the
+> zlib default — a better speed/ratio tradeoff), whereas `gzip.open()` defaults
+> to `9`. The two therefore produce different `.gz` sizes by default. For
+> byte-size parity with stdlib defaults, pass `compresslevel=9`:
+>
+> ```python
+> async with AsyncGzipFile("file.gz", "wb", compresslevel=9) as f:
+>     await f.write(b"...")
+> ```
 
 For `AsyncGzipTextFile`, `tell()` returns an opaque cookie value (a negative integer encoding the decoder state) for the current open stream. Use it only with `seek(cookie)` on the **same open handle**.
 

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -73,6 +73,14 @@ class AsyncGzipBinaryFile:
         async with AsyncGzipBinaryFile("data.gz", "rb") as f:
             data = await f.read()  # Returns bytes
 
+        # Imperative lifecycle when `async with` is impractical
+        f = AsyncGzipBinaryFile("data.gz", "rb")
+        await f.open()
+        try:
+            data = await f.read()
+        finally:
+            await f.close()
+
     Interoperability with gzip.open():
         # Files created by AsyncGzipBinaryFile can be read by gzip.open()
         async with AsyncGzipBinaryFile("data.gz", "wb") as f:
@@ -219,8 +227,28 @@ class AsyncGzipBinaryFile:
         self._decompressed_total: int = 0
         self._strict_size: bool = bool(strict_size)
 
-    async def __aenter__(self) -> "AsyncGzipBinaryFile":
-        """Enter the async context manager and initialize resources."""
+    async def open(self) -> "AsyncGzipBinaryFile":
+        """Open the file for I/O and return ``self``.
+
+        This performs the same initialization as entering the async context
+        manager, for callers who prefer an explicit try/finally over ``async
+        with``::
+
+            f = AsyncGzipBinaryFile("data.gz", "rb")
+            await f.open()
+            try:
+                data = await f.read()
+            finally:
+                await f.close()
+
+        Raises:
+            ValueError: if the file is already open, or has already been closed
+                (a closed instance cannot be reopened, matching io objects).
+        """
+        if self._is_closed:
+            raise ValueError("Cannot reopen a closed file")
+        if self._file is not None:
+            raise ValueError("File is already open")
         try:
             if self._external_file is not None:
                 self._file = cast(Any, self._external_file)
@@ -267,6 +295,10 @@ class AsyncGzipBinaryFile:
             await self._cleanup_failed_enter()
             raise
 
+    async def __aenter__(self) -> "AsyncGzipBinaryFile":
+        """Enter the async context manager and initialize resources."""
+        return await self.open()
+
     async def __aexit__(
         self,
         exc_type: Optional[type],
@@ -275,6 +307,12 @@ class AsyncGzipBinaryFile:
     ) -> None:
         """Exit the context manager, flushing and closing the file."""
         await self.close()
+
+    def __repr__(self) -> str:
+        return (
+            f"<aiogzip.AsyncGzipBinaryFile name={self.name!r} "
+            f"mode={self._mode!r} closed={self.closed}>"
+        )
 
     # File API compatibility helpers
     async def tell(self) -> int:

--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -60,6 +60,14 @@ class AsyncGzipTextFile:
         async with AsyncGzipTextFile("data.gz", "rt") as f:
             async for line in f:
                 print(line.strip())
+
+        # Imperative lifecycle when `async with` is impractical
+        f = AsyncGzipTextFile("data.gz", "rt")
+        await f.open()
+        try:
+            text = await f.read()
+        finally:
+            await f.close()
     """
 
     __slots__ = (
@@ -232,8 +240,28 @@ class AsyncGzipTextFile:
         self._pending_lines: List[str] = []
         self._pending_idx: int = 0
 
-    async def __aenter__(self) -> "AsyncGzipTextFile":
-        """Enter the async context manager and initialize resources."""
+    async def open(self) -> "AsyncGzipTextFile":
+        """Open the file for I/O and return ``self``.
+
+        This performs the same initialization as entering the async context
+        manager, for callers who prefer an explicit try/finally over ``async
+        with``::
+
+            f = AsyncGzipTextFile("data.txt.gz", "rt")
+            await f.open()
+            try:
+                text = await f.read()
+            finally:
+                await f.close()
+
+        Raises:
+            ValueError: if the file is already open, or has already been closed
+                (a closed instance cannot be reopened, matching io objects).
+        """
+        if self._is_closed:
+            raise ValueError("Cannot reopen a closed file")
+        if self._binary_file is not None:
+            raise ValueError("File is already open")
         filename = os.fspath(self._filename) if self._filename is not None else None
         self._binary_file = AsyncGzipBinaryFile(
             filename=filename,
@@ -250,7 +278,7 @@ class AsyncGzipTextFile:
             fast_compress=self._fast_compress,
         )
         try:
-            await self._binary_file.__aenter__()
+            await self._binary_file.open()
         except Exception:
             try:
                 await self._binary_file.close()
@@ -260,6 +288,10 @@ class AsyncGzipTextFile:
             raise
         return self
 
+    async def __aenter__(self) -> "AsyncGzipTextFile":
+        """Enter the async context manager and initialize resources."""
+        return await self.open()
+
     async def __aexit__(
         self,
         exc_type: Optional[type],
@@ -268,6 +300,12 @@ class AsyncGzipTextFile:
     ) -> None:
         """Exit the context manager, flushing and closing the file."""
         await self.close()
+
+    def __repr__(self) -> str:
+        return (
+            f"<aiogzip.AsyncGzipTextFile name={self.name!r} "
+            f"mode={self._mode!r} closed={self.closed}>"
+        )
 
     # File API compatibility helpers
     async def tell(self) -> int:

--- a/tests/test_edge_cases_and_errors.py
+++ b/tests/test_edge_cases_and_errors.py
@@ -285,7 +285,7 @@ class TestEdgeCasesAndErrors:
                 self.close_called = False
                 self.__class__.last_instance = self
 
-            async def __aenter__(self):
+            async def open(self):
                 raise OSError("binary setup failed")
 
             async def close(self):

--- a/tests/test_file_lifecycle.py
+++ b/tests/test_file_lifecycle.py
@@ -267,3 +267,161 @@ class TestResourceCleanup:
         async with f:
             assert await f.read(1) == "a"
         assert f._is_closed is True
+
+
+class TestOpenCloseLifecycle:
+    """Explicit open()/close() lifecycle (the imperative try/finally pattern)."""
+
+    @staticmethod
+    def _write(path, text=b"hello\nworld\n"):
+        import gzip
+
+        with gzip.open(path, "wb") as f:
+            f.write(text)
+
+    @pytest.mark.asyncio
+    async def test_binary_open_read_close(self, tmp_path):
+        p = tmp_path / "binary.gz"
+        self._write(p)
+        f = AsyncGzipBinaryFile(p, "rb")
+        assert f.closed is False
+        ret = await f.open()
+        assert ret is f  # open() returns self
+        try:
+            assert await f.read() == b"hello\nworld\n"
+        finally:
+            await f.close()
+        assert f.closed is True
+
+    @pytest.mark.asyncio
+    async def test_text_open_read_close(self, tmp_path):
+        p = tmp_path / "text.gz"
+        self._write(p)
+        f = AsyncGzipTextFile(p, "rt")
+        ret = await f.open()
+        assert ret is f
+        try:
+            assert await f.read() == "hello\nworld\n"
+        finally:
+            await f.close()
+        assert f.closed is True
+
+    @pytest.mark.asyncio
+    async def test_binary_open_write_round_trip(self, tmp_path):
+        p = tmp_path / "write.gz"
+        f = AsyncGzipBinaryFile(p, "wb")
+        await f.open()
+        try:
+            await f.write(b"payload data")
+        finally:
+            await f.close()
+
+        async with AsyncGzipBinaryFile(p, "rb") as r:
+            assert await r.read() == b"payload data"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cls", [AsyncGzipBinaryFile, AsyncGzipTextFile])
+    async def test_open_twice_raises(self, tmp_path, cls):
+        p = tmp_path / "twice.gz"
+        self._write(p)
+        mode = "rb" if cls is AsyncGzipBinaryFile else "rt"
+        f = cls(p, mode)
+        await f.open()
+        try:
+            with pytest.raises(ValueError, match="already open"):
+                await f.open()
+        finally:
+            await f.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cls", [AsyncGzipBinaryFile, AsyncGzipTextFile])
+    async def test_reopen_after_close_raises(self, tmp_path, cls):
+        p = tmp_path / "reopen.gz"
+        self._write(p)
+        mode = "rb" if cls is AsyncGzipBinaryFile else "rt"
+        f = cls(p, mode)
+        await f.open()
+        await f.close()
+        with pytest.raises(ValueError, match="closed"):
+            await f.open()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cls", [AsyncGzipBinaryFile, AsyncGzipTextFile])
+    async def test_operations_before_open_raise(self, tmp_path, cls):
+        p = tmp_path / "before.gz"
+        self._write(p)
+        mode = "rb" if cls is AsyncGzipBinaryFile else "rt"
+        f = cls(p, mode)
+        with pytest.raises(ValueError, match="File not opened"):
+            await f.read()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cls", [AsyncGzipBinaryFile, AsyncGzipTextFile])
+    async def test_aenter_matches_open(self, tmp_path, cls):
+        """__aenter__ is just open(): same result and same returned object."""
+        p = tmp_path / "aenter.gz"
+        self._write(p)
+        mode = "rb" if cls is AsyncGzipBinaryFile else "rt"
+        expected = b"hello\nworld\n" if cls is AsyncGzipBinaryFile else "hello\nworld\n"
+
+        async with cls(p, mode) as f:
+            assert f.closed is False
+            assert await f.read() == expected
+        assert f.closed is True
+
+
+class TestRepr:
+    """__repr__ shows name, mode, and closed state for both open and closed."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "cls,mode,classname",
+        [
+            (AsyncGzipBinaryFile, "rb", "AsyncGzipBinaryFile"),
+            (AsyncGzipTextFile, "rt", "AsyncGzipTextFile"),
+        ],
+    )
+    async def test_repr_open_and_closed(self, tmp_path, cls, mode, classname):
+        import gzip
+
+        p = tmp_path / "repr.gz"
+        with gzip.open(p, "wb") as fh:
+            fh.write(b"data")
+
+        name = str(p)
+        f = cls(name, mode)
+        await f.open()
+        assert repr(f) == (
+            f"<aiogzip.{classname} name={name!r} mode={mode!r} closed=False>"
+        )
+        await f.close()
+        assert repr(f) == (
+            f"<aiogzip.{classname} name={name!r} mode={mode!r} closed=True>"
+        )
+
+    @pytest.mark.asyncio
+    async def test_repr_fileobj_name_fallback(self, tmp_path):
+        """With filename=None, repr falls back to the fileobj's .name."""
+        import gzip
+        import io
+
+        raw = gzip.compress(b"xyz")
+
+        class NamedReader:
+            name = "in-memory.gz"
+
+            def __init__(self):
+                self._buf = io.BytesIO(raw)
+
+            async def read(self, size=-1):
+                return self._buf.read(size)
+
+            async def close(self):
+                pass
+
+        f = AsyncGzipBinaryFile(None, "rb", fileobj=NamedReader(), closefd=False)
+        await f.open()
+        try:
+            assert "name='in-memory.gz'" in repr(f)
+        finally:
+            await f.close()


### PR DESCRIPTION
## Summary

### `open()` / `close()` lifecycle
- `AsyncGzipBinaryFile.open()` and `AsyncGzipTextFile.open()` perform the initialization previously inlined in `__aenter__` and return `self`, so callers can manage the lifecycle imperatively with `try`/`finally` instead of `async with`.
- `__aenter__` is now just `return await self.open()` — one initialization path.
- `open()` raises `ValueError("File is already open")` on an already-open file, and `ValueError` on a closed instance (a closed file **cannot be reopened**, matching `io` objects — create a new instance instead). Operations before `open()` still raise the existing `"File not opened"` error.

### `__repr__`
Both classes render as `<aiogzip.AsyncGzipTextFile name='data.gz' mode='rt' closed=False>`, falling back to the `.name` property so the `fileobj` (filename=None) case shows the underlying stream's name.

### Docs
- The imperative `try`/`finally` pattern is documented in `docs/index.md` and both class docstrings.
- A note in `README.md` and `docs/index.md` (drop-in section) explains that aiogzip defaults to `compresslevel=6` (zlib default — better speed/ratio tradeoff) while `gzip.open()` defaults to `9`, with a `compresslevel=9` example for byte-size parity.

## Test plan
- `tests/test_file_lifecycle.py`: open/read/close round-trips (binary + text, incl. write mode); open-twice raises; reopen-after-close raises; operations-before-open raise; `__aenter__` matches `open()`; `__repr__` for open/closed states and the fileobj name fallback.
- Updated the existing text-enter-failure test (its mock binary now fails in `open()`, which `__aenter__` delegates to).
- Full suite: 741 passed, 7 skipped. `ruff`, `mypy src`, `ty check src`, and the py38-compat hook all pass. Runtime behavior of `__aenter__`/`close()` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)