### PR TITLE
Fix pre-release review findings ahead of v1.8.0

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -25,38 +25,8 @@ Implementation internals live in `aiogzip._common`, `aiogzip._binary`, and `aiog
 
 ### Resumable processing recipe
 
-Because cookies are not portable, checkpoint progress as a *plain* offset taken at a line boundary, where the decoder is guaranteed clean (`\n` is single-byte, so it never splits a multibyte character). Drive the binary layer — which splits lines without the text layer's read-ahead — so `await f.tell()` is an exact decompressed byte offset, then resume in a new process by opening in `"rt"` and seeking to that offset:
+Because cookies are not portable, checkpoint progress as a *plain* offset taken at a line boundary, where the decoder is guaranteed clean (`\n` is single-byte, so it never splits a multibyte character). Drive the binary layer — which splits lines without the text layer's read-ahead — so `await f.tell()` is an exact decompressed byte offset, then resume in a new process by opening in `"rt"` and seeking to that offset.
 
-```python
-import asyncio
-import gzip
-from aiogzip import AsyncGzipBinaryFile, AsyncGzipTextFile
-
-async def main():
-    path = "events.jsonl.gz"
-    with gzip.open(path, "wt", encoding="utf-8") as fh:
-        for i in range(1000):
-            fh.write(f'{{"id": {i}}}\n')
-
-    # Pass 1: process via the binary layer; checkpoint a plain offset per line.
-    saved_offset = 0
-    async with AsyncGzipBinaryFile(path, "rb") as f:
-        async for raw_line in f:
-            line = raw_line.decode("utf-8")
-            ...                                   # do your work
-            saved_offset = await f.tell()         # plain decompressed byte offset
-            if line.startswith('{"id": 499}'):
-                break                             # simulate interruption
-
-    # Pass 2: a fresh handle resumes by seeking to the saved plain offset.
-    async with AsyncGzipTextFile(path, "rt", encoding="utf-8") as f:
-        await f.seek(saved_offset)                # non-negative plain offset, not a cookie
-        async for line in f:
-            ...                                   # continues at id 500
-
-asyncio.run(main())
-```
-
-A forward plain `seek()` is **O(n)** in the target offset: gzip has no random access, so `aiogzip` restarts decompression from the start and replays bytes up to the offset. Checkpoint at a coarse granularity if that cost matters. See [Resumable text processing](index.md#resumable-text-processing) for more detail.
+A forward plain `seek()` is **O(n)** in the target offset: gzip has no random access, so `aiogzip` replays decompressed bytes up to the offset. Checkpoint at a coarse granularity if that cost matters. See [Resumable text processing](index.md#resumable-text-processing) for the full worked example.
 
 ::: aiogzip

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -449,6 +449,8 @@ class AsyncGzipBinaryFile:
         """Return up to size bytes without advancing the read position."""
         if self._mode_op != "r":
             raise OSError("File not open for reading")
+        if self._is_closed:
+            raise ValueError("I/O operation on closed file.")
         if self._file is None:
             raise ValueError("File not opened. Use async context manager.")
         if size is not None and size > _MAX_CHUNK_SIZE:
@@ -510,47 +512,36 @@ class AsyncGzipBinaryFile:
         view = memoryview(b)
         if view.readonly:
             raise TypeError("readinto() argument must be writable")
+        # Accept any writable buffer (e.g. array.array with itemsize > 1) by
+        # viewing it as bytes, like the stdlib io machinery does.
+        view = view.cast("B")
 
         total = len(view)
         if total == 0:
             return 0
 
-        # Fast path: the current buffer already satisfies the whole request, so
-        # fill the view with a single copy and no per-span loop overhead (this
-        # is the common case while a chunk's worth of decoded data lasts).
-        buf = self._buffer
-        offset = self._buffer_offset
-        if len(buf) - offset >= total:
-            end = offset + total
-            view[:] = memoryview(buf)[offset:end]
-            self._position += total
-            if end >= len(buf):
-                del buf[:]
-                self._buffer_offset = 0
-            else:
-                self._buffer_offset = end
-            return total
-
-        # Slow path: span the request across refills.
-        written = 0
+        # Fill the internal buffer until it can satisfy the whole request (or
+        # EOF), compacting a large consumed prefix first exactly as read()
+        # does, then copy once. Filling before consuming preserves read()'s
+        # error semantics: if a refill raises mid-request, the stream position
+        # and already-buffered data are left intact for the caller to salvage.
         threshold = self.BUFFER_COMPACTION_THRESHOLD
-        while written < total:
-            n = self._copy_into_view(view, written)
-            if n:
-                written += n
-                continue
-            # Buffer is drained; stop at EOF, otherwise refill (compacting a
-            # large consumed prefix first, exactly as read() does).
-            if self._eof:
-                break
+        available = len(self._buffer) - self._buffer_offset
+        while available < total and not self._eof:
             if self._buffer_offset > threshold:
                 del self._buffer[: self._buffer_offset]
                 self._buffer_offset = 0
             await self._fill_buffer()
-        return written
+            available = len(self._buffer) - self._buffer_offset
+        return self._copy_into_view(view, 0)
 
     async def read1(self, size: int = -1) -> bytes:
-        """Read up to size bytes from the buffer without looping."""
+        """Read up to size bytes with at most one data-producing fill.
+
+        A single compressed chunk can decode to nothing (e.g. while consuming
+        the gzip header), so fills repeat until at least one byte is available;
+        like stdlib gzip's ``read1()``, an empty result means EOF.
+        """
         if self._mode_op != "r":
             raise OSError("File not open for reading")
         if self._is_closed:
@@ -564,7 +555,7 @@ class AsyncGzipBinaryFile:
             return b""
 
         available = len(self._buffer) - self._buffer_offset
-        if available <= 0 and not self._eof:
+        while available <= 0 and not self._eof:
             await self._fill_buffer()
             available = len(self._buffer) - self._buffer_offset
 
@@ -588,11 +579,14 @@ class AsyncGzipBinaryFile:
         return data_to_return
 
     async def readinto1(self, b: Union[bytearray, memoryview]) -> int:
-        """Read directly into the buffer with at most one underlying fill.
+        """Read directly into the buffer with at most one data-producing fill.
 
         Like ``read1()`` but writes straight into the caller's buffer, avoiding
-        the intermediate ``bytes`` object. Returns the number of bytes written
-        (0 at EOF).
+        the intermediate ``bytes`` object. A single compressed chunk can decode
+        to nothing (e.g. while consuming the gzip header), so fills repeat
+        until at least one byte is available; the result is still capped at one
+        buffer's worth of decoded data. Returns the number of bytes written
+        (0 only at EOF), so ``while await f.readinto1(buf): ...`` is safe.
         """
         if self._mode_op != "r":
             raise OSError("File not open for reading")
@@ -602,15 +596,17 @@ class AsyncGzipBinaryFile:
             raise ValueError("File not opened. Use async context manager.")
         view = memoryview(b)
         if view.readonly:
-            raise TypeError("readinto() argument must be writable")
+            raise TypeError("readinto1() argument must be writable")
+        view = view.cast("B")
 
         total = len(view)
         if total == 0:
             return 0
 
         available = len(self._buffer) - self._buffer_offset
-        if available <= 0 and not self._eof:
+        while available <= 0 and not self._eof:
             await self._fill_buffer()
+            available = len(self._buffer) - self._buffer_offset
         return self._copy_into_view(view, 0)
 
     async def readline(self, limit: int = -1) -> bytes:
@@ -1158,18 +1154,22 @@ class AsyncGzipBinaryFile:
         up with _file cleared — otherwise the next caller can reach a
         handle we no longer own.
         """
-        if self._file is None or not self._owns_file:
+        file = self._file
+        owns_file = self._owns_file
+        # Clear the handle up front (even for external fileobjs we must not
+        # close) so a failed open() never leaves the instance looking open —
+        # otherwise a retry would hit the "File is already open" guard and
+        # write() could emit compressed data for a stream with no header.
+        self._file = None
+        self._owns_file = False
+        if file is None or not owns_file:
             return
 
-        close_method = getattr(self._file, "close", None)
-        try:
-            if callable(close_method):
-                result = close_method()
-                if hasattr(result, "__await__"):
-                    await result
-        finally:
-            self._file = None
-            self._owns_file = False
+        close_method = getattr(file, "close", None)
+        if callable(close_method):
+            result = close_method()
+            if hasattr(result, "__await__"):
+                await result
 
     async def flush(self) -> None:
         """

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -20,7 +20,9 @@ from ._common import (
     ZlibEngine,
     _build_gzip_header,
     _build_gzip_trailer,
+    _check_can_open,
     _derive_header_filename,
+    _format_file_repr,
     _normalize_mtime,
     _parse_mode_tokens,
     _try_parse_gzip_header_mtime,
@@ -245,10 +247,7 @@ class AsyncGzipBinaryFile:
             ValueError: if the file is already open, or has already been closed
                 (a closed instance cannot be reopened, matching io objects).
         """
-        if self._is_closed:
-            raise ValueError("Cannot reopen a closed file")
-        if self._file is not None:
-            raise ValueError("File is already open")
+        _check_can_open(self._is_closed, self._file is not None)
         try:
             if self._external_file is not None:
                 self._file = cast(Any, self._external_file)
@@ -309,10 +308,7 @@ class AsyncGzipBinaryFile:
         await self.close()
 
     def __repr__(self) -> str:
-        return (
-            f"<aiogzip.AsyncGzipBinaryFile name={self.name!r} "
-            f"mode={self._mode!r} closed={self.closed}>"
-        )
+        return _format_file_repr(self)
 
     # File API compatibility helpers
     async def tell(self) -> int:
@@ -496,6 +492,24 @@ class AsyncGzipBinaryFile:
             self._buffer_offset = new_offset
         return n
 
+    async def _fill_until(self, size: int) -> int:
+        """Refill until ``size`` unread bytes are buffered (or EOF).
+
+        Compacts a large consumed prefix before each refill so a long run of
+        partial reads cannot grow the buffer unbounded. Shared by the sized
+        ``read()`` path and ``readinto()``. Returns the unread byte count,
+        which may be short of ``size`` only at EOF.
+        """
+        available = len(self._buffer) - self._buffer_offset
+        threshold = self.BUFFER_COMPACTION_THRESHOLD
+        while available < size and not self._eof:
+            if self._buffer_offset > threshold:
+                del self._buffer[: self._buffer_offset]
+                self._buffer_offset = 0
+            await self._fill_buffer()
+            available = len(self._buffer) - self._buffer_offset
+        return available
+
     async def readinto(self, b: Union[bytearray, memoryview]) -> int:
         """Read bytes directly into a pre-allocated, writable buffer.
 
@@ -521,18 +535,10 @@ class AsyncGzipBinaryFile:
             return 0
 
         # Fill the internal buffer until it can satisfy the whole request (or
-        # EOF), compacting a large consumed prefix first exactly as read()
-        # does, then copy once. Filling before consuming preserves read()'s
+        # EOF), then copy once. Filling before consuming preserves read()'s
         # error semantics: if a refill raises mid-request, the stream position
         # and already-buffered data are left intact for the caller to salvage.
-        threshold = self.BUFFER_COMPACTION_THRESHOLD
-        available = len(self._buffer) - self._buffer_offset
-        while available < total and not self._eof:
-            if self._buffer_offset > threshold:
-                del self._buffer[: self._buffer_offset]
-                self._buffer_offset = 0
-            await self._fill_buffer()
-            available = len(self._buffer) - self._buffer_offset
+        await self._fill_until(total)
         return self._copy_into_view(view, 0)
 
     async def read1(self, size: int = -1) -> bytes:
@@ -905,13 +911,7 @@ class AsyncGzipBinaryFile:
                 return data_to_return
 
             # Fill until we have enough
-            threshold = self.BUFFER_COMPACTION_THRESHOLD
-            while available < size and not self._eof:
-                if self._buffer_offset > threshold:
-                    del self._buffer[: self._buffer_offset]
-                    self._buffer_offset = 0
-                await self._fill_buffer()
-                available = len(self._buffer) - self._buffer_offset
+            available = await self._fill_until(size)
 
             # Return what we have
             actual_read_size = min(size, available)

--- a/src/aiogzip/_common.py
+++ b/src/aiogzip/_common.py
@@ -42,6 +42,36 @@ ZlibEngine = Any
 
 
 # Validation helper functions
+def _check_can_open(is_closed: bool, is_open: bool) -> None:
+    """Validate the open() precondition shared by the binary and text classes.
+
+    Raises:
+        ValueError: If the file is already open, or has been closed (a closed
+            instance cannot be reopened, matching io objects).
+    """
+    if is_closed:
+        raise ValueError("Cannot reopen a closed file")
+    if is_open:
+        raise ValueError("File is already open")
+
+
+def _format_file_repr(obj: Any) -> str:
+    """Shared __repr__ for the file classes: name, mode, and closed state.
+
+    Tolerates partially-constructed instances: the classes use __slots__ and
+    their __init__ can raise mid-validation, and debuggers / locals-capturing
+    traceback formatters call repr() on such half-built objects.
+    """
+    cls_name = type(obj).__name__
+    try:
+        return (
+            f"<aiogzip.{cls_name} name={obj.name!r} "
+            f"mode={obj._mode!r} closed={obj.closed}>"
+        )
+    except AttributeError:
+        return f"<aiogzip.{cls_name} [uninitialized]>"
+
+
 def _validate_filename(filename: Union[str, bytes, Path, None], fileobj: Any) -> None:
     """Validate filename parameter.
 

--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -93,6 +93,7 @@ class AsyncGzipTextFile:
         "_text_buffer_offset",
         "_trailing_cr",
         "_seen_newline_types",
+        "_decoder_byte_position",
         "_cookie_nonce",
         "_buffer_origin_offset",
         "_buffer_origin_decoder_state",
@@ -209,6 +210,11 @@ class AsyncGzipTextFile:
         self._text_buffer_offset: int = 0  # Start of unread text within _text_buffer
         self._trailing_cr: bool = False  # Track if last decoded chunk ended with \r
         self._seen_newline_types: int = 0
+        # Binary-layer offset of the last byte fed to the incremental decoder.
+        # Reads made directly on the public `buffer` accessor advance the
+        # binary position without going through the decoder, so this frontier
+        # is what plain-position bookkeeping must compare against.
+        self._decoder_byte_position: int = 0
         self._cookie_nonce: int = secrets.randbits(64)
         initial_decoder_state = self._decoder.getstate()
         self._buffer_origin_offset: int = 0
@@ -365,6 +371,7 @@ class AsyncGzipTextFile:
             ) = self._decode_cookie(offset)
             await self._binary_file.seek(origin_offset)
             self._decoder.setstate(decoder_state)
+            self._decoder_byte_position = origin_offset
             self._trailing_cr = trailing_cr
             self._seen_newline_types = seen_newlines
             self._set_buffer("")
@@ -549,6 +556,7 @@ class AsyncGzipTextFile:
             raise ValueError("File not opened. Use async context manager.")
         await self._binary_file.seek(0)
         self._decoder.reset()
+        self._decoder_byte_position = 0
         self._set_buffer("")
         self._trailing_cr = False
         self._seen_newline_types = 0
@@ -600,6 +608,10 @@ class AsyncGzipTextFile:
         if (
             not self._binary_file._eof
             and offset >= self._binary_file._position
+            # Bytes consumed directly via the public `buffer` accessor bypass
+            # the decoder; the live state is only reusable when the decoder
+            # has seen everything up to the current binary position.
+            and self._binary_file._position == self._decoder_byte_position
             and self._can_use_plain_position(self._decoder.getstate())
         ):
             # Already a plain position at/behind the target: replay only the
@@ -611,6 +623,7 @@ class AsyncGzipTextFile:
 
         while remaining > 0:
             raw_chunk = await self._binary_file.read(min(self._chunk_size, remaining))
+            self._decoder_byte_position = self._binary_file._position
             if not raw_chunk:
                 break
             remaining -= len(raw_chunk)
@@ -742,6 +755,7 @@ class AsyncGzipTextFile:
             self._buffer_origin_seen_newline_types = self._seen_newline_types
 
         raw_chunk = await bf.read(self._chunk_size)
+        self._decoder_byte_position = bf._position
         if not raw_chunk:
             final_decoded = self._decoder.decode(b"", final=True)
             if final_decoded:
@@ -785,6 +799,7 @@ class AsyncGzipTextFile:
             self._capture_buffer_origin()
 
         raw_chunk = await bf.read(self._chunk_size)
+        self._decoder_byte_position = bf._position
         if not raw_chunk:
             final_decoded = self._decoder.decode(b"", final=True)
             translated = (

--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -15,6 +15,8 @@ from ._common import (
     WithAsyncRead,
     WithAsyncReadWrite,
     WithAsyncWrite,
+    _check_can_open,
+    _format_file_repr,
     _normalize_mtime,
     _parse_mode_tokens,
     _validate_chunk_size,
@@ -264,10 +266,7 @@ class AsyncGzipTextFile:
             ValueError: if the file is already open, or has already been closed
                 (a closed instance cannot be reopened, matching io objects).
         """
-        if self._is_closed:
-            raise ValueError("Cannot reopen a closed file")
-        if self._binary_file is not None:
-            raise ValueError("File is already open")
+        _check_can_open(self._is_closed, self._binary_file is not None)
         filename = os.fspath(self._filename) if self._filename is not None else None
         self._binary_file = AsyncGzipBinaryFile(
             filename=filename,
@@ -308,10 +307,7 @@ class AsyncGzipTextFile:
         await self.close()
 
     def __repr__(self) -> str:
-        return (
-            f"<aiogzip.AsyncGzipTextFile name={self.name!r} "
-            f"mode={self._mode!r} closed={self.closed}>"
-        )
+        return _format_file_repr(self)
 
     # File API compatibility helpers
     async def tell(self) -> int:
@@ -595,16 +591,21 @@ class AsyncGzipTextFile:
     async def _seek_to_plain_position(self, offset: int) -> None:
         """Restore a plain text position by replaying decoded bytes forward.
 
-        Fast path: when the stream is already at a plain position at or behind
-        the target (and not at EOF), replay only the bytes between the current
-        binary position and ``offset`` instead of restarting from the beginning.
-        The incremental decoder and the newline tracker compose, so feeding the
-        delta onto the live state reaches the same decoder/newline state a full
-        replay-from-zero would. Otherwise reset and replay from the start.
+        Fast path: when the live decoder state corresponds to a clean byte
+        boundary at or behind the target (and not at EOF), replay only the
+        bytes between the current binary position and ``offset`` instead of
+        restarting from the beginning. The incremental decoder and the newline
+        tracker compose, so feeding the delta onto the live state reaches the
+        same decoder/newline state a full replay-from-zero would. Unlike
+        tell()'s plain-position check, buffered read-ahead text does not
+        disqualify the fast path: the buffer is discarded either way, and the
+        live state already reflects every byte up to the decoder frontier.
+        Otherwise reset and replay from the start.
         """
         if self._binary_file is None:
             raise ValueError("File not opened. Use async context manager.")
 
+        decoder_bytes, decoder_flag = self._decoder.getstate()
         if (
             not self._binary_file._eof
             and offset >= self._binary_file._position
@@ -612,7 +613,9 @@ class AsyncGzipTextFile:
             # the decoder; the live state is only reusable when the decoder
             # has seen everything up to the current binary position.
             and self._binary_file._position == self._decoder_byte_position
-            and self._can_use_plain_position(self._decoder.getstate())
+            and decoder_bytes == b""
+            and decoder_flag == 0
+            and not self._trailing_cr
         ):
             # Already a plain position at/behind the target: replay only the
             # forward delta, keeping the live decoder and newline state.
@@ -987,45 +990,33 @@ class AsyncGzipTextFile:
         if not self._universal_newlines:
             return text
 
-        trailing_cr = self._trailing_cr
         seen = self._seen_newline_types
 
-        # Handle trailing CR from previous chunk
-        if trailing_cr:
-            if text[0] == "\n":
-                seen |= self._SEEN_CRLF
-            else:
-                seen |= self._SEEN_CR
+        # A leading '\n' completes a CRLF pair split across the chunk boundary.
+        crlf_completed = self._trailing_cr and text[0] == "\n"
+
+        # Resolve the trailing CR held over from the previous chunk.
+        if self._trailing_cr:
+            seen |= self._SEEN_CRLF if crlf_completed else self._SEEN_CR
 
         pending_trailing_cr = text[-1] == "\r"
 
-        # Track newline types using C-speed string operations
+        # Track newline types using C-speed counting. The scan window excludes
+        # a leading '\n' that completed a boundary-straddling CRLF (already
+        # recorded above) and a trailing '\r' held for the next chunk. Each
+        # CRLF pair contributes one '\r' and one '\n' to the raw counts, so a
+        # count exceeding the pair count means a bare occurrence exists.
         need = 7 & ~seen  # 7 == _SEEN_CR | _SEEN_LF | _SEEN_CRLF
         if need:
-            # A leading '\n' completing a CRLF split across the chunk boundary
-            # was already recorded above; drop it so the bare-LF scan does not
-            # double-count it. A trailing '\r' is likewise held for the next
-            # chunk rather than scanned here.
-            body = text[1:] if (trailing_cr and text[0] == "\n") else text
-            scan = body[:-1] if pending_trailing_cr else body
-
-            # Whether *this* chunk contains a CRLF pair. Computed unconditionally
-            # (not just when CRLF is still unseen) because the bare-CR / bare-LF
-            # disambiguation below must strip CRLF pairs regardless of which
-            # types earlier chunks already recorded. Skipping it once CRLF was
-            # seen would mis-count the \r and \n of a \r\n pair as a bare CR and
-            # a bare LF.
-            has_crlf = "\r\n" in scan
-            if need & 4 and has_crlf:
+            start = 1 if crlf_completed else 0
+            end = len(text) - 1 if pending_trailing_cr else len(text)
+            crlf = text.count("\r\n", start, end)
+            if crlf:
                 seen |= self._SEEN_CRLF
-
-            if need & 2 and "\n" in scan:
-                if not has_crlf or "\n" in scan.replace("\r\n", "\r\r"):
-                    seen |= self._SEEN_LF
-
-            if need & 1 and "\r" in scan:
-                if not has_crlf or "\r" in scan.replace("\r\n", "\n\n"):
-                    seen |= self._SEEN_CR
+            if need & self._SEEN_LF and text.count("\n", start, end) > crlf:
+                seen |= self._SEEN_LF
+            if need & self._SEEN_CR and text.count("\r", start, end) > crlf:
+                seen |= self._SEEN_CR
 
         self._seen_newline_types = seen
 
@@ -1033,8 +1024,10 @@ class AsyncGzipTextFile:
             self._trailing_cr = pending_trailing_cr
             return text
 
-        # Universal newline translation (newline is None)
-        if trailing_cr and text[0] == "\n":
+        # Universal newline translation (newline is None): the held CR was
+        # already emitted as '\n' at the end of the previous chunk, so drop
+        # the '\n' that completed the pair.
+        if crlf_completed:
             text = text[1:]
 
         self._trailing_cr = pending_trailing_cr

--- a/tests/test_binary_io.py
+++ b/tests/test_binary_io.py
@@ -281,6 +281,19 @@ class TestAsyncGzipBinaryFile:
             assert await f.read() == payload
 
     @pytest.mark.asyncio
+    async def test_binary_peek_on_closed_file_raises(self, temp_file):
+        """peek() on a closed file raises the same ValueError as read()."""
+        payload = b"abcdef"
+        async with AsyncGzipBinaryFile(temp_file, "wb") as f:
+            await f.write(payload)
+
+        f = AsyncGzipBinaryFile(temp_file, "rb")
+        await f.open()
+        await f.close()
+        with pytest.raises(ValueError, match="closed"):
+            await f.peek(1)
+
+    @pytest.mark.asyncio
     async def test_binary_peek_from_start_returns_data(self, temp_file):
         """peek() from a fresh reader should not return empty for valid gzip data."""
         payload = b"abcdefghijklmnopqrstuvwxyz"

--- a/tests/test_file_lifecycle.py
+++ b/tests/test_file_lifecycle.py
@@ -497,3 +497,26 @@ class TestFailedOpenRecovery:
                 await f.write(b"hello")
         finally:
             await inner.close()
+
+
+class TestReprOnPartialObjects:
+    """repr() must not raise on partially-constructed instances.
+
+    The classes use __slots__ and __init__ validates mid-assignment, so a
+    constructor failure leaves an object missing some attributes; debuggers
+    and locals-capturing traceback formatters still call repr() on it.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cls", [AsyncGzipBinaryFile, AsyncGzipTextFile])
+    async def test_repr_after_failed_init(self, tmp_path, cls):
+        obj = cls.__new__(cls)
+        try:
+            # compresslevel=99 raises after _filename/_mode are assigned but
+            # before _is_closed, leaving the object half-built.
+            mode = "wb" if cls is AsyncGzipBinaryFile else "wt"
+            obj.__init__(tmp_path / "x.gz", mode, compresslevel=99)
+        except ValueError:
+            pass
+        r = repr(obj)  # must not raise
+        assert cls.__name__ in r

--- a/tests/test_file_lifecycle.py
+++ b/tests/test_file_lifecycle.py
@@ -425,3 +425,75 @@ class TestRepr:
             assert "name='in-memory.gz'" in repr(f)
         finally:
             await f.close()
+
+
+class TestFailedOpenRecovery:
+    """A failed open() must leave the instance retryable, not half-open.
+
+    Regression: with an external fileobj, _cleanup_failed_enter left _file
+    set after a failed open, so a retry raised "File is already open" and
+    write() would emit compressed data for a stream whose gzip header was
+    never written.
+    """
+
+    class _FlakyWriter:
+        """Fails the first write (the gzip header), then delegates."""
+
+        def __init__(self, target):
+            self._target = target
+            self.fail_next = True
+            self.closed = False
+
+        async def write(self, data):
+            if self.fail_next:
+                self.fail_next = False
+                raise OSError("transient write failure")
+            return await self._target.write(data)
+
+        async def close(self):
+            self.closed = True
+
+    @pytest.mark.asyncio
+    async def test_failed_open_with_external_fileobj_can_retry(self, tmp_path):
+        import gzip
+
+        import aiofiles
+
+        p = tmp_path / "flaky.gz"
+        inner = await aiofiles.open(p, "wb")
+        try:
+            writer = self._FlakyWriter(inner)
+            f = AsyncGzipBinaryFile(None, "wb", fileobj=writer)
+
+            with pytest.raises(OSError, match="transient write failure"):
+                await f.open()
+
+            # The failed open leaves no half-open state behind: the handle is
+            # cleared, the caller's fileobj is untouched, and a retry works.
+            assert f._file is None
+            assert writer.closed is False
+
+            async with f:
+                await f.write(b"recovered payload")
+        finally:
+            await inner.close()
+
+        with gzip.open(p, "rb") as check:
+            assert check.read() == b"recovered payload"
+
+    @pytest.mark.asyncio
+    async def test_failed_open_then_write_raises_not_opened(self, tmp_path):
+        """After a failed open, write() reports the file as not opened rather
+        than silently compressing into a headerless stream."""
+        import aiofiles
+
+        inner = await aiofiles.open(tmp_path / "wedge.gz", "wb")
+        try:
+            writer = self._FlakyWriter(inner)
+            f = AsyncGzipBinaryFile(None, "wb", fileobj=writer)
+            with pytest.raises(OSError, match="transient write failure"):
+                await f.open()
+            with pytest.raises(ValueError, match="File not opened"):
+                await f.write(b"hello")
+        finally:
+            await inner.close()

--- a/tests/test_hypothesis_parity.py
+++ b/tests/test_hypothesis_parity.py
@@ -72,16 +72,23 @@ _chunk_size = st.sampled_from(CHUNK_SIZES)
 
 
 def _build_raw(members):
-    """Encode the member spec into concatenated gzip members with NUL padding."""
+    """Encode the member spec into concatenated gzip members with NUL padding.
+
+    Returns ``(raw, flg_offsets)``: the stream bytes plus the offset of each
+    member's FLG header byte (byte 3 of the member), so the corruption test
+    can scope its only allowed strictness exemption to reserved-FLG-bit flips.
+    """
     out = bytearray()
+    flg_offsets = []
     for payload, level, pad in members:
         buf = io.BytesIO()
         # mtime=0 keeps the header deterministic.
         with gzip.GzipFile(fileobj=buf, mode="wb", compresslevel=level, mtime=0) as g:
             g.write(payload)
+        flg_offsets.append(len(out) + 3)
         out += buf.getvalue()
         out += b"\x00" * pad
-    return bytes(out)
+    return bytes(out), flg_offsets
 
 
 def _expected_len(members):
@@ -165,7 +172,7 @@ async def _check_pattern(path, chunk_size, pattern, params):
 @given(members=_members, chunk_size=_chunk_size, data=st.data())
 def test_read_patterns_match_stdlib(members, chunk_size, data):
     """aiogzip output and tell() match stdlib gzip across access patterns."""
-    raw = _build_raw(members)
+    raw, _ = _build_raw(members)
     total = _expected_len(members)
     pattern = data.draw(st.sampled_from(["all", "fixed", "line", "interleave"]))
 
@@ -220,13 +227,14 @@ def test_single_byte_corruption_parity(members, pos, mask):
     - If stdlib detects corruption, aiogzip must too (it never decodes a stream
       stdlib rejects).
     - When both decode the stream, their output is byte-identical.
-
-    aiogzip is allowed to be *stricter* than stdlib: it decompresses via zlib,
-    which rejects reserved gzip header-flag bits that stdlib's hand-rolled
-    header parser silently ignores. So a flip that leaves stdlib reading cleanly
-    may still (legitimately) make aiogzip raise; that case is not a failure.
+    - If aiogzip raises where stdlib decoded cleanly, the flip must have set a
+      reserved bit of a member's FLG header byte — the one place aiogzip is
+      legitimately *stricter*: it decompresses via zlib, which rejects reserved
+      flag bits that stdlib's hand-rolled header parser silently ignores. Any
+      other spurious rejection of a stream stdlib accepts is a failure.
     """
-    raw = bytearray(_build_raw(members))
+    built, flg_offsets = _build_raw(members)
+    raw = bytearray(built)
     idx = pos % len(raw)  # raw is always a full gzip member, so len(raw) > 0
     raw[idx] ^= mask
     corrupt = bytes(raw)
@@ -259,6 +267,14 @@ def test_single_byte_corruption_parity(members, pos, mask):
     if aio_raised:
         # aiogzip surfaces corruption as gzip.BadGzipFile, a subclass of OSError.
         assert isinstance(aio_exc, (gzip.BadGzipFile, OSError))
+        if not std_raised:
+            # Stricter-than-stdlib is allowed only for reserved FLG bits
+            # (0xE0); anything else is a spurious rejection of a valid stream.
+            assert idx in flg_offsets and mask & 0xE0, (
+                f"aiogzip raised {aio_exc!r} on a stream stdlib decoded "
+                f"cleanly (flip at byte {idx} with mask {mask:#04x} is not a "
+                f"reserved FLG-bit flip)"
+            )
     else:
         # aiogzip decoded; it must agree with stdlib whenever stdlib also decoded.
         assert std_raised or aio_bytes == std_bytes

--- a/tests/test_readinto.py
+++ b/tests/test_readinto.py
@@ -243,7 +243,7 @@ async def test_readinto_on_closed_file_raises(temp_file):
     """readinto()/readinto1() on a closed file raise the same error as read()."""
     _write(temp_file, b"abc")
     f = AsyncGzipBinaryFile(temp_file, "rb")
-    await f.__aenter__()
+    await f.open()
     await f.close()
     with pytest.raises(ValueError, match="closed"):
         await f.readinto(bytearray(4))

--- a/tests/test_readinto.py
+++ b/tests/test_readinto.py
@@ -6,6 +6,7 @@ with ``read()`` across chunk sizes (including ``chunk_size=1``), partial final
 fills at EOF, and both ``bytearray`` and ``memoryview`` (incl. slice) targets.
 """
 
+import array
 import gzip
 import os
 
@@ -132,13 +133,98 @@ async def test_readinto_memoryview_slice_target(temp_file, chunk_size):
 
 @pytest.mark.asyncio
 async def test_readinto_readonly_buffer_raises(temp_file):
-    """A read-only target is rejected with TypeError, before any read."""
+    """A read-only target is rejected with TypeError naming the right method."""
     _write(temp_file, b"abc")
     async with AsyncGzipBinaryFile(temp_file, "rb") as f:
-        with pytest.raises(TypeError, match="writable"):
+        with pytest.raises(TypeError, match=r"readinto\(\) argument must be writable"):
             await f.readinto(memoryview(b"immutable"))
-        with pytest.raises(TypeError, match="writable"):
+        with pytest.raises(TypeError, match=r"readinto1\(\) argument must be writable"):
             await f.readinto1(memoryview(b"immutable"))
+
+
+@pytest.mark.asyncio
+async def test_readinto_itemsize_gt_one_buffer_matches_stdlib(temp_file):
+    """Writable buffers with itemsize > 1 (array.array) fill like stdlib gzip.
+
+    The view must be cast to bytes: without the cast, the slice assignment
+    raises ValueError and the count would be in elements rather than bytes.
+    """
+    item = array.array("i", [0]).itemsize
+    payload = os.urandom(100 * item)
+    _write(temp_file, payload)
+
+    expected = array.array("i", bytes(100 * item))
+    with gzip.open(temp_file, "rb") as sf:
+        n_std = sf.readinto(expected)
+
+    arr = array.array("i", bytes(100 * item))
+    async with AsyncGzipBinaryFile(temp_file, "rb") as f:
+        n = await f.readinto(arr)
+    assert n == n_std == 100 * item  # byte count, not element count
+    assert arr == expected
+
+    arr1 = array.array("i", bytes(100 * item))
+    async with AsyncGzipBinaryFile(temp_file, "rb") as f:
+        n1 = await f.readinto1(arr1)
+    assert n1 > 0
+    assert arr1.tobytes()[:n1] == payload[:n1]
+
+
+@pytest.mark.asyncio
+async def test_readinto_error_leaves_position_and_buffer_intact(temp_file):
+    """A decompression error mid-request must not consume already-decoded data.
+
+    readinto() fills the internal buffer before copying anything into the
+    caller's view, so when a refill raises (truncated stream here) the
+    position is unchanged and the good prefix is still readable — the same
+    salvage semantics as read().
+    """
+    payload = b"payload data " * 4096
+    _write(temp_file, payload)
+    blob = open(temp_file, "rb").read()
+    with open(temp_file, "wb") as fh:
+        fh.write(blob[: len(blob) // 2])  # truncate mid-stream
+
+    async with AsyncGzipBinaryFile(temp_file, "rb", chunk_size=64) as f:
+        with pytest.raises(OSError):
+            await f.readinto(bytearray(len(payload)))
+        # Nothing was consumed by the failed call...
+        assert await f.tell() == 0
+        # ...and the decoded prefix is still available to salvage.
+        assert await f.read(10) == payload[:10]
+
+
+@pytest.mark.parametrize("chunk_size", [1, 2, 3])
+@pytest.mark.asyncio
+async def test_readinto1_and_read1_zero_only_at_eof(temp_file, chunk_size):
+    """readinto1()/read1() return 0/b'' only at EOF, like stdlib gzip.
+
+    With a tiny chunk_size a single fill can decode nothing (it is still
+    consuming the gzip header), so the fill must repeat until at least one
+    byte is available; otherwise the standard ``while n := readinto1(buf)``
+    consumer loop terminates before any data.
+    """
+    payload = b"hello world"
+    _write(temp_file, payload)
+
+    out = bytearray()
+    async with AsyncGzipBinaryFile(temp_file, "rb", chunk_size=chunk_size) as f:
+        buf = bytearray(4)
+        while True:
+            n = await f.readinto1(buf)
+            if n == 0:
+                break
+            out += buf[:n]
+    assert bytes(out) == payload
+
+    out1 = b""
+    async with AsyncGzipBinaryFile(temp_file, "rb", chunk_size=chunk_size) as f:
+        while True:
+            chunk = await f.read1(4)
+            if not chunk:
+                break
+            out1 += chunk
+    assert out1 == payload
 
 
 @pytest.mark.asyncio
@@ -181,10 +267,9 @@ async def test_readinto_in_write_mode_raises(temp_file):
 async def test_readinto1_matches_read1(temp_file, chunk_size, buf_size):
     """readinto1() returns the same bytes/length as read1(), one fill at a time.
 
-    read1()/readinto1() do at most one underlying fill, so with a small
-    chunk_size they can legitimately return 0 mid-stream (a fill that decoded
-    nothing yet) — that is not EOF, so the loop runs until the payload is fully
-    collected rather than stopping on a zero.
+    Both repeat fills until at least one byte decodes (a fill can consume
+    compressed input, e.g. the gzip header, without producing output), so a
+    zero/empty result means EOF for both and they stay in lockstep.
     """
     payload = os.urandom(3000)
     _write(temp_file, payload)

--- a/tests/test_seek_plain_fast.py
+++ b/tests/test_seek_plain_fast.py
@@ -182,3 +182,41 @@ async def test_forward_plain_seek_skips_reset_backward_does_not(temp_file):
             await f.seek(p1)  # backward -> must reset and replay from zero
             assert mock_reset.call_count == calls_before + 1
             assert (await f.tell()) == p1
+
+
+@pytest.mark.asyncio
+async def test_forward_seek_after_direct_buffer_read_replays_from_zero(temp_file):
+    """Bytes consumed via the public binary `buffer` accessor bypass the text
+    decoder, so the live decoder state no longer matches the binary position.
+
+    Regression: the fast path spliced the decoder onto the advanced binary
+    position and resumed decoding mid-character (UnicodeDecodeError for
+    strict encodings, silent corruption for tolerant ones). It must fall
+    back to replay-from-zero instead.
+    """
+    raw = ("☃" * 100).encode("utf-8")  # 3 bytes per snowman
+    _write_raw(temp_file, raw)
+
+    async with AsyncGzipTextFile(temp_file, "rt", chunk_size=64) as f:
+        # Consume one byte behind the decoder's back, stopping mid-character.
+        assert await f.buffer.read(1) == raw[:1]
+        # Seek to a character boundary: must decode cleanly from there.
+        assert await f.seek(3) == 3
+        assert await f.read() == "☃" * 99
+
+
+@pytest.mark.asyncio
+async def test_fast_path_still_used_after_pure_text_seeks(temp_file):
+    """Sanity: the decoder-frontier gate does not disable the fast path for
+    the supported pattern (plain seeks/tells with no direct buffer reads)."""
+    raw = b"".join(b"row%d\n" % i for i in range(200))
+    _write_raw(temp_file, raw)
+
+    async with AsyncGzipTextFile(temp_file, "rt") as f:
+        await f.seek(6)
+        with patch.object(
+            AsyncGzipTextFile, "_reset_to_start", side_effect=AssertionError
+        ):
+            await f.seek(12)
+        # Offset 12 is two bytes into "row2\n".
+        assert await f.read(6) == "w2\nrow"

--- a/tests/test_seek_plain_fast.py
+++ b/tests/test_seek_plain_fast.py
@@ -220,3 +220,30 @@ async def test_fast_path_still_used_after_pure_text_seeks(temp_file):
             await f.seek(12)
         # Offset 12 is two bytes into "row2\n".
         assert await f.read(6) == "w2\nrow"
+
+
+@pytest.mark.asyncio
+async def test_forward_seek_with_text_readahead_uses_fast_path(temp_file):
+    """Buffered read-ahead does not disqualify the fast path.
+
+    A text readline() leaves decoded read-ahead, but the live decoder and
+    newline state still correspond to the binary frontier (every byte the
+    binary layer advanced past was fed to the decoder), and the seek discards
+    the buffer either way — so only the forward delta is replayed, and the
+    result matches a replay-from-zero.
+    """
+    lines = [b"row%d\n" % i for i in range(200)]
+    raw = b"".join(lines)
+    _write_raw(temp_file, raw)
+    target = _line_offsets(lines)[120]
+
+    ref_ret, ref_nl, ref_rest = await _replay_from_zero(temp_file, target)
+
+    async with AsyncGzipTextFile(temp_file, "rt", chunk_size=64) as f:
+        assert await f.readline() == "row0\n"  # leaves read-ahead buffered
+        with patch.object(
+            AsyncGzipTextFile, "_reset_to_start", side_effect=AssertionError
+        ):
+            assert await f.seek(target) == ref_ret == target
+        assert await f.read() == ref_rest
+        assert f.newlines == ref_nl


### PR DESCRIPTION
## Summary

A final multi-angle review of `v1.7.0..HEAD` surfaced 13 verified findings (each confirmed with a repro). This PR fixes all of them ahead of the 1.8.0 release.

### Correctness fixes (commit 1)

- **Text seek fast path** could splice the live decoder onto a binary position it had never decoded when bytes were consumed via the public `buffer` accessor — `UnicodeDecodeError` or silent corruption (regression vs v1.7.0). A new `_decoder_byte_position` frontier gates the fast path.
- **Failed `open()` with an external fileobj** left `_file` set: retries raised "File is already open" forever and `write()` could emit compressed data into a headerless stream. The handle is now cleared up front (without closing the caller's fileobj).
- **`readinto()`/`readinto1()`** now cast the target view to bytes, so writable buffers with itemsize > 1 (`array.array`) fill like stdlib gzip instead of raising `ValueError`.
- **`readinto()`** fills before consuming, so a decompression error mid-request no longer eats the already-decoded prefix (position and buffered data survive for salvage, matching `read()`).
- **`readinto1()`/`read1()`** repeat fills until at least one byte decodes, so a zero/empty result now means EOF, as documented and as stdlib behaves.
- **`peek()`** gained the missing closed-file check; **`readinto1()`**'s writable-buffer `TypeError` names the right method.

### Cleanups (commit 2)

- Corruption-parity property test: restored the "aiogzip must not spuriously reject what stdlib accepts" assertion, scoped to the one legitimate exemption (reserved FLG-bit flips).
- Shared `_check_can_open()` / `_format_file_repr()` helpers in `_common.py` replace verbatim duplication in both file classes; repr now tolerates partially-constructed `__slots__` instances.
- Extracted `_fill_until()` so `read()` and `readinto()` share one compact-then-refill loop.
- Newline detection now uses windowed `str.count` instead of `replace()` tricks — allocation-free on pure-CRLF streams, single `crlf_completed` predicate.
- Seek fast path no longer falls back to a full replay-from-zero when text read-ahead is buffered (the buffer is discarded either way); `tell()` keeps the stricter rule.
- `docs/api.md` links to the canonical resumable-processing recipe instead of duplicating it.

## Test plan

- [x] 755 tests pass (12 new regression tests covering every fix)
- [x] Hypothesis parity suite re-run multiple times with fresh examples to validate the scoped FLG-only exemption
- [x] mypy, ruff check, ruff format clean; no PEP 585 / Python 3.8 incompatibilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)