### PR TITLE
Fix stream correctness and stabilize benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,29 @@ All notable changes to this project will be documented in this file.
   header, compressed block, flush block, and trailer byte has been accepted.
   Zero-progress and invalid write counts raise `OSError` instead of silently
   producing a truncated or malformed archive.
+- `chunk_size`, `compresslevel`, `max_decompressed_size`, and
+  `max_rewind_cache_size` now reject floats, strings, and booleans immediately
+  with `TypeError` instead of failing later inside slicing, file I/O, or zlib.
+
+### Performance
+
+- Binary and text `writelines()` now combine small inputs into bounded batches
+  before encoding/compression, reducing coroutine and compressor-call overhead
+  while preserving streaming behavior for large inputs and failing iterators.
+
+### Maintenance
+
+- The fast text-line refill path now has a narrow first-line helper and asserts
+  that general pending consumption already happened in the two intentionally
+  inlined hot paths, removing redundant pending-state handling without adding a
+  per-line function call.
 
 ### Documentation
 
 - Clarified that `max_decompressed_size` bounds individual inflate output and
   documented continuous incremental encoding for text writers.
+- Documented bounded `writelines()` batching and strict integer-only tuning
+  parameters.
 
 ## [1.9.0] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ All notable changes to this project will be documented in this file.
   that general pending consumption already happened in the two intentionally
   inlined hot paths, removing redundant pending-state handling without adding a
   per-line function call.
+- The benchmark runner now executes each category three times by default and
+  reports median durations with metrics from the closest real sample. Use
+  `--repeat` to tune stability versus runtime. Removed an unused mypy override
+  that produced a configuration warning on every source-only type check.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to this project will be documented in this file.
   that reader unusable. The worker thread may still advance its zlib state, so
   subsequent reads and seeks raise `OSError` instead of risking skipped or
   corrupted output; close the handle and reopen the gzip file to continue.
+- Short writes from external `fileobj` sinks are now retried until every gzip
+  header, compressed block, flush block, and trailer byte has been accepted.
+  Zero-progress and invalid write counts raise `OSError` instead of silently
+  producing a truncated or malformed archive.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `max_decompressed_size` now bounds each inflate call to the remaining
+  allowance plus one byte instead of checking only after zlib returned its full
+  output. Highly compressible untrusted input can no longer allocate its entire
+  expansion before the decompression-bomb guard raises `OSError`.
+- A failed write of `flush()` output now marks the compressor stream broken.
+  Follow-up writes are rejected and `close()` does not append a misleading
+  final block or trailer to an already torn gzip member.
+- Text writers now keep one incremental encoder across `write()` calls and
+  finalize it before closing the gzip member. Stateful encodings such as
+  UTF-16 and ISO-2022-JP no longer emit repeated BOMs or reset sequences when a
+  document is written in multiple calls.
+
+### Documentation
+
+- Clarified that `max_decompressed_size` bounds individual inflate output and
+  documented continuous incremental encoding for text writers.
+
 ## [1.9.0] - 2026-07-02
 
 ### Announced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this project will be documented in this file.
   finalize it before closing the gzip member. Stateful encodings such as
   UTF-16 and ISO-2022-JP no longer emit repeated BOMs or reset sequences when a
   document is written in multiple calls.
+- Cancelling a read while decompression is running in the executor now marks
+  that reader unusable. The worker thread may still advance its zlib state, so
+  subsequent reads and seeks raise `OSError` instead of risking skipped or
+  corrupted output; close the handle and reopen the gzip file to continue.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - **Backward seeks restart decompression** from the beginning of the file, so forward-only access is much faster than mixed-direction access.
 - **Non-seekable input streams use a bounded rewind cache**. By default, up to 128 MiB of compressed input is retained so backward seeks can replay the stream; pass `max_rewind_cache_size=<bytes>` to tune this, or `None` to allow an unbounded cache.
 - **Writes past 4 GiB of uncompressed data** produce a gzip trailer whose `ISIZE` field wraps to `size & 0xFFFFFFFF` (this matches the gzip format spec and `gzip.open()`). Pass `strict_size=True` to refuse writes that would exceed the limit instead.
-- **Guard against decompression bombs** by passing `max_decompressed_size=<bytes>` when reading untrusted files; the decompressor aborts with `OSError` once the cap is exceeded.
+- **Guard against decompression bombs** by passing `max_decompressed_size=<bytes>` when reading untrusted files. The decompressor limits each inflate call to the remaining allowance (plus one byte for overflow detection) and raises `OSError` without materializing the payload beyond that bound.
 - **Use one file object per task.** An open `aiogzip` file is not safe for concurrent use by multiple `asyncio` tasks — its internal buffers and decoder/compressor state are mutated without locking, the same contract as standard-library file objects. Give each task its own file object, or serialize access behind your own lock.
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - **Writes past 4 GiB of uncompressed data** produce a gzip trailer whose `ISIZE` field wraps to `size & 0xFFFFFFFF` (this matches the gzip format spec and `gzip.open()`). Pass `strict_size=True` to refuse writes that would exceed the limit instead.
 - **Guard against decompression bombs** by passing `max_decompressed_size=<bytes>` when reading untrusted files. The decompressor limits each inflate call to the remaining allowance (plus one byte for overflow detection) and raises `OSError` without materializing the payload beyond that bound.
 - **Use one file object per task.** An open `aiogzip` file is not safe for concurrent use by multiple `asyncio` tasks — its internal buffers and decoder/compressor state are mutated without locking, the same contract as standard-library file objects. Give each task its own file object, or serialize access behind your own lock.
+- **Reopen after cancelling CPU-heavy reads.** If a task is cancelled while a large decompression call is running in the executor, the open reader becomes unusable because the worker thread cannot be stopped safely. Later reads and seeks raise `OSError`; close that handle and open a new one.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ finally:
 - **Binary I/O**: Near parity with `gzip` for bulk writes, with fast bulk reads (a full `read(-1)` of compressible data runs at several hundred MB/s); can be slower for very small chunk sizes.
 - **Concurrency**: CPU-heavy `zlib` compress/decompress calls run in the default executor above a 256 KiB threshold, so multiple gzip streams on the same event loop compress and decompress in parallel instead of serializing on the loop thread. The repo's concurrent-I/O benchmark runs ~4x faster since this landed in 1.4.0; single-stream throughput stays at parity.
 - **Line Iteration**: For the single-character newline modes (`None`, `"\n"`, `"\r"`), lines are bulk-split per chunk and served from a batch, making `async for`/`readline()` roughly ~1.2–1.3x faster (~4M lines/sec).
+- **Batched line writes**: `writelines()` combines small binary or text inputs into bounded `chunk_size` batches, avoiding one compression call per line while preserving generator streaming.
 - **Optional faster codec**: With `aiogzip[fast]` installed, decompression uses `zlib-ng` automatically (~1.2-2x on typical data, up to ~7-10x on highly compressible bulk reads; byte-identical output), and `fast_compress=True` gives ~1.2-1.5x compression. See the [Performance Guide](https://geoff-davis.github.io/aiogzip/performance/).
 - **Memory**: Optimized buffer management for stable memory usage.
 - **JSONL**: For large gzipped JSONL files, prefer `AsyncGzipTextFile(..., newline="\n", chunk_size=512 * 1024)` to reduce line-iteration overhead.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -95,8 +95,14 @@ Options:
   --category, -c CAT    Run specific categories (comma-separated)
   --quick              Run quick benchmarks (io, compression)
   --size N             Data size in MB (default: 1)
+  --repeat N           Run each category N times, report median (default: 3)
   --output, -o FILE    Save results to JSON file
 ```
+
+Each category runs three times by default. Reported durations are medians, and
+the displayed secondary metrics come from the sample closest to that median.
+Use `--repeat 1` for a faster smoke run or a larger odd count for more stable
+release comparisons.
 
 ### Usage Examples
 

--- a/benchmarks/bench_common.py
+++ b/benchmarks/bench_common.py
@@ -9,6 +9,7 @@ import json
 import os
 import random
 import shutil
+import statistics
 import string
 import tempfile
 import time
@@ -44,6 +45,45 @@ class BenchmarkResults:
             else:
                 lines.append(f"  {key}: {value}")
         return "\n".join(lines)
+
+
+def median_results(
+    runs: List[List[BenchmarkResults]],
+) -> List[BenchmarkResults]:
+    """Aggregate repeated benchmark runs by median duration.
+
+    Metrics come from the sample closest to the median so related throughput
+    values remain internally consistent with a real run rather than being
+    combined independently.
+    """
+    if not runs:
+        return []
+
+    expected_names = [result.name for result in runs[0]]
+    expected_set = set(expected_names)
+    for run in runs[1:]:
+        if {result.name for result in run} != expected_set:
+            raise ValueError("benchmark runs produced different result sets")
+
+    lookups = [{result.name: result for result in run} for run in runs]
+    aggregated: List[BenchmarkResults] = []
+    for name in expected_names:
+        samples = [lookup[name] for lookup in lookups]
+        duration = float(statistics.median(sample.duration for sample in samples))
+        representative = min(
+            samples, key=lambda sample: abs(sample.duration - duration)
+        )
+        metrics = dict(representative.metrics)
+        metrics["suite_repeats"] = len(runs)
+        aggregated.append(
+            BenchmarkResults(
+                name=name,
+                category=representative.category,
+                duration=duration,
+                metrics=metrics,
+            )
+        )
+    return aggregated
 
 
 class TempFileManager:

--- a/benchmarks/bench_micro.py
+++ b/benchmarks/bench_micro.py
@@ -125,6 +125,32 @@ class MicroBenchmarks(BenchmarkBase):
             ops_per_sec=f"{1000 / duration:.0f}",
         )
 
+    async def benchmark_text_writelines_batching(self):
+        """Compare batched writelines against explicit per-line writes."""
+        individual_file = self.temp_mgr.get_path("micro_lines_individual.gz")
+        batched_file = self.temp_mgr.get_path("micro_lines_batched.gz")
+        lines = [f"record {i:05d}\n" for i in range(10_000)]
+
+        start = time.perf_counter()
+        async with AsyncGzipTextFile(individual_file, "wt") as f:
+            for line in lines:
+                await f.write(line)
+        individual_time = time.perf_counter() - start
+
+        start = time.perf_counter()
+        async with AsyncGzipTextFile(batched_file, "wt") as f:
+            await f.writelines(lines)
+        batched_time = time.perf_counter() - start
+
+        self.add_result(
+            "Text writelines batching (10K lines)",
+            "micro",
+            batched_time,
+            individual_time=f"{individual_time * 1000:.3f}ms",
+            batched_time=f"{batched_time * 1000:.3f}ms",
+            speedup=f"{individual_time / batched_time:.2f}x",
+        )
+
     async def benchmark_binary_readline_long_line_small_chunks(self):
         """Benchmark binary readline on long lines with tiny compressed chunks."""
         binary_file = self.temp_mgr.get_path("micro_binary_readline.gz")
@@ -162,4 +188,5 @@ class MicroBenchmarks(BenchmarkBase):
         await self.benchmark_line_iteration()
         await self.benchmark_readline_loop()
         await self.benchmark_small_writes()
+        await self.benchmark_text_writelines_batching()
         await self.benchmark_binary_readline_long_line_small_chunks()

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -15,6 +15,11 @@ import importlib
 import sys
 from pathlib import Path
 
+try:
+    from .bench_common import median_results
+except ImportError:  # Direct script execution: benchmarks/ is on sys.path.
+    from bench_common import median_results
+
 # Available benchmark categories
 CATEGORIES = {
     "io": "bench_io",
@@ -29,8 +34,8 @@ CATEGORIES = {
 QUICK_CATEGORIES = ["io", "compression"]
 
 
-async def run_category(category: str, data_size_mb: int = 1):
-    """Run benchmarks for a specific category."""
+async def run_category(category: str, data_size_mb: int = 1, repeat: int = 3):
+    """Run a category repeatedly and return median-duration results."""
     if category not in CATEGORIES:
         print(f"Error: Unknown category '{category}'")
         print(f"Available categories: {', '.join(CATEGORIES.keys())}")
@@ -52,24 +57,34 @@ async def run_category(category: str, data_size_mb: int = 1):
         return None
 
     benchmark_class = getattr(module, benchmark_class_name)
-    benchmark = benchmark_class(data_size_mb=data_size_mb)
 
     print(f"\n{'=' * 60}")
-    print(f"Running {category.upper()} Benchmarks")
+    print(f"Running {category.upper()} Benchmarks (median of {repeat} runs)")
     print(f"{'=' * 60}")
 
-    try:
-        benchmark.setup()
-        await benchmark.run_all()
-        results = benchmark.get_results()
+    repeated_results = []
+    for _ in range(repeat):
+        benchmark = benchmark_class(data_size_mb=data_size_mb)
+        try:
+            benchmark.setup()
+            await benchmark.run_all()
+            repeated_results.append(benchmark.get_results())
+        finally:
+            benchmark.cleanup()
 
-        # Print results
-        for result in results:
-            print(f"\n{result}")
+    results = median_results(repeated_results)
+    for result in results:
+        print(f"\n{result}")
 
-        return results
-    finally:
-        benchmark.cleanup()
+    return results
+
+
+def positive_int(value: str) -> int:
+    """Argparse type for strictly positive repeat counts."""
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
 
 
 async def main():
@@ -91,6 +106,12 @@ async def main():
     parser.add_argument(
         "--size", type=int, default=1, help="Data size in MB (default: 1)"
     )
+    parser.add_argument(
+        "--repeat",
+        type=positive_int,
+        default=3,
+        help="Run each category N times and report medians (default: 3)",
+    )
     parser.add_argument("--output", "-o", type=str, help="Save results to JSON file")
 
     args = parser.parse_args()
@@ -110,7 +131,9 @@ async def main():
     # Run benchmarks
     all_results = []
     for category in categories_to_run:
-        results = await run_category(category, data_size_mb=args.size)
+        results = await run_category(
+            category, data_size_mb=args.size, repeat=args.repeat
+        )
         if results:
             all_results.extend(results)
 
@@ -123,6 +146,7 @@ async def main():
         data = {
             "categories": categories_to_run,
             "data_size_mb": args.size,
+            "repeat": args.repeat,
             "results": [r.to_dict() for r in all_results],
         }
         with open(output_path, "w") as f:

--- a/docs/api.md
+++ b/docs/api.md
@@ -34,6 +34,14 @@ continuous encoded byte stream, including for stateful encodings such as
 UTF-16, UTF-32, and ISO-2022-JP. Any final encoder shift sequence is written
 before the gzip member's final block and trailer.
 
+Both binary and text `writelines()` collect small inputs into bounded
+`chunk_size` batches before compression. Inputs larger than a batch are written
+directly, so generators remain streaming and memory use stays bounded.
+
+Byte-count and compression tuning parameters are integer-only:
+`chunk_size`, `compresslevel`, `max_decompressed_size`, and
+`max_rewind_cache_size` reject floats, strings, and booleans with `TypeError`.
+
 ## `seek()` and `tell()` in text mode
 
 `AsyncGzipBinaryFile.tell()` returns the current position as a plain non-negative count of decompressed bytes, and `seek(offset)` accepts any such offset.

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,11 @@
 
 Implementation internals live in `aiogzip._common`, `aiogzip._binary`, and `aiogzip._text`. Treat those modules as private and unstable.
 
+When writing through an external asynchronous `fileobj`, its `write()` method
+may accept fewer bytes than requested as long as it returns the accepted byte
+count. `aiogzip` retries short writes until the complete gzip block is written.
+A zero-progress or otherwise invalid count raises `OSError`.
+
 ## Safety limits
 
 Set `max_decompressed_size=<bytes>` when reading untrusted gzip data. The

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,23 @@
 
 Implementation internals live in `aiogzip._common`, `aiogzip._binary`, and `aiogzip._text`. Treat those modules as private and unstable.
 
+## Safety limits
+
+Set `max_decompressed_size=<bytes>` when reading untrusted gzip data. The
+limit applies to cumulative decompressed output for the current pass through
+the stream. Each inflate call is restricted to the remaining allowance plus
+one byte, so an over-limit member raises `OSError` without first materializing
+its full expansion in memory. Rewinding resets the accounting because the new
+read pass starts again at byte zero.
+
+## Text encodings
+
+`AsyncGzipTextFile` keeps one incremental encoder for the lifetime of a write
+stream. Multiple `write()` or `writelines()` calls therefore produce one
+continuous encoded byte stream, including for stateful encodings such as
+UTF-16, UTF-32, and ISO-2022-JP. Any final encoder shift sequence is written
+before the gzip member's final block and trailer.
+
 ## `seek()` and `tell()` in text mode
 
 `AsyncGzipBinaryFile.tell()` returns the current position as a plain non-negative count of decompressed bytes, and `seek(offset)` accepts any such offset.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -155,7 +155,9 @@ asyncio.run(safe_read())
 ## Reading Untrusted Files Safely
 
 When reading gzip data from untrusted sources, cap decompressed output to avoid
-expanding a small compressed file into unbounded memory usage:
+expanding a small compressed file into unbounded memory usage. The inflater is
+limited to the remaining allowance plus one byte, so the guard does not first
+allocate the complete expanded payload:
 
 ```python
 import asyncio

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -18,6 +18,11 @@ All benchmarks were conducted on standard hardware using Python 3.12+.
 
 **Why?** `aiogzip` uses optimized UTF-8 decoding strategies (using `codecs.getincrementaldecoder`) and manages buffers efficiently to minimize encoding/decoding overhead. For the single-character newline modes (`None`, `"\n"`, `"\r"`), each decoded chunk's lines are bulk-split in one pass and served from a batch, which makes `async for` line iteration roughly **1.3x** faster than per-line scanning.
 
+For writing many small records, prefer `writelines()` over an explicit loop of
+`await f.write(line)`. It combines inputs into bounded `chunk_size` batches,
+reducing Python coroutine and compressor-call overhead without loading the full
+iterable into memory.
+
 ### Binary Operations (Tie)
 
 For bulk binary I/O, `aiogzip` matches the throughput of standard `gzip`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,10 +129,6 @@ warn_unused_configs = true
 disallow_untyped_defs = true
 check_untyped_defs = true
 
-[[tool.mypy.overrides]]
-module = ["tests.*"]
-disallow_untyped_defs = false
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -5,6 +5,7 @@ import gzip
 import io
 import os
 import warnings
+from functools import partial
 from pathlib import Path
 from typing import Any, Callable, Iterable, List, Optional, Union, cast
 
@@ -1015,15 +1016,18 @@ class AsyncGzipBinaryFile:
         # Decompress the chunk
         pieces = []
         try:
-            if len(compressed_chunk) >= _ZLIB_OFFLOAD_THRESHOLD:
-                decompressed = await _run_zlib_in_thread(
-                    self._engine.decompress, compressed_chunk
-                )
+            if self._max_decompressed_size is None:
+                if len(compressed_chunk) >= _ZLIB_OFFLOAD_THRESHOLD:
+                    decompressed = await _run_zlib_in_thread(
+                        self._engine.decompress, compressed_chunk
+                    )
+                else:
+                    decompressed = self._engine.decompress(compressed_chunk)
+                if decompressed:
+                    self._account_decompressed(len(decompressed))
+                    pieces.append(decompressed)
             else:
-                decompressed = self._engine.decompress(compressed_chunk)
-            if decompressed:
-                self._account_decompressed(len(decompressed))
-                pieces.append(decompressed)
+                pieces.extend(await self._decompress_payload_limited(compressed_chunk))
 
             # Handle multi-member gzip archives (created by append mode).
             # CPython's gzip reader ignores zero padding between/after members,
@@ -1035,15 +1039,18 @@ class AsyncGzipBinaryFile:
                     break
 
                 self._engine = _engine.decompressobj(GZIP_WBITS)
-                if len(unused) >= _ZLIB_OFFLOAD_THRESHOLD:
-                    decompressed = await _run_zlib_in_thread(
-                        self._engine.decompress, unused
-                    )
+                if self._max_decompressed_size is None:
+                    if len(unused) >= _ZLIB_OFFLOAD_THRESHOLD:
+                        decompressed = await _run_zlib_in_thread(
+                            self._engine.decompress, unused
+                        )
+                    else:
+                        decompressed = self._engine.decompress(unused)
+                    if decompressed:
+                        self._account_decompressed(len(decompressed))
+                        pieces.append(decompressed)
                 else:
-                    decompressed = self._engine.decompress(unused)
-                if decompressed:
-                    self._account_decompressed(len(decompressed))
-                    pieces.append(decompressed)
+                    pieces.extend(await self._decompress_payload_limited(unused))
                 unused = self._engine.unused_data
         except _engine.ZLIB_ERRORS as e:
             raise gzip.BadGzipFile(f"Error decompressing gzip data: {e}") from e
@@ -1053,6 +1060,42 @@ class AsyncGzipBinaryFile:
             raise
         except Exception as e:
             raise OSError(f"Unexpected error during decompression: {e}") from e
+        return pieces
+
+    async def _decompress_payload_limited(self, compressed: bytes) -> List[bytes]:
+        """Inflate one compressed span without exceeding the configured cap.
+
+        Zlib receives the remaining allowance plus one byte: that extra byte lets
+        us detect an over-limit stream without first materializing its full
+        expansion. ``unconsumed_tail`` is replayed until the input is drained or
+        the cap trips. The unlimited hot path stays inline in ``_decompress_next``
+        so readers that do not request a safety cap pay no extra coroutine call.
+        """
+        cap = self._max_decompressed_size
+        assert cap is not None
+
+        pieces: List[bytes] = []
+        pending = compressed
+        while pending:
+            remaining = cap - self._decompressed_total
+            max_length = remaining + 1
+            decompress = partial(self._engine.decompress, max_length=max_length)
+            if len(pending) >= _ZLIB_OFFLOAD_THRESHOLD:
+                decompressed = await _run_zlib_in_thread(decompress, pending)
+            else:
+                decompressed = decompress(pending)
+
+            if decompressed:
+                self._account_decompressed(len(decompressed))
+                pieces.append(decompressed)
+
+            tail = self._engine.unconsumed_tail
+            if not tail:
+                break
+            if len(tail) == len(pending) and tail == pending and not decompressed:
+                raise OSError("gzip decompressor made no progress")
+            pending = tail
+
         return pieces
 
     async def _fill_buffer(self) -> None:
@@ -1236,7 +1279,13 @@ class AsyncGzipBinaryFile:
             try:
                 flushed_data = self._engine.flush(_engine.Z_SYNC_FLUSH)
                 if flushed_data:
-                    await self._file.write(flushed_data)
+                    try:
+                        await self._file.write(flushed_data)
+                    except BaseException:
+                        # Z_SYNC_FLUSH advanced the compressor. If its output did
+                        # not reach the sink, no later bytes can repair the member.
+                        self._write_broken = True
+                        raise
 
                 # Also flush the underlying file if it has a flush method
                 flush_method = getattr(self._file, "flush", None)

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -124,6 +124,7 @@ class AsyncGzipBinaryFile:
         "_underlying_seekable",
         "_max_rewind_cache_size",
         "_write_broken",
+        "_read_broken",
         "_max_decompressed_size",
         "_decompressed_total",
         "_strict_size",
@@ -226,6 +227,7 @@ class AsyncGzipBinaryFile:
         self._underlying_seekable: bool = True
         self._max_rewind_cache_size: Optional[int] = max_rewind_cache_size
         self._write_broken: bool = False
+        self._read_broken: bool = False
         self._max_decompressed_size: Optional[int] = max_decompressed_size
         self._decompressed_total: int = 0
         self._strict_size: bool = bool(strict_size)
@@ -351,6 +353,8 @@ class AsyncGzipBinaryFile:
                     remaining -= len(chunk)
             return self._position
 
+        self._check_read_usable()
+
         if whence == os.SEEK_SET:
             target = offset
         elif whence == os.SEEK_CUR:
@@ -463,6 +467,7 @@ class AsyncGzipBinaryFile:
             raise ValueError("I/O operation on closed file.")
         if self._file is None:
             raise ValueError("File not opened. Call await open() or use async with.")
+        self._check_read_usable()
         if size is not None and size > _MAX_CHUNK_SIZE:
             raise ValueError(
                 f"peek size must be <= {_MAX_CHUNK_SIZE} bytes "
@@ -537,6 +542,7 @@ class AsyncGzipBinaryFile:
             raise ValueError("I/O operation on closed file.")
         if self._file is None:
             raise ValueError("File not opened. Call await open() or use async with.")
+        self._check_read_usable()
         view = memoryview(b)
         if view.readonly:
             raise TypeError("readinto() argument must be writable")
@@ -568,6 +574,7 @@ class AsyncGzipBinaryFile:
             raise ValueError("I/O operation on closed file.")
         if self._file is None:
             raise ValueError("File not opened. Call await open() or use async with.")
+        self._check_read_usable()
 
         if size is None:
             size = -1
@@ -614,6 +621,7 @@ class AsyncGzipBinaryFile:
             raise ValueError("I/O operation on closed file.")
         if self._file is None:
             raise ValueError("File not opened. Call await open() or use async with.")
+        self._check_read_usable()
         view = memoryview(b)
         if view.readonly:
             raise TypeError("readinto1() argument must be writable")
@@ -637,6 +645,7 @@ class AsyncGzipBinaryFile:
             raise ValueError("I/O operation on closed file.")
         if self._file is None:
             raise ValueError("File not opened. Call await open() or use async with.")
+        self._check_read_usable()
         if limit is None or limit < 0:
             # Any negative limit means "no limit", matching io.IOBase. Values
             # below -1 must not reach the arithmetic below, where they would
@@ -887,6 +896,7 @@ class AsyncGzipBinaryFile:
             raise ValueError("I/O operation on closed file.")
         if self._file is None:
             raise ValueError("File not opened. Call await open() or use async with.")
+        self._check_read_usable()
 
         if size is None:
             size = -1
@@ -969,6 +979,7 @@ class AsyncGzipBinaryFile:
         ``_fill_buffer`` extends the buffer with them for the partial-read
         paths. Returns an empty list at or after EOF.
         """
+        self._check_read_usable()
         if self._eof or self._file is None:
             return []
 
@@ -1018,7 +1029,7 @@ class AsyncGzipBinaryFile:
         try:
             if self._max_decompressed_size is None:
                 if len(compressed_chunk) >= _ZLIB_OFFLOAD_THRESHOLD:
-                    decompressed = await _run_zlib_in_thread(
+                    decompressed = await self._run_decompress_in_thread(
                         self._engine.decompress, compressed_chunk
                     )
                 else:
@@ -1041,7 +1052,7 @@ class AsyncGzipBinaryFile:
                 self._engine = _engine.decompressobj(GZIP_WBITS)
                 if self._max_decompressed_size is None:
                     if len(unused) >= _ZLIB_OFFLOAD_THRESHOLD:
-                        decompressed = await _run_zlib_in_thread(
+                        decompressed = await self._run_decompress_in_thread(
                             self._engine.decompress, unused
                         )
                     else:
@@ -1081,7 +1092,7 @@ class AsyncGzipBinaryFile:
             max_length = remaining + 1
             decompress = partial(self._engine.decompress, max_length=max_length)
             if len(pending) >= _ZLIB_OFFLOAD_THRESHOLD:
-                decompressed = await _run_zlib_in_thread(decompress, pending)
+                decompressed = await self._run_decompress_in_thread(decompress, pending)
             else:
                 decompressed = decompress(pending)
 
@@ -1097,6 +1108,26 @@ class AsyncGzipBinaryFile:
             pending = tail
 
         return pieces
+
+    def _check_read_usable(self) -> None:
+        """Reject access after cancellation may have advanced the decompressor."""
+        if self._read_broken:
+            raise OSError(
+                "read stream is broken after cancelled decompression; "
+                "close and reopen the gzip file"
+            )
+
+    async def _run_decompress_in_thread(
+        self, method: Callable[[bytes], bytes], data: bytes
+    ) -> bytes:
+        """Offload decompression and poison state if the await is cancelled."""
+        try:
+            return await _run_zlib_in_thread(method, data)
+        except asyncio.CancelledError:
+            # Cancelling the await cannot stop an already-running executor call.
+            # It may still advance the shared engine after control returns here.
+            self._read_broken = True
+            raise
 
     async def _fill_buffer(self) -> None:
         """Decompress the next compressed chunk into the read buffer.

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -279,7 +279,7 @@ class AsyncGzipBinaryFile:
                     self._header_mtime,
                     self._compresslevel,
                 )
-                await self._file.write(header)
+                await self._write_all(header)
                 self._crc = 0
                 self._input_size = 0
             else:  # read mode
@@ -836,7 +836,7 @@ class AsyncGzipBinaryFile:
 
         if compressed:
             try:
-                await self._file.write(compressed)
+                await self._write_all(compressed)
             except BaseException:
                 # File write failed after compressor already consumed input;
                 # further writes would produce a torn member.
@@ -874,6 +874,30 @@ class AsyncGzipBinaryFile:
         if view.itemsize != 1:
             return view.cast("B")
         return view
+
+    async def _write_all(self, data: bytes) -> None:
+        """Write every byte to the underlying sink or raise on no progress."""
+        if self._file is None:
+            raise ValueError("File not opened. Call await open() or use async with.")
+
+        offset = 0
+        length = len(data)
+        while offset < length:
+            written = await self._file.write(data if offset == 0 else data[offset:])
+            if not isinstance(written, int) or isinstance(written, bool):
+                raise OSError(
+                    "underlying file write() returned an invalid byte count "
+                    f"({written!r})"
+                )
+            remaining = length - offset
+            if written <= 0:
+                raise OSError("underlying file write() made no progress")
+            if written > remaining:
+                raise OSError(
+                    "underlying file write() returned more bytes than requested "
+                    f"({written} > {remaining})"
+                )
+            offset += written
 
     async def read(self, size: int = -1) -> bytes:
         """
@@ -1311,7 +1335,7 @@ class AsyncGzipBinaryFile:
                 flushed_data = self._engine.flush(_engine.Z_SYNC_FLUSH)
                 if flushed_data:
                     try:
-                        await self._file.write(flushed_data)
+                        await self._write_all(flushed_data)
                     except BaseException:
                         # Z_SYNC_FLUSH advanced the compressor. If its output did
                         # not reach the sink, no later bytes can repair the member.
@@ -1352,9 +1376,9 @@ class AsyncGzipBinaryFile:
                 # trailer would lie about the bytes actually on disk.
                 remaining_data = self._engine.flush()
                 if remaining_data:
-                    await self._file.write(remaining_data)
+                    await self._write_all(remaining_data)
                 trailer = _build_gzip_trailer(self._crc, self._input_size)
-                await self._file.write(trailer)
+                await self._write_all(trailer)
         except BaseException:
             write_failed = True
             raise

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -30,6 +30,7 @@ from ._common import (
     _validate_chunk_size,
     _validate_compresslevel,
     _validate_filename,
+    _validate_optional_positive_int,
     _validate_original_filename,
 )
 
@@ -166,10 +167,8 @@ class AsyncGzipBinaryFile:
         # Validate inputs using shared validation functions
         _validate_filename(filename, fileobj)
         _validate_chunk_size(chunk_size)
-        if max_decompressed_size is not None and max_decompressed_size <= 0:
-            raise ValueError("max_decompressed_size must be a positive integer")
-        if max_rewind_cache_size is not None and max_rewind_cache_size <= 0:
-            raise ValueError("max_rewind_cache_size must be a positive integer")
+        _validate_optional_positive_int(max_decompressed_size, "max_decompressed_size")
+        _validate_optional_positive_int(max_rewind_cache_size, "max_rewind_cache_size")
 
         # Validate mode and derive file characteristics
         mode_op, saw_b, saw_t, plus = _parse_mode_tokens(mode)
@@ -738,14 +737,45 @@ class AsyncGzipBinaryFile:
         return lines
 
     async def writelines(self, lines: Iterable[bytes]) -> None:
-        """Write a sequence of bytes-like lines to the binary stream."""
+        """Write bytes-like lines in bounded batches without adding separators."""
         if not self._writing_mode:
             raise OSError("File not open for writing")
         if self._is_closed:
             raise ValueError("I/O operation on closed file.")
 
-        for line in lines:
-            await self.write(line)
+        pending = bytearray()
+        iterator = iter(lines)
+        while True:
+            try:
+                line = next(iterator)
+            except StopIteration:
+                break
+            except BaseException:
+                if pending:
+                    await self.write(pending)
+                raise
+
+            try:
+                data = self._coerce_byteslike(line)
+            except BaseException:
+                if pending:
+                    await self.write(pending)
+                raise
+
+            length = len(data)
+            if length >= self._chunk_size:
+                if pending:
+                    await self.write(pending)
+                    pending.clear()
+                await self.write(data)
+            else:
+                if pending and len(pending) + length > self._chunk_size:
+                    await self.write(pending)
+                    pending.clear()
+                pending.extend(data)
+
+        if pending:
+            await self.write(pending)
 
     def readable(self) -> bool:
         return self._mode_op == "r"
@@ -1003,7 +1033,6 @@ class AsyncGzipBinaryFile:
         ``_fill_buffer`` extends the buffer with them for the partial-read
         paths. Returns an empty list at or after EOF.
         """
-        self._check_read_usable()
         if self._eof or self._file is None:
             return []
 

--- a/src/aiogzip/_common.py
+++ b/src/aiogzip/_common.py
@@ -101,6 +101,8 @@ def _validate_chunk_size(chunk_size: int) -> None:
     Raises:
         ValueError: If chunk size is invalid
     """
+    if not isinstance(chunk_size, int) or isinstance(chunk_size, bool):
+        raise TypeError("Chunk size must be an integer")
     if chunk_size <= 0:
         raise ValueError("Chunk size must be positive")
     if chunk_size > _MAX_CHUNK_SIZE:
@@ -119,8 +121,20 @@ def _validate_compresslevel(compresslevel: int) -> None:
     Raises:
         ValueError: If compression level is not between -1 and 9
     """
+    if not isinstance(compresslevel, int) or isinstance(compresslevel, bool):
+        raise TypeError("Compression level must be an integer")
     if not (-1 <= compresslevel <= 9):
         raise ValueError("Compression level must be between -1 and 9")
+
+
+def _validate_optional_positive_int(value: Optional[int], name: str) -> None:
+    """Validate an optional byte-count limit shared by both stream classes."""
+    if value is None:
+        return
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"{name} must be a positive integer or None")
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
 
 
 def _normalize_mtime(mtime: Optional[Union[int, float]]) -> Optional[int]:
@@ -338,6 +352,7 @@ __all__ = [
     "_validate_filename",
     "_validate_chunk_size",
     "_validate_compresslevel",
+    "_validate_optional_positive_int",
     "_normalize_mtime",
     "_validate_original_filename",
     "_derive_header_filename",

--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -22,6 +22,7 @@ from ._common import (
     _validate_chunk_size,
     _validate_compresslevel,
     _validate_filename,
+    _validate_optional_positive_int,
     _validate_original_filename,
 )
 
@@ -158,10 +159,8 @@ class AsyncGzipTextFile:
         # Validate inputs using shared validation functions
         _validate_filename(filename, fileobj)
         _validate_chunk_size(chunk_size)
-        if max_decompressed_size is not None and max_decompressed_size <= 0:
-            raise ValueError("max_decompressed_size must be a positive integer")
-        if max_rewind_cache_size is not None and max_rewind_cache_size <= 0:
-            raise ValueError("max_rewind_cache_size must be a positive integer")
+        _validate_optional_positive_int(max_decompressed_size, "max_decompressed_size")
+        _validate_optional_positive_int(max_rewind_cache_size, "max_rewind_cache_size")
 
         # Validate text-specific parameters
         if encoding is None:
@@ -1104,38 +1103,24 @@ class AsyncGzipTextFile:
     # boundaries and stay on the buffer-accumulating path.
     _FAST_READLINE_NEWLINES = frozenset({None, "\n", "\r"})
 
-    def _take_pending_line(self) -> Optional[str]:
-        """Pop the next pre-split line, advancing the buffer offset by its length.
-
-        Advancing ``_text_buffer_offset`` exactly as ``_consume_buffer`` would
-        keeps tell()/seek() bookkeeping identical to consuming one line at a
-        time. Returns None when ``_pending_lines`` is exhausted.
-
-        This is the canonical implementation; ``__anext__`` and
-        ``_readline_fast`` inline the same logic in their hot paths (a per-line
-        method call costs ~7% throughput). Keep all three in sync.
-        """
-        idx = self._pending_idx
+    def _take_first_refilled_line(self) -> str:
+        """Take the first line immediately after a bounded batch refill."""
         pending = self._pending_lines
-        if idx < len(pending):
-            line = pending[idx]
-            self._pending_idx = idx + 1
-            self._text_buffer_offset += len(line)
-            return line
-        return None
+        assert self._pending_idx == 0 and pending
+        line = pending[0]
+        self._pending_idx = 1
+        self._text_buffer_offset += len(line)
+        return line
 
     async def _next_fast_line(self) -> Optional[str]:
         """Return the next line for a single-character terminator mode.
 
-        Serves from ``_pending_lines`` first; when those run out it bulk-splits
-        the complete lines in the buffered remainder in one C-level pass, or
-        (for a line spanning the chunk boundary or the final unterminated line)
-        accumulates across chunks exactly as the original per-line path did.
-        Returns None at end of input.
+        Called only after ``_pending_lines`` is exhausted. Bulk-splits complete
+        lines in the buffered remainder in one C-level pass, or (for a line
+        spanning the chunk boundary or the final unterminated line) accumulates
+        across chunks. Returns None at end of input.
         """
-        line = self._take_pending_line()
-        if line is not None:
-            return line
+        assert self._pending_idx >= len(self._pending_lines)
 
         term = self._line_term
         split_re = self._line_split_re
@@ -1160,7 +1145,7 @@ class AsyncGzipTextFile:
             region = buf[start : last + 1]
             self._pending_lines = split_re.findall(region)
             self._pending_idx = 0
-            return self._take_pending_line()
+            return self._take_first_refilled_line()
 
         # The remainder has no terminator: it is the head of a line that
         # continues into later chunks (or the final unterminated line). Pull it
@@ -1199,9 +1184,10 @@ class AsyncGzipTextFile:
         Returns "" at end of input. Only valid when
         ``self._line_term is not None``.
         """
-        # Inlined pending-line pop (canonical copy: _take_pending_line). Kept
-        # inline in the two hot read paths because a per-line method call
-        # measurably (~7%) lowers iteration throughput; keep the copies in sync.
+        # Pending-line consumption is inlined in the two hot read paths because
+        # a per-line method call measurably (~7%) lowers iteration throughput.
+        # Keep this block in sync with __anext__; the refill-only helper has a
+        # narrower contract and cannot consume an arbitrary pending position.
         idx = self._pending_idx
         pending = self._pending_lines
         if idx < len(pending):
@@ -1222,8 +1208,8 @@ class AsyncGzipTextFile:
             raise StopAsyncIteration
 
         if self._line_term is not None:
-            # Inlined pending-line pop (canonical copy: _take_pending_line);
-            # kept inline in this hot path for throughput. Keep copies in sync.
+            # Keep this inline block in sync with _readline_fast; a helper call
+            # in this per-line hot path measurably lowers iteration throughput.
             idx = self._pending_idx
             pending = self._pending_lines
             if idx < len(pending):
@@ -1392,8 +1378,42 @@ class AsyncGzipTextFile:
         if self._is_closed:
             raise ValueError("I/O operation on closed file.")
 
-        for line in lines:
-            await self.write(line)
+        pending: List[str] = []
+        pending_chars = 0
+        iterator = iter(lines)
+        while True:
+            try:
+                line = next(iterator)
+            except StopIteration:
+                break
+            except BaseException:
+                if pending:
+                    await self.write("".join(pending))
+                raise
+
+            if not isinstance(line, str):
+                if pending:
+                    await self.write("".join(pending))
+                await self.write(line)
+                continue
+
+            length = len(line)
+            if length >= self._chunk_size:
+                if pending:
+                    await self.write("".join(pending))
+                    pending = []
+                    pending_chars = 0
+                await self.write(line)
+            else:
+                if pending and pending_chars + length > self._chunk_size:
+                    await self.write("".join(pending))
+                    pending = []
+                    pending_chars = 0
+                pending.append(line)
+                pending_chars += length
+
+        if pending:
+            await self.write("".join(pending))
 
     async def flush(self) -> None:
         """

--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -91,6 +91,8 @@ class AsyncGzipTextFile:
         "_binary_file",
         "_is_closed",
         "_decoder",
+        "_encoder",
+        "_encoder_used",
         "_text_buffer",
         "_text_buffer_offset",
         "_trailing_cr",
@@ -207,6 +209,12 @@ class AsyncGzipTextFile:
         self._decoder = codecs.getincrementaldecoder(self._encoding)(
             errors=self._errors
         )
+        self._encoder = (
+            codecs.getincrementalencoder(self._encoding)(errors=self._errors)
+            if self._writing_mode
+            else None
+        )
+        self._encoder_used: bool = False
         self._text_buffer: str = ""  # Backing store for buffered decoded text
         self._text_buffer_offset: int = 0  # Start of unread text within _text_buffer
         self._trailing_cr: bool = False  # Track if last decoded chunk ended with \r
@@ -522,9 +530,23 @@ class AsyncGzipTextFile:
             # newline == '' means no translation; any other value treat as no translation
             pass
 
-        # Encode string to bytes
-        encoded_data = text_to_encode.encode(self._encoding, errors=self._errors)
-        await self._binary_file.write(encoded_data)
+        # Keep one encoder for the lifetime of the stream. Stateless str.encode()
+        # would emit a fresh BOM or reset sequence on every write for encodings
+        # such as UTF-16 and ISO-2022-JP.
+        encoder = self._encoder
+        assert encoder is not None
+        encoder_state = encoder.getstate()
+        encoder_was_used = self._encoder_used
+        self._encoder_used = True
+        try:
+            encoded_data = encoder.encode(text_to_encode, final=False)
+            await self._binary_file.write(encoded_data)
+        except BaseException:
+            # Preserve retryability when the binary layer rejected the write
+            # before consuming it (for example strict_size validation).
+            encoder.setstate(encoder_state)
+            self._encoder_used = encoder_was_used
+            raise
         return len(data)
 
     def _buffered_text_len(self) -> int:
@@ -1402,5 +1424,24 @@ class AsyncGzipTextFile:
         # Mark as closed immediately to prevent concurrent close attempts
         self._is_closed = True
 
-        if self._binary_file is not None:
-            await self._binary_file.close()
+        binary_file = self._binary_file
+        if binary_file is None:
+            return
+
+        encoder_failed = False
+        try:
+            if self._writing_mode and self._encoder_used:
+                encoder = self._encoder
+                assert encoder is not None
+                final_data = encoder.encode("", final=True)
+                if final_data:
+                    await binary_file.write(final_data)
+        except BaseException:
+            encoder_failed = True
+            raise
+        finally:
+            try:
+                await binary_file.close()
+            except BaseException:
+                if not encoder_failed:
+                    raise

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -1,0 +1,61 @@
+import argparse
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+BENCHMARKS_DIR = Path(__file__).resolve().parents[1] / "benchmarks"
+sys.path.insert(0, str(BENCHMARKS_DIR))
+bench_common = importlib.import_module("bench_common")
+run_benchmarks = importlib.import_module("run_benchmarks")
+BenchmarkResults = bench_common.BenchmarkResults
+median_results = bench_common.median_results
+positive_int = run_benchmarks.positive_int
+
+
+def _result(name, duration, marker):
+    return BenchmarkResults(
+        name=name,
+        category="test",
+        duration=duration,
+        metrics={"marker": marker},
+    )
+
+
+def test_median_results_uses_representative_sample_metrics():
+    runs = [
+        [_result("operation", 1.0, "fast")],
+        [_result("operation", 100.0, "slow")],
+        [_result("operation", 3.0, "median")],
+    ]
+
+    [result] = median_results(runs)
+
+    assert result.duration == 3.0
+    assert result.metrics == {"marker": "median", "suite_repeats": 3}
+
+
+def test_median_results_preserves_first_run_order():
+    runs = [
+        [_result("second", 2.0, "a"), _result("first", 1.0, "b")],
+        [_result("first", 3.0, "c"), _result("second", 4.0, "d")],
+    ]
+
+    assert [result.name for result in median_results(runs)] == ["second", "first"]
+
+
+def test_median_results_rejects_mismatched_runs():
+    with pytest.raises(ValueError, match="different result sets"):
+        median_results([[_result("one", 1.0, "a")], [_result("two", 2.0, "b")]])
+
+
+@pytest.mark.parametrize(("value", "expected"), [("1", 1), ("5", 5)])
+def test_positive_int(value, expected):
+    assert positive_int(value) == expected
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_positive_int_rejects_nonpositive_values(value):
+    with pytest.raises(argparse.ArgumentTypeError, match="positive integer"):
+        positive_int(value)

--- a/tests/test_edge_cases_and_errors.py
+++ b/tests/test_edge_cases_and_errors.py
@@ -25,6 +25,21 @@ class TestEdgeCasesAndErrors:
         ):
             AsyncGzipBinaryFile("test.gz", mode="wb", compresslevel=10)
 
+    @pytest.mark.parametrize("invalid", [1.5, "1024", True])
+    def test_integer_only_size_and_compression_parameters(self, invalid):
+        for cls, mode in (
+            (AsyncGzipBinaryFile, "wb"),
+            (AsyncGzipTextFile, "wt"),
+        ):
+            with pytest.raises(TypeError, match="Chunk size must be an integer"):
+                cls("test.gz", mode=mode, chunk_size=invalid)
+            with pytest.raises(TypeError, match="Compression level must be an integer"):
+                cls("test.gz", mode=mode, compresslevel=invalid)
+            with pytest.raises(TypeError, match="max_decompressed_size"):
+                cls("test.gz", mode=mode, max_decompressed_size=invalid)
+            with pytest.raises(TypeError, match="max_rewind_cache_size"):
+                cls("test.gz", mode=mode, max_rewind_cache_size=invalid)
+
     async def test_mtime_validation(self):
         """Test validation of mtime values."""
         AsyncGzipBinaryFile("test.gz", mode="wb", mtime=0xFFFFFFFF)

--- a/tests/test_fileobj.py
+++ b/tests/test_fileobj.py
@@ -41,6 +41,69 @@ class TestFileobjSupport:
                 data = await f.read()
                 assert data == b"hello fileobj"
 
+    async def test_short_writing_fileobj_is_retried_until_complete(self):
+        class ShortWriter:
+            def __init__(self, max_write):
+                self.max_write = max_write
+                self.buffer = bytearray()
+                self.calls = 0
+
+            async def write(self, data):
+                self.calls += 1
+                written = min(self.max_write, len(data))
+                self.buffer.extend(data[:written])
+                return written
+
+            async def close(self):
+                pass
+
+        payload = os.urandom(512 * 1024)
+        writer = ShortWriter(max_write=7)
+        async with AsyncGzipBinaryFile(
+            None, "wb", fileobj=writer, closefd=False, mtime=0
+        ) as f:
+            await f.write(payload)
+
+        assert writer.calls > 3
+        assert gzip.decompress(bytes(writer.buffer)) == payload
+
+    async def test_zero_progress_write_breaks_active_member(self):
+        class StallingWriter:
+            def __init__(self):
+                self.calls = 0
+
+            async def write(self, data):
+                self.calls += 1
+                if self.calls == 2:
+                    return 0
+                return len(data)
+
+            async def close(self):
+                pass
+
+        writer = StallingWriter()
+        f = AsyncGzipBinaryFile(None, "wb", fileobj=writer, closefd=False)
+        await f.open()
+        with pytest.raises(OSError, match="made no progress"):
+            await f.write(os.urandom(512 * 1024))
+        assert f._write_broken is True
+        with pytest.raises(OSError, match="broken"):
+            await f.write(b"more")
+        await f.close()
+
+    @pytest.mark.parametrize("invalid_count", [None, -1, True, 1000])
+    async def test_invalid_write_count_fails_open(self, invalid_count):
+        class InvalidWriter:
+            async def write(self, data):
+                return invalid_count
+
+            async def close(self):
+                pass
+
+        f = AsyncGzipBinaryFile(None, "wb", fileobj=InvalidWriter(), closefd=False)
+        with pytest.raises(OSError, match="invalid byte count|no progress|requested"):
+            await f.open()
+
     async def test_non_seekable_fileobj_supports_backward_seek(self):
         payload = b"abcdefghijklmnopqrstuvwxyz"
         compressed = gzip.compress(payload)

--- a/tests/test_modes_and_api.py
+++ b/tests/test_modes_and_api.py
@@ -351,3 +351,57 @@ class TestNewAPIMethods:
         finally:
             if os.path.exists(temp_file2):
                 os.unlink(temp_file2)
+
+    async def test_text_writelines_batches_small_inputs(self, temp_file, monkeypatch):
+        lines = [f"{i:03d}\n" for i in range(100)]
+        calls = []
+        original = AsyncGzipTextFile.write
+
+        async def tracking_write(self, data):
+            calls.append(len(data))
+            return await original(self, data)
+
+        monkeypatch.setattr(AsyncGzipTextFile, "write", tracking_write)
+        async with AsyncGzipTextFile(temp_file, "wt", chunk_size=32) as f:
+            await f.writelines(lines)
+
+        assert len(calls) < len(lines)
+        assert max(calls) <= 32
+        async with AsyncGzipTextFile(temp_file, "rt") as f:
+            assert await f.readlines() == lines
+
+    async def test_binary_writelines_batches_small_inputs(self, temp_file, monkeypatch):
+        lines = [f"{i:03d}\n".encode() for i in range(100)]
+        calls = []
+        original = AsyncGzipBinaryFile.write
+
+        async def tracking_write(self, data):
+            calls.append(len(data))
+            return await original(self, data)
+
+        monkeypatch.setattr(AsyncGzipBinaryFile, "write", tracking_write)
+        async with AsyncGzipBinaryFile(temp_file, "wb", chunk_size=32) as f:
+            await f.writelines(lines)
+
+        assert len(calls) < len(lines)
+        assert max(calls) <= 32
+        async with AsyncGzipBinaryFile(temp_file, "rb") as f:
+            assert await f.readlines() == lines
+
+    async def test_writelines_flushes_yielded_data_before_iterator_error(
+        self, temp_file
+    ):
+        class IteratorFailure(Exception):
+            pass
+
+        def broken_lines():
+            yield "first\n"
+            yield "second\n"
+            raise IteratorFailure
+
+        async with AsyncGzipTextFile(temp_file, "wt") as f:
+            with pytest.raises(IteratorFailure):
+                await f.writelines(broken_lines())
+
+        async with AsyncGzipTextFile(temp_file, "rt") as f:
+            assert await f.read() == "first\nsecond\n"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1318,3 +1318,52 @@ class TestWriteCancellationDuringOffload:
                 await f.write(b"more")
         finally:
             await f.__aexit__(None, None, None)
+
+
+class TestReadCancellationDuringOffload:
+    """Cancelling executor decompression must make later reads fail safely."""
+
+    @pytest.mark.parametrize("use_cap", [False, True])
+    async def test_cancelled_offloaded_read_marks_stream_broken(
+        self, temp_file, monkeypatch, use_cap
+    ):
+        import asyncio
+        import gzip
+
+        from aiogzip import _binary
+
+        payload = os.urandom(512 * 1024)
+        with gzip.open(temp_file, "wb") as raw:
+            raw.write(payload)
+
+        started = asyncio.Event()
+
+        async def blocking_offload(method, data):
+            started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(_binary, "_run_zlib_in_thread", blocking_offload)
+        cap = len(payload) * 2 if use_cap else None
+        f = AsyncGzipBinaryFile(
+            temp_file,
+            "rb",
+            chunk_size=1024 * 1024,
+            max_decompressed_size=cap,
+        )
+        await f.open()
+        try:
+            task = asyncio.ensure_future(f.read())
+            await started.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            assert f._read_broken is True
+            with pytest.raises(OSError, match="broken.*close and reopen"):
+                await f.read()
+            with pytest.raises(OSError, match="broken.*close and reopen"):
+                await f.peek(1)
+            with pytest.raises(OSError, match="broken.*close and reopen"):
+                await f.seek(0)
+        finally:
+            await f.close()

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -530,6 +530,27 @@ class TestMediumPriorityEdgeCases:
             data = await f.read()
             assert data == test_text
 
+    @pytest.mark.parametrize(
+        ("encoding", "parts"),
+        [
+            ("utf-16", ["Hello ", "世界", " 🚀"]),
+            ("iso2022_jp", ["日本", "語の", "文章"]),
+        ],
+    )
+    async def test_stateful_encoding_is_preserved_across_writes(
+        self, temp_file, encoding, parts
+    ):
+        """Separate text writes must share one incremental encoder state."""
+        import gzip as _gzip
+
+        async with AsyncGzipTextFile(temp_file, "wt", encoding=encoding) as f:
+            for part in parts:
+                await f.write(part)
+
+        with open(temp_file, "rb") as raw_file:
+            raw = _gzip.decompress(raw_file.read())
+        assert raw == "".join(parts).encode(encoding)
+
     async def test_write_failure_does_not_advance_accounting(self):
         """If the underlying file.write fails, CRC/size/position must not
         reflect bytes that never reached the file, and subsequent writes
@@ -580,6 +601,38 @@ class TestMediumPriorityEdgeCases:
         # a trailer that claims data never written.
         await f.__aexit__(None, None, None)
 
+    async def test_flush_write_failure_marks_stream_broken(self):
+        """A failed sync-flush write advances zlib and must poison the stream."""
+
+        class FlushFailingWriter:
+            def __init__(self):
+                self.calls = 0
+
+            async def write(self, data):
+                self.calls += 1
+                if self.calls == 2:
+                    raise OSError("simulated flush failure")
+                return len(data)
+
+            async def close(self):
+                pass
+
+        writer = FlushFailingWriter()
+        f = AsyncGzipBinaryFile(None, "wb", fileobj=writer, closefd=False)
+        await f.open()
+        await f.write(b"pending data")
+
+        with pytest.raises(OSError, match="simulated flush failure"):
+            await f.flush()
+
+        assert f._write_broken is True
+        with pytest.raises(OSError, match="broken"):
+            await f.write(b"more")
+
+        # A broken stream must not append a final block or trailer on close.
+        await f.close()
+        assert writer.calls == 2
+
     async def test_max_decompressed_size_trips_on_bomb(self, temp_file):
         """A highly compressible gzip should not expand past the caller's
         max_decompressed_size cap."""
@@ -597,6 +650,66 @@ class TestMediumPriorityEdgeCases:
                 temp_file, "rb", max_decompressed_size=1 * 1024 * 1024
             ) as f:
                 await f.read()
+
+    async def test_max_decompressed_size_bounds_each_inflate_call(
+        self, temp_file, monkeypatch
+    ):
+        """The guard must limit zlib output, not inspect it after allocation."""
+        import gzip as _gzip
+        import zlib
+
+        from aiogzip import _binary
+
+        cap = 1 * 1024 * 1024
+        with open(temp_file, "wb") as raw_file:
+            raw_file.write(_gzip.compress(b"x" * (20 * 1024 * 1024)))
+
+        class TrackingDecompressor:
+            def __init__(self, wbits):
+                self.inner = zlib.decompressobj(wbits)
+                self.limits = []
+                self.output_sizes = []
+
+            def decompress(self, data, max_length=0):
+                self.limits.append(max_length)
+                output = self.inner.decompress(data, max_length)
+                self.output_sizes.append(len(output))
+                return output
+
+            def flush(self):
+                return self.inner.flush()
+
+            @property
+            def eof(self):
+                return self.inner.eof
+
+            @property
+            def unconsumed_tail(self):
+                return self.inner.unconsumed_tail
+
+            @property
+            def unused_data(self):
+                return self.inner.unused_data
+
+        engines = []
+
+        def tracking_factory(wbits):
+            engine = TrackingDecompressor(wbits)
+            engines.append(engine)
+            return engine
+
+        monkeypatch.setattr(_binary._engine, "decompressobj", tracking_factory)
+
+        with pytest.raises(OSError, match="max_decompressed_size"):
+            async with AsyncGzipBinaryFile(
+                temp_file, "rb", max_decompressed_size=cap
+            ) as f:
+                await f.read()
+
+        assert engines
+        assert engines[0].limits
+        assert all(limit > 0 for limit in engines[0].limits)
+        assert max(engines[0].output_sizes) <= cap + 1
 
     async def test_max_decompressed_size_allows_under_cap(self, temp_file):
         """Reads comfortably under the cap should succeed."""


### PR DESCRIPTION
## Summary

- bound decompression-bomb output before full expansion and poison readers after cancelled executor decompression
- preserve stateful text encodings and handle short writes from external sinks
- batch writelines, tighten numeric validation, and simplify fast-line refill bookkeeping
- report benchmark medians from three repeated category runs
- update regression coverage, changelog, and documentation

## Validation

- 890 tests passed
- uv run pre-commit run --all-files
- full repeated benchmark suite completed successfully
- text writelines benchmark: 3.66x faster than individual writes