### PR TITLE
Prepare release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-07-09
+
 ### Fixed
 
 - `max_decompressed_size` now bounds each inflate call to the remaining

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,14 +286,14 @@ Always include:
 ## Version History
 
 - **0.3** - Major refactoring, binary/text separation
-- **1.9.0 (current)** - See `CHANGELOG.md` for the full release history. Recent
-  work includes the public `open()` lifecycle method and `__repr__`, Hypothesis
-  parity tests against stdlib gzip, the optional zlib-ng codec
-  (`aiogzip[fast]`), batched readline splitting, the 256 KiB default chunk
-  size, the rewind cache for non-seekable streams, decompression-bomb guards
-  (`max_decompressed_size`), `strict_size`, and zlib executor offload.
+- **1.9.1 (current)** - See `CHANGELOG.md` for the full release history. Recent
+  work bounds decompression-bomb output before allocation, preserves stateful
+  text encoders across writes, rejects reuse after cancelled decompression,
+  completes short external writes, batches `writelines()`, tightens tuning
+  parameter validation, and reports median benchmark results from repeated
+  runs.
 
 ---
 
-**Last Updated:** 2026-07-06
+**Last Updated:** 2026-07-09
 **Maintainer Notes:** Keep this file updated with new gotchas and best practices!

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -19,7 +19,7 @@ from ._common import (
 )
 from ._text import AsyncGzipTextFile
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 
 # Mode strings that select a text stream (they contain a 't'). The factory
 # parses modes character-by-character and is permutation-tolerant, so these


### PR DESCRIPTION
## Summary
- publish the stream-correctness fixes and write-path performance improvements as v1.9.1
- move the accumulated changelog entries into the dated v1.9.1 section
- update package and maintainer-facing version documentation

## Validation
- uv run pytest -q (890 passed)
- uv run pre-commit run --all-files
- uv build --out-dir /tmp/aiogzip-dist-1.9.1
- twine check on wheel and source distribution