### PR TITLE
Docs: sync with origin before starting work

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,29 @@
 # Pre-commit hooks for aiogzip
 # Install: pip install pre-commit && pre-commit install
+# (installs both the pre-commit and pre-push hook types; see
+# default_install_hook_types below)
 # Run manually: pre-commit run --all-files
 
+default_install_hook_types: [pre-commit, pre-push]
+
+# Hooks without an explicit `stages` run in every installed stage; keep the
+# lint/type/format hooks at commit time only so pushes stay fast — only the
+# check-branch-fresh guard below runs at push.
+default_stages: [pre-commit]
+
 repos:
+  # Refuse pushes from a branch based on a stale main (multi-machine
+  # development guard; see CLAUDE.md "Sync Before Working").
+  - repo: local
+    hooks:
+      - id: check-branch-fresh
+        name: check-branch-fresh
+        entry: scripts/check_branch_fresh.sh
+        language: system
+        stages: [pre-push]
+        always_run: true
+        pass_filenames: false
+
   # Ruff - Fast Python linter (replaces flake8, isort, etc.)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.20

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,14 @@ two commits duplicated already-shipped work, the PR opened conflicting, and
 everything had to be rebased. The git status snapshot at session start only
 reflects the local clone; it says nothing about freshness relative to origin.
 
+A pre-push hook (`scripts/check_branch_fresh.sh`, wired up as the
+`check-branch-fresh` pre-commit hook) backstops this: it refuses a push when
+`origin/main` has commits missing from the branch's history, which also
+catches main moving *mid-session*. It requires the pre-push hook type to be
+installed — `pre-commit install` handles it via `default_install_hook_types`,
+but run it once on each machine/clone. Intentionally-behind pushes:
+`SKIP=check-branch-fresh git push`. The hook fails open when offline.
+
 ## Python 3.8 Compatibility Checklist
 
 **IMPORTANT:** This library supports Python 3.8+. Always check for PEP 585 compatibility before committing!

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,27 @@
 
 This document contains important reminders and best practices for maintaining the aiogzip library.
 
+## Sync Before Working
+
+This library is developed from multiple machines, so the local checkout can
+silently lag origin. **Before reviewing code or starting any changes:**
+
+```bash
+git fetch origin
+git log --oneline main..origin/main   # anything here means local main is stale
+```
+
+If local main is behind, fast-forward it (`git checkout main && git pull
+--ff-only`) and branch from the updated main. As a cross-check, `__version__`
+in `src/aiogzip/__init__.py` should match the newest `CHANGELOG.md` entry and
+the latest tag (`git tag --sort=-v:refname | head -1`).
+
+Why this matters: a stale checkout here once produced a full package review
+and a 21-commit branch built on v1.7.0 while origin was already at v1.8.0 —
+two commits duplicated already-shipped work, the PR opened conflicting, and
+everything had to be rebased. The git status snapshot at session start only
+reflects the local clone; it says nothing about freshness relative to origin.
+
 ## Python 3.8 Compatibility Checklist
 
 **IMPORTANT:** This library supports Python 3.8+. Always check for PEP 585 compatibility before committing!

--- a/scripts/check_branch_fresh.sh
+++ b/scripts/check_branch_fresh.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Pre-push guard: fail when origin/main has commits that are not in the
+# history of the branch being pushed — i.e. the branch was cut from (or has
+# drifted behind) a stale main. This repo is developed from multiple
+# machines, so a locally-green branch can still be based on old code.
+# See CLAUDE.md "Sync Before Working".
+set -u
+
+# Fail open when offline: a fetch failure must not block pushing.
+if ! git fetch --quiet origin main 2>/dev/null; then
+    echo "check-branch-fresh: could not fetch origin/main (offline?); skipping check" >&2
+    exit 0
+fi
+
+behind=$(git rev-list --count HEAD..origin/main)
+if [ "${behind}" -gt 0 ]; then
+    echo "check-branch-fresh: origin/main has ${behind} commit(s) missing from this branch:" >&2
+    git log --oneline HEAD..origin/main | head -10 >&2
+    echo "" >&2
+    echo "The branch is based on a stale main. Rebase before pushing:" >&2
+    echo "    git rebase origin/main" >&2
+    echo "Or, if being behind is intentional, skip once with:" >&2
+    echo "    SKIP=check-branch-fresh git push" >&2
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
aiogzip is developed from multiple machines, and a stale local checkout just caused a full review + 21-commit branch to be built against v1.7.0 while origin was already at v1.8.0 (see #33's history: two duplicated commits, a conflicting PR, and a rebase). Add a "Sync Before Working" section at the top of CLAUDE.md documenting the fetch/compare/fast-forward routine plus version cross-checks, mirroring the same guard added to other repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)