### PR TITLE
Restore grouped weekly dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,27 @@
+# Dependabot keeps CI actions and Python dev dependencies current, so the
+# action runtimes don't silently drift onto deprecated versions again.
 version: 2
 updates:
+  # GitHub Actions used in the workflows under .github/workflows/
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    commit-message:
+      prefix: "Update"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # Python dependencies declared in pyproject.toml (dev/test/docs extras)
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    commit-message:
+      prefix: "Update"
+    groups:
+      python-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
The richer dependabot config (weekly cadence, grouped `actions` / `python-deps` updates, `Update:` commit prefix) was unintentionally replaced by a minimal monthly config during the PR #33 rebase — which is why dependabot superseded its grouped PRs (#31/#32) with per-dependency ones (#34/#35/#36). This restores the original config from `67a77b0` verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)