### PR TITLE
Modernize package license metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Packaging
+
+- Switched the build backend from setuptools to `flit_core` so source builds
+  keep working on Python 3.8 while adopting modern PEP 639 metadata. The
+  project now publishes an SPDX `MIT` license expression and explicit license
+  file without deprecated license classifiers or build warnings.
+
 ## [1.9.1] - 2026-07-09
 
 ### Fixed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,0 @@
-# Explicit sdist contents so builds do not depend on which setuptools
-# file-finder plugins happen to be installed in the build environment.
-include CHANGELOG.md
-include SECURITY.md
-include mkdocs.yml
-recursive-include tests *.py
-recursive-include docs *.md
-recursive-include scripts *.py *.sh
-recursive-include benchmarks *.py *.md

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Contributions are welcome! This project uses `setuptools` for packaging and modern tooling for quality assurance.
+Contributions are welcome! This project uses `flit_core` for packaging and modern tooling for quality assurance.
 
 ## Development Setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,6 @@
 [build-system]
-# NOTE: PEP 639 (license = "MIT" SPDX string + license-files) is deferred to
-# 2.0: it needs setuptools >= 77, which requires Python >= 3.9 at build time,
-# and CI's editable install on the 3.8 leg builds from source. Until 3.8/3.9
-# are dropped, keep the legacy license table below despite the deprecation
-# warning from newer setuptools.
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["flit_core>=3.11,<5"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "aiogzip"
@@ -16,14 +11,12 @@ authors = [
 description = "Asynchronous gzip file reading and writing for Python asyncio — aiofiles-style API, streaming text/binary modes, decompression-bomb guards, optional zlib-ng acceleration."
 readme = "README.md"
 requires-python = ">=3.8"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 keywords = ["gzip", "async", "asyncio", "compression", "decompression", "aiofiles", "zlib", "zlib-ng", "file-io"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    # Remove this classifier when the PEP 639 migration lands in 2.0 (639
-    # forbids license classifiers alongside an SPDX license expression).
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -90,15 +83,16 @@ Changelog = "https://github.com/geoff-davis/aiogzip/blob/main/CHANGELOG.md"
 # `uv run --python 3.8`. Remove when 3.8/3.9 support is dropped in 2.0.
 environments = ["python_full_version >= '3.10'"]
 
-[tool.setuptools]
-package-dir = {"" = "src"}
-packages = ["aiogzip"]
-
-[tool.setuptools.package-data]
-"aiogzip" = ["py.typed"]
-
-[tool.setuptools.dynamic]
-version = { attr = "aiogzip.__version__" }
+[tool.flit.sdist]
+include = [
+    "CHANGELOG.md",
+    "SECURITY.md",
+    "mkdocs.yml",
+    "benchmarks/",
+    "docs/",
+    "scripts/",
+    "tests/",
+]
 
 [tool.ruff]
 line-length = 88

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -22,14 +22,29 @@ def test_version_consistency():
     )
     assert "version" in project.get("dynamic", []), "Version must be declared dynamic"
 
-    dynamic_cfg = data["tool"]["setuptools"]["dynamic"]["version"]
-    assert dynamic_cfg["attr"] == "aiogzip.__version__", (
-        "Dynamic version should reference aiogzip.__version__"
+    build_system = data["build-system"]
+    assert build_system["build-backend"] == "flit_core.buildapi"
+    assert any(
+        requirement.startswith("flit_core>=3.11")
+        for requirement in build_system["requires"]
     )
 
     module = importlib.import_module("aiogzip")
     assert module.__version__ == aiogzip.__version__, (
         "aiogzip exposes inconsistent __version__ values"
+    )
+
+
+def test_pep639_license_metadata():
+    """License metadata should use the modern PEP 639 representation."""
+    root = Path(__file__).resolve().parents[1]
+    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+
+    project = data["project"]
+    assert project["license"] == "MIT"
+    assert project["license-files"] == ["LICENSE"]
+    assert not any(
+        classifier.startswith("License ::") for classifier in project["classifiers"]
     )
 
 


### PR DESCRIPTION
## Summary
- switch the build backend from setuptools to flit_core while preserving Python 3.8 source builds
- publish PEP 639 SPDX license metadata and remove the deprecated license classifier
- replace MANIFEST.in with explicit Flit sdist inclusions
- update packaging documentation and add metadata regression coverage

## Validation
- uv run pytest -q (891 passed)
- uv run pre-commit run --all-files
- uv build --out-dir /tmp/aiogzip-flit-dist
- twine check on wheel and source distribution
- isolated Python 3.8 installation from the source distribution
- verified Core Metadata 2.4, License-Expression: MIT, and License-File: LICENSE