### PR TITLE
Workflow housekeeping: dependabot, concurrency, job timeouts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Dependabot keeps CI actions and Python dev dependencies current, so the
+# action runtimes don't silently drift onto deprecated versions again.
+version: 2
+updates:
+  # GitHub Actions used in the workflows under .github/workflows/
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Update"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # Python dependencies declared in pyproject.toml (dev/test/docs extras)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Update"
+    groups:
+      python-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,18 @@ on:
 permissions:
   contents: read
 
+# Cancel an in-progress run when a newer commit is pushed to the same ref
+# (e.g. a PR branch), so superseded runs don't tie up CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     # Defines a build matrix for your tests. Linux runs the full Python
     # version sweep; Windows and macOS run a single version each to guard
     # platform-specific paths (e.g. os.linesep newline translation in text
@@ -92,6 +99,7 @@ jobs:
   # compression paths are exercised on one representative version.
   fast-engine:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -116,6 +124,7 @@ jobs:
 
   coverage-comment:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: build
     permissions:
       contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: pypi
     permissions:
       id-token: write  # Required for trusted publishing


### PR DESCRIPTION
## Summary

Follow-up to #28 (Node 24 action bumps) to keep CI healthy going forward.

- **Dependabot** (`.github/dependabot.yml`) — watches the `github-actions` and `pip` ecosystems weekly, grouped, with an `Update` commit prefix. This is what prevents action runtimes (and dev deps) from silently drifting onto deprecated versions again, as the Node 20 runtime did.
- **Concurrency group** on the CI workflow — a new push to a PR branch cancels the superseded in-progress run, saving CI minutes.
- **`timeout-minutes: 15`** on every job (ci `build`/`fast-engine`/`coverage-comment`, docs `deploy`, publish `publish`) — a hung job fails fast instead of running to the 6h default. Current jobs finish in ~3 min, so 15 is comfortable headroom.

## Notes

- Config-only; no functional code changes.
- All four YAML files validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)