### PR TITLE
Update PyPI keywords and summary for discoverability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,11 @@ dynamic = ["version"]
 authors = [
   { name="Geoff Davis", email="geoff@keksi.ai" },
 ]
-description = "Asynchronous gzip file reader/writer with aiocsv support."
+description = "Asynchronous gzip file reading and writing for Python asyncio — aiofiles-style API, streaming text/binary modes, decompression-bomb guards, optional zlib-ng acceleration."
 readme = "README.md"
 requires-python = ">=3.8"
 license = { text = "MIT" }
-keywords = ["gzip", "async", "asyncio", "compression", "aiofiles", "zlib"]
+keywords = ["gzip", "async", "asyncio", "compression", "decompression", "aiofiles", "zlib", "zlib-ng", "file-io"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
Aligns `pyproject.toml` metadata with the GitHub repo topics added today:

- **keywords**: adds `decompression`, `zlib-ng`, `file-io` (now: gzip, async, asyncio, compression, decompression, aiofiles, zlib, zlib-ng, file-io)
- **summary**: expands the one-liner to mention the asyncio/aiofiles-style API, streaming text/binary modes, decompression-bomb guards, and optional zlib-ng acceleration

Metadata-only change; takes effect on PyPI with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)