### PR TITLE
Preserve compatibility in Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,19 +19,27 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # This is a library: keep compatible lower bounds when they already admit
+    # a newer release instead of silently dropping supported Python versions.
+    versioning-strategy: "increase-if-necessary"
     commit-message:
       prefix: "Update"
+    # Ruff's project pin and pre-commit hook revision must move together, which
+    # Dependabot cannot express as one update.
+    ignore:
+      - dependency-name: "ruff"
     groups:
       python-deps:
         patterns:
           - "*"
 
-  # Keep the committed uv.lock in step with pyproject bumps; the pip
-  # updater above edits pyproject.toml but never touches the lockfile.
+  # Refresh resolved development dependencies without rewriting the library's
+  # compatibility constraints in pyproject.toml.
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: "lockfile-only"
     commit-message:
       prefix: "Update"
     groups:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Maintenance
+
+- Dependabot now preserves compatible lower bounds for pip requirements and
+  limits uv updates to `uv.lock`, preventing grouped updates from dropping
+  supported Python versions or rewriting build metadata. Ruff remains a
+  manual paired update with its pre-commit hook revision.
+
 ### Packaging
 
 - Switched the build backend from setuptools to `flit_core` so source builds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,8 @@ test = [
 ]
 dev = [
     "aiogzip[test]",
-    # Keep in sync with the ruff-pre-commit rev in .pre-commit-config.yaml;
-    # dependabot bumps this pin but nothing updates pre-commit revs.
+    # Update manually with the ruff-pre-commit rev in .pre-commit-config.yaml;
+    # Dependabot ignores this pin because it cannot update both locations.
     "ruff==0.15.20",
     "ty>=0.0.1a16",
     "pre-commit",


### PR DESCRIPTION
## Summary
- keep pip lower bounds unchanged when they already admit newer releases
- restrict uv updates to uv.lock so they cannot rewrite build or compatibility metadata
- ignore Ruff in pip updates because its project pin must move with the pre-commit hook revision
- document the policy in pyproject.toml and the changelog

## Context
Dependabot PRs #50 and #51 raised dependency floors to releases that dropped Python 3.8/3.9, restored Setuptools after the Flit migration, and failed compatibility CI.

## Validation
- uv run pytest -q (891 passed)
- uv run pre-commit run --all-files
- official GitHub configuration values: increase-if-necessary for pip and lockfile-only for uv