### PR TITLE
Prepare release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-07-02
+
 ### Announced
 
 - The 1.x line is the last to support Python 3.8 and 3.9 (both past
@@ -29,6 +31,19 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `AsyncGzipTextFile` file-API parity with the binary class: `mtime`, `isatty()`, `detach()`, `truncate()`; `seekable()` now delegates to the binary layer instead of returning a constant `True`.
+
+### Packaging
+
+- PyPI metadata now carries the MIT license classifier, Documentation and
+  Changelog URLs, and keywords; sdists have deterministic contents via
+  MANIFEST.in and include CHANGELOG.md/SECURITY.md. Publishing is gated on
+  a test run and a tag-vs-version check.
+
+### Documentation
+
+- Corrected the text `seek()`/`tell()` docs: plain-offset seeks replay only
+  the forward delta when possible (not always "from the start"), and
+  `tell()` returns a plain offset at clean boundaries, a cookie otherwise.
 
 ## [1.8.0] - 2026-06-10
 

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -19,7 +19,7 @@ from ._common import (
 )
 from ._text import AsyncGzipTextFile
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 
 # Mode strings that select a text stream (they contain a 't'). The factory
 # parses modes character-by-character and is permutation-tolerant, so these


### PR DESCRIPTION
Bumps `__version__` to 1.9.0 and dates the changelog section.

## v1.9.0 highlights

### Fixed
- Cancellation-safe `open()` (both classes) — a cancelled open no longer wedges the instance
- Negative `readline(limit)` no longer corrupts the read position (binary + text)
- Zero-byte files read as empty, matching `gzip.open()`; mid-member truncation still raises
- Consistent `ValueError` on closed-file `seek`/`tell`/`rewind`/`readinto`/`readinto1`
- `flush()` raises on a broken write stream instead of silently returning
- Cancelled write during the zlib executor hop marks the stream broken
- `fileno()` no longer leaks an un-awaited coroutine

### Added
- Text-class file-API parity: `mtime`, `isatty()`, `detach()`, `truncate()`, delegating `seekable()`

### Announced
- 1.x is the last line supporting Python 3.8/3.9; 2.0 will require 3.11+

### Packaging / Documentation
- License classifier, project URLs, keywords; deterministic sdists; gated publishing
- Corrected text seek/tell documentation

After CI passes and this merges, `/release-tag` tags and publishes v1.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)