### PR TITLE
Speed up CI: uv installs, slimmer test extra, reuse coverage data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,14 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
+
+      # Deliberately unpinned (uv.lock is not consulted): CI exercises fresh
+      # dependency releases before users hit them. uv just installs faster.
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev,csv]
+        run: uv pip install --system -e ".[dev,csv]"
 
       - name: Lint with Ruff
         run: ruff check .
@@ -88,13 +90,15 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
 
-      # Step 3: Install dependencies
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
+
+      # Step 3: Install dependencies. The [test] extra skips lint-only
+      # tooling (ruff, ty, pre-commit); deliberately unpinned (uv.lock is
+      # not consulted) so CI exercises fresh dependency releases.
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev,csv]
+        run: uv pip install --system -e ".[test,csv]"
 
       # Step 4: Run tests with pytest and coverage
       # --cov-fail-under gates against silent coverage regressions. The
@@ -104,7 +108,18 @@ jobs:
         run: |
           pytest --cov --cov-report=term-missing --cov-report=xml --cov-fail-under=85
 
-  # The main matrix above installs only [dev,csv], so it exercises the
+      # The coverage-comment job reuses this leg's coverage data instead of
+      # re-running the suite. relative_files = true in [tool.coverage.run]
+      # keeps the paths portable across jobs.
+      - name: Upload coverage data
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-data
+          path: .coverage
+          include-hidden-files: true
+
+  # The main matrix above installs only [test,csv], so it exercises the
   # pure-Python default (stdlib zlib, zlib-ng absent) — the common
   # `pip install aiogzip` install — across the full version/OS sweep. This
   # job adds the [fast] extra so the zlib-ng decompression and opt-in
@@ -120,12 +135,12 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies (with fast extra)
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev,csv,fast]
+        run: uv pip install --system -e ".[test,csv,fast]"
 
       - name: Run tests with zlib-ng active
         run: |
@@ -135,6 +150,8 @@ jobs:
         run: |
           AIOGZIP_ENGINE=stdlib pytest -q
 
+  # Posts the coverage comment from the ubuntu/3.12 build leg's uploaded
+  # .coverage data — no dependency install or duplicate test run needed.
   coverage-comment:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -146,20 +163,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+      - name: Download coverage data
+        uses: actions/download-artifact@v8
         with:
-          python-version: "3.12"
-          cache: "pip"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev,csv]
-
-      - name: Run tests with coverage
-        run: |
-          pytest --cov --cov-report=xml
+          name: coverage-data
 
       - name: Coverage comment
         uses: py-cov-action/python-coverage-comment-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.0
 
       # Deliberately unpinned (uv.lock is not consulted): CI exercises fresh
       # dependency releases before users hit them. uv just installs faster.
@@ -92,7 +92,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.0
 
       # Step 3: Install dependencies. The [test] extra skips lint-only
       # tooling (ruff, ty, pre-commit); deliberately unpinned (uv.lock is
@@ -137,7 +137,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.0
 
       - name: Install dependencies (with fast extra)
         run: uv pip install --system -e ".[test,csv,fast]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,20 +52,26 @@ docs = [
     "mkdocs-material>=9.5.0",
     "mkdocstrings[python]>=0.24.0",
 ]
-dev = [
+# What the CI test matrix installs. mypy, types-aiofiles and
+# typing_extensions live here (not in dev) because test_factory_typing.py
+# shells out to `mypy --strict`; dropping them would silently skip that test.
+test = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24",
     "pytest-cov>=4.0.0",
     "hypothesis>=6.0.0",
     "psutil",
     "tomli; python_version < \"3.11\"",
+    "mypy>=1.0.0",
+    "types-aiofiles",
+    "typing_extensions",
+]
+dev = [
+    "aiogzip[test]",
     # Keep in sync with the ruff-pre-commit rev in .pre-commit-config.yaml;
     # dependabot bumps this pin but nothing updates pre-commit revs.
     "ruff==0.15.20",
-    "mypy>=1.0.0",
     "ty>=0.0.1a16",
-    "types-aiofiles",
-    "typing_extensions",
     "pre-commit",
 ]
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -118,29 +118,41 @@ docs = [
 fast = [
     { name = "zlib-ng", marker = "python_full_version >= '3.10'" },
 ]
+test = [
+    { name = "hypothesis", marker = "python_full_version >= '3.10'" },
+    { name = "mypy", marker = "python_full_version >= '3.10'" },
+    { name = "psutil", marker = "python_full_version >= '3.10'" },
+    { name = "pytest", marker = "python_full_version >= '3.10'" },
+    { name = "pytest-asyncio", marker = "python_full_version >= '3.10'" },
+    { name = "pytest-cov", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "types-aiofiles", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "aiocsv", marker = "extra == 'csv'", specifier = ">=1.2.0" },
     { name = "aiofiles", specifier = ">=23.0.0" },
-    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0.0" },
+    { name = "aiogzip", extras = ["test"], marker = "extra == 'dev'" },
+    { name = "hypothesis", marker = "extra == 'test'", specifier = ">=6.0.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "mypy", marker = "extra == 'test'", specifier = ">=1.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'" },
-    { name = "psutil", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "psutil", marker = "extra == 'test'" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
-    { name = "tomli", marker = "python_full_version < '3.11' and extra == 'dev'" },
+    { name = "tomli", marker = "python_full_version < '3.11' and extra == 'test'" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a16" },
-    { name = "types-aiofiles", marker = "extra == 'dev'" },
-    { name = "typing-extensions", marker = "extra == 'dev'" },
+    { name = "types-aiofiles", marker = "extra == 'test'" },
+    { name = "typing-extensions", marker = "extra == 'test'" },
     { name = "zlib-ng", marker = "extra == 'fast'", specifier = ">=0.4.0" },
 ]
-provides-extras = ["csv", "fast", "docs", "dev"]
+provides-extras = ["csv", "fast", "docs", "test", "dev"]
 
 [[package]]
 name = "ast-serialize"


### PR DESCRIPTION
Cuts PR-CI wall clock from ~5.7 min to an estimated ~2.5–3 min. Three changes, nothing removed from what is tested:

1. **Reuse coverage data instead of re-running the suite.** `coverage-comment` was an exact duplicate of the `build (ubuntu-latest, 3.12)` leg — full install plus full test run, serialized after the whole matrix (~2.3 min on the critical path). The 3.12 Linux leg now uploads `.coverage` as an artifact and the comment job just downloads it (`relative_files = true` was already set, which is what makes the data portable across jobs).

2. **New `[test]` extra for the build matrix.** Test legs stop installing ruff, ty, and pre-commit. `mypy`, `types-aiofiles`, and `typing_extensions` stay in `[test]` deliberately: `test_factory_typing.py` shells out to `mypy --strict` and would silently skip without them. `[dev]` now includes `aiogzip[test]`, so `pip install -e ".[dev,csv]"` and `uv sync --all-extras` behave as before.

3. **Install with uv everywhere** (`astral-sh/setup-uv` + `uv pip install --system`). Still resolves fresh from PyPI — `uv.lock` is not consulted — so the deliberate "CI exercises new dependency releases across 3.8–3.14 before users hit them" property is preserved.

**Verification:** fresh venv with only `.[test,csv]` runs the full suite green — 850 passed, 7 skipped, all "zlib-ng not installed" (identical to current build legs; `fast-engine` covers zlib-ng). The typing test runs rather than skips. This PR's own CI run exercises the new workflow end to end.

Stacked on #43 (both touch `pyproject.toml`/`uv.lock`); will retarget to main when it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)