### PR TITLE
Add package-level open(), whole-file helpers, engine diagnostics, and doc rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added `aiogzip.open()` as the recommended typed package-level entry point.
+  The existing `AsyncGzipFile()` factory remains fully supported and has
+  identical behavior.
+- Added asynchronous `aiogzip.read()` and `aiogzip.write()` helpers for small
+  binary payloads that fit in memory.
+- Added the immutable `EngineInfo` result and `engine_info()` diagnostic API,
+  which report the default compression and active decompression engines.
+
+### Documentation
+
+- Reorganized the README around installation and immediate text/binary
+  quickstarts, with detailed operational behavior moved later.
+- Added a migration guide for users of standard-library `gzip` and a focused
+  recipes page covering JSON Lines, untrusted input, reproducible output,
+  append mode, seeking, cancellation, and external async file objects.
+
 ### Maintenance
 
 - Dependabot now preserves compatible lower bounds for pip requirements and

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # aiogzip ⚡️
 
-**An asynchronous library for reading and writing gzip-compressed files.**
+An asynchronous API modeled after Python's `gzip` module for reading and
+writing gzip-compressed files.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PyPI version](https://img.shields.io/pypi/v/aiogzip.svg)](https://pypi.org/project/aiogzip/)
@@ -9,109 +10,189 @@
 [![Coverage](https://raw.githubusercontent.com/geoff-davis/aiogzip/python-coverage-comment-action-data/badge.svg)](https://github.com/geoff-davis/aiogzip/tree/python-coverage-comment-action-data)
 [![Documentation](https://img.shields.io/badge/docs-mkdocs-blue)](https://geoff-davis.github.io/aiogzip/)
 
-`aiogzip` provides a fast, simple, and asyncio-native interface for handling `.gz` files, making it a useful complement to Python's built-in `gzip` module for asynchronous applications.
-
-**🚀 [Read the Documentation](https://geoff-davis.github.io/aiogzip/)**
-
-## Features
-
-- **Truly Asynchronous**: Built with `asyncio` and `aiofiles`.
-- **High-Performance**: Optimized buffer handling for fast I/O.
-- **Drop-in Replacement**: Mimics `gzip.open()` with async `seek`, `tell`, `peek`, and `readinto` support; verified against tarfile-style access patterns and aiocsv workflows.
-- **Reproducible Archives**: Control gzip `mtime` and embedded filenames.
-- **Type-Safe**: Distinct `AsyncGzipBinaryFile` and `AsyncGzipTextFile`.
-- **`aiocsv` Ready**: Seamless integration for CSV pipelines.
-- **Optional faster codec**: Install `aiogzip[fast]` to use [`zlib-ng`](https://pypi.org/project/zlib-ng/) for decompression automatically (byte-identical output) and, with `fast_compress=True`, for compression.
-- **Predictable Performance**: Backward seeks rewind the stream and re-decompress data (same as `gzip.GzipFile`), so treat random access as O(n) and prefer forward-only patterns when possible.
-
-### Append mode and large files
-
-- **Append mode (`"ab"`, `"at"`) writes a new gzip member**. The file ends up as two (or more) concatenated gzip members. Every standards-compliant reader — including `aiogzip`, `gzip.open()`, and command-line `gunzip` — transparently concatenates the output, but each additional open writes a new member rather than extending the existing deflate stream.
-- **Backward seeks restart decompression** from the beginning of the file, so forward-only access is much faster than mixed-direction access.
-- **Non-seekable input streams use a bounded rewind cache**. By default, up to 128 MiB of compressed input is retained so backward seeks can replay the stream; pass `max_rewind_cache_size=<bytes>` to tune this, or `None` to allow an unbounded cache.
-- **Writes past 4 GiB of uncompressed data** produce a gzip trailer whose `ISIZE` field wraps to `size & 0xFFFFFFFF` (this matches the gzip format spec and `gzip.open()`). Pass `strict_size=True` to refuse writes that would exceed the limit instead.
-- **Guard against decompression bombs** by passing `max_decompressed_size=<bytes>` when reading untrusted files. The decompressor limits each inflate call to the remaining allowance (plus one byte for overflow detection) and raises `OSError` without materializing the payload beyond that bound.
-- **Use one file object per task.** An open `aiogzip` file is not safe for concurrent use by multiple `asyncio` tasks — its internal buffers and decoder/compressor state are mutated without locking, the same contract as standard-library file objects. Give each task its own file object, or serialize access behind your own lock.
-- **Reopen after cancelling CPU-heavy reads.** If a task is cancelled while a large decompression call is running in the executor, the open reader becomes unusable because the worker thread cannot be stopped safely. Later reads and seeks raise `OSError`; close that handle and open a new one.
-
-## Quickstart
+## Installation
 
 ```bash
 pip install aiogzip
+```
 
-# Optional: faster compression/decompression via zlib-ng
+Python 3.8 through 3.14 are supported by the 1.x release line.
+
+## Text-mode quickstart
+
+File methods are asynchronous, and line iteration uses `async for`:
+
+```python
+import aiogzip
+
+async with aiogzip.open("events.jsonl.gz", "rt") as f:
+    async for line in f:
+        print(line)
+```
+
+## Binary-mode quickstart
+
+```python
+import aiogzip
+
+async with aiogzip.open("payload.bin.gz", "wb") as f:
+    await f.write(b"Hello, async world!")
+
+async with aiogzip.open("payload.bin.gz", "rb") as f:
+    payload = await f.read()
+```
+
+For small files that comfortably fit in memory, use the binary whole-file
+helpers:
+
+```python
+import aiogzip
+
+data = await aiogzip.read("payload.bin.gz")
+await aiogzip.write("copy.bin.gz", data)
+```
+
+`read()` and `write()` load the entire decompressed or uncompressed payload
+into memory. Use `open()` to stream large files. The existing
+`AsyncGzipFile()` factory remains fully supported for compatibility.
+
+See the [recipes](https://geoff-davis.github.io/aiogzip/recipes/) for JSON
+Lines, untrusted input, reproducible output, append mode, seeking,
+cancellation recovery, and external async streams.
+
+## Why use aiogzip?
+
+- Async file I/O built on `asyncio` and `aiofiles`.
+- Binary and text modes with distinct, typed concrete classes.
+- Async `read`, `write`, `readline`, `seek`, `tell`, `peek`, `readinto`, and
+  line iteration.
+- Interoperable gzip output, concatenated-member reads, and append support.
+- Configurable gzip metadata for reproducible archives.
+- Bounded decompression and rewind-cache controls for untrusted or
+  non-seekable input.
+- Optional zlib-ng acceleration without a required runtime dependency.
+- Verified tarfile-style access patterns and `aiocsv` workflows.
+
+## Migrating from `gzip`
+
+The API follows `gzip`, but file operations must be awaited:
+
+| Standard library | aiogzip |
+| --- | --- |
+| `gzip.open(path, "rt")` | `aiogzip.open(path, "rt")` |
+| `f.read()` | `await f.read()` |
+| `f.readline()` | `await f.readline()` |
+| `for line in f` | `async for line in f` |
+| `f.seek(offset)` | `await f.seek(offset)` |
+| `f.close()` | `await f.close()` |
+
+Synchronous code:
+
+```python
+import gzip
+
+with gzip.open("events.jsonl.gz", "rt") as f:
+    for line in f:
+        process(line)
+```
+
+becomes asynchronous code:
+
+```python
+import aiogzip
+
+async with aiogzip.open("events.jsonl.gz", "rt") as f:
+    async for line in f:
+        await process(line)
+```
+
+Important differences and caveats:
+
+- `aiogzip` defaults to `compresslevel=6`; `gzip.open()` defaults to `9`.
+  Pass `compresslevel=9` when that parity matters.
+- Paths (including `pathlib.Path`) are accepted directly. Supported external
+  asynchronous sources and destinations are passed with `filename=None` and
+  `fileobj=...`; their `read()` or `write()` methods must be async.
+- Append modes (`"ab"` and `"at"`) create a new gzip member. Both libraries
+  transparently read concatenated members as one decompressed stream.
+- An open file object is stateful and is not safe for simultaneous use by
+  multiple tasks. Use one handle per task or serialize access.
+- Gzip has no random-access index. Backward seeks rewind and replay
+  decompression, so mixed-direction access can be O(n).
+- Cancelling an executor-backed decompression can leave that reader unusable;
+  close it and open a new handle before continuing.
+
+## Compatibility and operational behavior
+
+`aiogzip` reads and writes standard gzip streams and supports text and binary
+modes, `tarfile`-style reads, `aiocsv`, append mode, and concatenated members.
+It is an asynchronous API modeled after `gzip`, not a synchronous drop-in
+replacement.
+
+- **Lifecycle:** Prefer `async with`. When that is impractical, call
+  `await f.open()` and pair it with `await f.close()` in `finally`.
+- **Seeking:** Backward seeks replay decompression from the start. Forward
+  access is fastest. Text `tell()` may return a handle-bound opaque cookie
+  when decoder state is buffered; do not persist that cookie across reopens.
+- **Non-seekable sources:** Up to 128 MiB of compressed input is cached by
+  default for replay. Tune `max_rewind_cache_size`, or pass `None` for an
+  unbounded cache.
+- **Untrusted input:** `max_decompressed_size` caps cumulative decompressed
+  output for a read pass. Overflow raises `OSError` without first materializing
+  the complete expansion.
+- **Task safety:** Do not operate on one open handle concurrently from several
+  tasks; internal codec and buffer state is mutable and intentionally unlocked.
+- **Cancellation:** If cancellation occurs during executor-backed
+  decompression, later reads and seeks raise `OSError`. Close and reopen the
+  reader. A similarly cancelled compression makes that output member unusable;
+  discard it and start a new writer.
+- **Append mode:** Each append creates another member instead of extending the
+  existing deflate stream. Standards-compliant readers concatenate the members.
+- **Large writes:** Gzip's 32-bit `ISIZE` wraps after 4 GiB, as it does in
+  `gzip.open()`. Pass `strict_size=True` to reject a member that would cross
+  that limit.
+- **Compression metadata:** `mtime` and the embedded original filename affect
+  output bytes. Set both explicitly when reproducibility across paths matters.
+
+## Performance and optional acceleration
+
+Text bulk workflows are commonly faster than synchronous `gzip`; binary bulk
+writes are near parity, while very small calls can be slower due to async
+overhead. Large codec calls are offloaded to the default executor, allowing
+independent streams to make progress concurrently. Line iteration and
+`writelines()` use bounded batching.
+
+For large UTF-8 JSON Lines files with `\n` terminators, the measured fast path
+uses `newline="\n"` and `chunk_size=512 * 1024`. Tune memory and throughput for
+your workload rather than assuming one chunk size fits every application.
+
+Install the optional codec with:
+
+```bash
 pip install "aiogzip[fast]"
 ```
 
-When `aiogzip[fast]` is installed, decompression transparently uses `zlib-ng`
-(its output is byte-identical to stdlib `zlib`). Compression stays on stdlib by
-default so produced `.gz` bytes are unchanged; opt in per file with
-`fast_compress=True`. Set `AIOGZIP_ENGINE=stdlib` to force stdlib regardless of
-what is installed.
+When installed, zlib-ng is selected automatically for decompression.
+Compression remains on stdlib zlib so installation alone does not change gzip
+bytes; pass `fast_compress=True` per writer to opt in. Set
+`AIOGZIP_ENGINE=stdlib` to force stdlib behavior. Inspect the default selections
+for a diagnostic report:
 
 ```python
-import asyncio
-from aiogzip import AsyncGzipFile
+import aiogzip
 
-async def main():
-    # Write
-    async with AsyncGzipFile("file.gz", "wb") as f:
-        await f.write(b"Hello, async world!")
-
-    # Read
-    async with AsyncGzipFile("file.gz", "rb") as f:
-        print(await f.read())
-
-    # Deterministic metadata
-    async with AsyncGzipFile(
-        "dataset.gz", "wb", mtime=0, original_filename="dataset.csv"
-    ) as f:
-        await f.write(b"stable bytes")
-
-asyncio.run(main())
+print(aiogzip.engine_info())
 ```
 
-> **Default compression level.** As a drop-in replacement, `aiogzip` matches
-> `gzip.open()`'s API but **defaults to `compresslevel=6`** (the zlib default — a
-> better speed/ratio tradeoff), whereas `gzip.open()` defaults to `9`. Pass
-> `compresslevel=9` for byte-size parity with stdlib defaults:
->
-> ```python
-> async with AsyncGzipFile("file.gz", "wb", compresslevel=9) as f:
->     await f.write(b"...")  # same compression level as gzip.open() defaults
-> ```
+The engine names are informational, not a stable machine-readable interface.
+See the [performance guide](https://geoff-davis.github.io/aiogzip/performance/)
+for benchmarks and tuning guidance.
 
-If you cannot use `async with`, open and close explicitly with try/finally:
+## Development and contributing
 
-```python
-f = AsyncGzipFile("file.gz", "rb")
-await f.open()
-try:
-    data = await f.read()
-finally:
-    await f.close()
-```
+The 1.x line is the last to support Python 3.8 and 3.9; aiogzip 2.0 will
+require Python 3.11+. Older interpreters will continue to resolve the latest
+compatible 1.x release from PyPI.
 
-## Performance
-
-- **Text I/O**: Often ~2-3x faster than standard `gzip` in bulk text workflows.
-- **Binary I/O**: Near parity with `gzip` for bulk writes, with fast bulk reads (a full `read(-1)` of compressible data runs at several hundred MB/s); can be slower for very small chunk sizes.
-- **Concurrency**: CPU-heavy `zlib` compress/decompress calls run in the default executor above a 256 KiB threshold, so multiple gzip streams on the same event loop compress and decompress in parallel instead of serializing on the loop thread. The repo's concurrent-I/O benchmark runs ~4x faster since this landed in 1.4.0; single-stream throughput stays at parity.
-- **Line Iteration**: For the single-character newline modes (`None`, `"\n"`, `"\r"`), lines are bulk-split per chunk and served from a batch, making `async for`/`readline()` roughly ~1.2–1.3x faster (~4M lines/sec).
-- **Batched line writes**: `writelines()` combines small binary or text inputs into bounded `chunk_size` batches, avoiding one compression call per line while preserving generator streaming.
-- **Optional faster codec**: With `aiogzip[fast]` installed, decompression uses `zlib-ng` automatically (~1.2-2x on typical data, up to ~7-10x on highly compressible bulk reads; byte-identical output), and `fast_compress=True` gives ~1.2-1.5x compression. See the [Performance Guide](https://geoff-davis.github.io/aiogzip/performance/).
-- **Memory**: Optimized buffer management for stable memory usage.
-- **JSONL**: For large gzipped JSONL files, prefer `AsyncGzipTextFile(..., newline="\n", chunk_size=512 * 1024)` to reduce line-iteration overhead.
-
-See the [Performance Guide](https://geoff-davis.github.io/aiogzip/performance/) for detailed benchmarks.
-
-## Python version support
-
-`aiogzip` 1.x supports Python 3.8-3.14. **The 1.x line is the last to support
-Python 3.8 and 3.9** (both past end-of-life); `aiogzip` 2.0 will require
-Python 3.11+. Older interpreters will continue to resolve the latest 1.x
-release from PyPI automatically.
-
-## Contributing
-
-See the [Contributing Guide](https://geoff-davis.github.io/aiogzip/contributing/) for development instructions.
+See the [contributing guide](https://geoff-davis.github.io/aiogzip/contributing/)
+for setup, tests, linting, typing, documentation, and benchmark workflows.

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,8 @@
 - `AsyncGzipTextFile` — text-mode reader/writer
 - `open` — recommended factory returning the right class for a mode string (accepts `r`/`w`/`a`/`x` ops with a `b` or `t` suffix)
 - `AsyncGzipFile` — compatibility name for the same factory behavior; it remains fully supported
+- `read` — read and decompress a complete binary stream into memory
+- `write` — compress and write a complete bytes-like payload
 - `WithAsyncRead`, `WithAsyncWrite`, `WithAsyncReadWrite` — runtime-checkable protocols describing the async file objects accepted via `fileobj=`
 - `ZlibEngine` — type alias for zlib compressor/decompressor objects (currently `Any`; the concrete C types are not exposed in type stubs)
 - `GZIP_WBITS`, `GZIP_METHOD_DEFLATE`, `GZIP_OS_UNKNOWN`, and the `GZIP_FLAG_FNAME` / `GZIP_FLAG_FHCRC` / `GZIP_FLAG_FEXTRA` / `GZIP_FLAG_FCOMMENT` header-flag constants — useful when inspecting gzip headers alongside this library
@@ -20,6 +22,17 @@ async with aiogzip.open("events.jsonl.gz", "rt") as stream:
     async for line in stream:
         print(line)
 ```
+
+For small files that fit comfortably in memory, the whole-file helpers avoid
+manual lifecycle management:
+
+```python
+data = await aiogzip.read("payload.bin.gz")
+await aiogzip.write("copy.bin.gz", data, mtime=0)
+```
+
+Both helpers operate in binary mode and load the entire uncompressed payload
+into memory. Use `open()` for streaming large files.
 
 When writing through an external asynchronous `fileobj`, its `write()` method
 may accept fewer bytes than requested as long as it returns the accepted byte

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,7 @@
 - `AsyncGzipFile` — compatibility name for the same factory behavior; it remains fully supported
 - `read` — read and decompress a complete binary stream into memory
 - `write` — compress and write a complete bytes-like payload
+- `EngineInfo` and `engine_info` — immutable diagnostic information about the default compression and active decompression engines
 - `WithAsyncRead`, `WithAsyncWrite`, `WithAsyncReadWrite` — runtime-checkable protocols describing the async file objects accepted via `fileobj=`
 - `ZlibEngine` — type alias for zlib compressor/decompressor objects (currently `Any`; the concrete C types are not exposed in type stubs)
 - `GZIP_WBITS`, `GZIP_METHOD_DEFLATE`, `GZIP_OS_UNKNOWN`, and the `GZIP_FLAG_FNAME` / `GZIP_FLAG_FHCRC` / `GZIP_FLAG_FEXTRA` / `GZIP_FLAG_FCOMMENT` header-flag constants — useful when inspecting gzip headers alongside this library
@@ -33,6 +34,23 @@ await aiogzip.write("copy.bin.gz", data, mtime=0)
 
 Both helpers operate in binary mode and load the entire uncompressed payload
 into memory. Use `open()` for streaming large files.
+
+## Engine diagnostics
+
+`engine_info()` reports the default compression implementation and the active
+decompression implementation without exposing internal codec objects:
+
+```python
+import aiogzip
+
+print(aiogzip.engine_info())
+```
+
+Compression is reported as `stdlib-zlib` because that is the default even when
+zlib-ng is installed. A writer created with `fast_compress=True` opts that
+individual stream into zlib-ng; that per-stream choice is not reflected by
+`engine_info()`. The strings are human-readable diagnostics and are not a
+stable machine-readable feature-detection API.
 
 When writing through an external asynchronous `fileobj`, its `write()` method
 may accept fewer bytes than requested as long as it returns the accepted byte

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,13 +4,22 @@
 
 - `AsyncGzipBinaryFile` — binary-mode reader/writer
 - `AsyncGzipTextFile` — text-mode reader/writer
-- `AsyncGzipFile` — factory returning the right class for a mode string (accepts `r`/`w`/`a`/`x` ops with a `b` or `t` suffix)
+- `open` — recommended factory returning the right class for a mode string (accepts `r`/`w`/`a`/`x` ops with a `b` or `t` suffix)
+- `AsyncGzipFile` — compatibility name for the same factory behavior; it remains fully supported
 - `WithAsyncRead`, `WithAsyncWrite`, `WithAsyncReadWrite` — runtime-checkable protocols describing the async file objects accepted via `fileobj=`
 - `ZlibEngine` — type alias for zlib compressor/decompressor objects (currently `Any`; the concrete C types are not exposed in type stubs)
 - `GZIP_WBITS`, `GZIP_METHOD_DEFLATE`, `GZIP_OS_UNKNOWN`, and the `GZIP_FLAG_FNAME` / `GZIP_FLAG_FHCRC` / `GZIP_FLAG_FEXTRA` / `GZIP_FLAG_FCOMMENT` header-flag constants — useful when inspecting gzip headers alongside this library
 - `__version__`
 
 Implementation internals live in `aiogzip._common`, `aiogzip._binary`, and `aiogzip._text`. Treat those modules as private and unstable.
+
+```python
+import aiogzip
+
+async with aiogzip.open("events.jsonl.gz", "rt") as stream:
+    async for line in stream:
+        print(line)
+```
 
 When writing through an external asynchronous `fileobj`, its `write()` method
 may accept fewer bytes than requested as long as it returns the accepted byte

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -55,7 +55,8 @@ Core implementation is split across focused modules in `src/aiogzip`:
 - `_common.py`: shared constants, validation helpers, and protocols
 - `_binary.py`: `AsyncGzipBinaryFile` implementation
 - `_text.py`: `AsyncGzipTextFile` implementation
-- `__init__.py`: public API exports and `AsyncGzipFile` factory
+- `__init__.py`: public API exports, recommended `open()` entry point, and the
+  compatibility `AsyncGzipFile` factory
 
 When adding new internals, prefer one of the focused modules and keep `__init__.py` as the stable public API surface.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -138,11 +138,12 @@ async def main():
 
 ```python
 import asyncio
-from aiogzip import AsyncGzipFile
+
+import aiogzip
 
 async def safe_read():
     try:
-        async with AsyncGzipFile("non_existent.gz", "rb") as f:
+        async with aiogzip.open("non_existent.gz", "rb") as f:
             await f.read()
     except FileNotFoundError:
         print("File not found!")
@@ -161,10 +162,13 @@ allocate the complete expanded payload:
 
 ```python
 import asyncio
-from aiogzip import AsyncGzipFile
+
+import aiogzip
 
 async def read_untrusted(path):
-    async with AsyncGzipFile(path, "rb", max_decompressed_size=100 * 1024 * 1024) as f:
+    async with aiogzip.open(
+        path, "rb", max_decompressed_size=100 * 1024 * 1024
+    ) as f:
         return await f.read()
 
 asyncio.run(read_untrusted("upload.gz"))

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ It is designed for high-performance I/O operations, especially for text-based da
 ## Quick Links
 
 - [Installation & Usage](examples.md)
+- [Focused Recipes](recipes.md)
 - [Performance Benchmarks](performance.md)
 - [API Reference](api.md)
 - [Contributing](contributing.md)
@@ -40,15 +41,16 @@ Using `aiogzip` is as simple as using the standard `gzip` module, but with `asyn
 
 ```python
 import asyncio
-from aiogzip import AsyncGzipFile
+
+import aiogzip
 
 async def main():
     # Write binary data
-    async with AsyncGzipFile("file.gz", "wb") as f:
+    async with aiogzip.open("file.gz", "wb") as f:
         await f.write(b"Hello, async world!")
 
     # Write text data
-    async with AsyncGzipFile("file.txt.gz", "wt") as f:
+    async with aiogzip.open("file.txt.gz", "wt") as f:
         await f.write("This is a text file.")
 
 asyncio.run(main())
@@ -58,16 +60,17 @@ asyncio.run(main())
 
 ```python
 import asyncio
-from aiogzip import AsyncGzipFile
+
+import aiogzip
 
 async def main():
     # Read the entire file
-    async with AsyncGzipFile("file.gz", "rb") as f:
+    async with aiogzip.open("file.gz", "rb") as f:
         content = await f.read()
         print(content)
 
     # Iterate over lines in a text file
-    async with AsyncGzipFile("file.txt.gz", "rt") as f:
+    async with aiogzip.open("file.txt.gz", "rt") as f:
         async for line in f:
             print(line.strip())
 
@@ -82,7 +85,7 @@ impractical you can manage the lifecycle imperatively with `open()` and
 an error occurs:
 
 ```python
-f = AsyncGzipFile("file.txt.gz", "rt")
+f = aiogzip.open("file.txt.gz", "rt")
 await f.open()        # initializes the stream and returns the file; __aenter__ calls this
 try:
     async for line in f:
@@ -114,7 +117,7 @@ use async with.").
 > byte-size parity with stdlib defaults, pass `compresslevel=9`:
 >
 > ```python
-> async with AsyncGzipFile("file.gz", "wb", compresslevel=9) as f:
+> async with aiogzip.open("file.gz", "wb", compresslevel=9) as f:
 >     await f.write(b"...")
 > ```
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,163 @@
+# Recipes
+
+These recipes use the public API and the behavior covered by aiogzip's test
+suite. Use `open()` for streaming; the whole-file `read()` and `write()` helpers
+are intended for payloads that comfortably fit in memory.
+
+## Reading JSON Lines
+
+```python
+import json
+
+import aiogzip
+
+async with aiogzip.open("events.jsonl.gz", "rt") as f:
+    async for line in f:
+        event = json.loads(line)
+        await process(event)
+```
+
+For large UTF-8 JSON Lines files that are known to use `\n` terminators,
+`newline="\n"` avoids universal-newline translation. Benchmarks in this
+project use `chunk_size=512 * 1024` to reduce async read overhead; tune that
+value for your memory budget and workload.
+
+## Writing JSON Lines
+
+Write records as they become available instead of building the complete file
+in memory:
+
+```python
+import json
+
+import aiogzip
+
+async with aiogzip.open("events.jsonl.gz", "wt", newline="\n") as f:
+    async for event in events:
+        await f.write(json.dumps(event) + "\n")
+```
+
+If the records already exist as a synchronous iterable of strings,
+`await f.writelines(records)` batches small writes while keeping memory use
+bounded.
+
+## Processing untrusted gzip input
+
+Set an application-appropriate decompressed-size ceiling:
+
+```python
+import aiogzip
+
+async with aiogzip.open(
+    "uploaded-data.gz",
+    "rb",
+    max_decompressed_size=100 * 1024 * 1024,
+) as f:
+    while chunk := await f.read(64 * 1024):
+        await process(chunk)
+```
+
+The right limit depends on the file format, account quotas, and available
+resources. Crossing it raises `OSError`; the inflater is bounded to the
+remaining allowance plus one byte for overflow detection instead of first
+allocating the complete expanded payload.
+
+## Reproducible gzip output
+
+The gzip header timestamp and embedded filename both affect output bytes. Set
+`mtime` and `original_filename` explicitly when output must be identical even
+if the destination path changes:
+
+```python
+import aiogzip
+
+await aiogzip.write(
+    "build/output.gz",
+    b"stable payload",
+    mtime=0,
+    original_filename="payload.bin",
+)
+```
+
+Use `original_filename=""` to omit the filename header field. Keep the
+compression engine and level fixed as well: default compression uses stdlib
+zlib at level 6, while `fast_compress=True` can produce different valid gzip
+bytes.
+
+## Append mode and concatenated gzip members
+
+```python
+import aiogzip
+
+async with aiogzip.open("events.gz", "wb") as f:
+    await f.write(b"first\n")
+
+async with aiogzip.open("events.gz", "ab") as f:
+    await f.write(b"second\n")
+
+assert await aiogzip.read("events.gz") == b"first\nsecond\n"
+```
+
+Append mode adds a new gzip member; it does not rewrite or extend the first
+deflate stream. `aiogzip`, `gzip.open()`, and other standards-compliant readers
+return the concatenated decompressed contents.
+
+## Seeking
+
+```python
+import aiogzip
+
+async with aiogzip.open("events.gz", "rb") as f:
+    header = await f.read(100)
+    await f.seek(0)
+    complete_data = await f.read()
+```
+
+Backward seeking rewinds and replays decompression because gzip has no random
+access index. Prefer sequential processing when possible. If repeated replay
+is expensive, reopening can make lifecycle intent clearer but does not avoid
+the decompression cost required to reach a later uncompressed offset.
+
+## Cancellation
+
+Large compression and decompression calls may run in an executor. A worker
+thread cannot be stopped after its awaiting task is cancelled, so the codec
+state may still advance.
+
+If an executor-backed read is cancelled, close that reader and open a new one;
+later reads and seeks on the old handle raise `OSError`. If an executor-backed
+write is cancelled, discard that incomplete output member and create a new
+writer rather than continuing on the broken stream.
+
+```python
+import asyncio
+
+import aiogzip
+
+async def read_payload(path):
+    try:
+        return await aiogzip.read(path)
+    except asyncio.CancelledError:
+        # aiogzip.read() closes its handle before propagating cancellation.
+        raise
+```
+
+## External async file objects
+
+The `fileobj` argument accepts objects with asynchronous `read()` or `write()`
+methods. For example, an existing `aiofiles` handle can be wrapped without
+transferring ownership:
+
+```python
+import aiofiles
+
+import aiogzip
+
+async with aiofiles.open("payload.gz", "rb") as raw:
+    async with aiogzip.open(None, "rb", fileobj=raw, closefd=False) as f:
+        payload = await f.read()
+```
+
+With `closefd=False`, closing the gzip wrapper leaves the external object open.
+Pass `closefd=True` only when the wrapper should close it. Non-seekable readers
+use a bounded compressed-input replay cache for backward seeks.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Examples: examples.md
+  - Recipes: recipes.md
   - Performance: performance.md
   - API Reference: api.md
   - Contributing: contributing.md

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -18,6 +18,7 @@ from ._common import (
     WithAsyncWrite,
     ZlibEngine,
 )
+from ._engine import EngineInfo, engine_info
 from ._text import AsyncGzipTextFile
 
 __version__ = "1.9.1"
@@ -313,6 +314,7 @@ __all__ = [
     "AsyncGzipBinaryFile",
     "AsyncGzipFile",
     "AsyncGzipTextFile",
+    "EngineInfo",
     "WithAsyncRead",
     "WithAsyncReadWrite",
     "WithAsyncWrite",
@@ -327,4 +329,5 @@ __all__ = [
     "open",
     "read",
     "write",
+    "engine_info",
 ]

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -196,6 +196,64 @@ def AsyncGzipFile(
         return AsyncGzipBinaryFile(filename, mode, **kwargs)
 
 
+@overload
+def open(
+    filename: _Filename,
+    mode: _TextMode,
+    *,
+    chunk_size: int = ...,
+    encoding: Optional[str] = ...,
+    errors: Optional[str] = ...,
+    newline: Optional[str] = ...,
+    compresslevel: int = ...,
+    mtime: Optional[Union[int, float]] = ...,
+    original_filename: Optional[Union[str, bytes]] = ...,
+    fileobj: _FileObj = ...,
+    closefd: Optional[bool] = ...,
+    max_decompressed_size: Optional[int] = ...,
+    max_rewind_cache_size: Optional[int] = ...,
+    strict_size: bool = ...,
+    fast_compress: bool = ...,
+) -> AsyncGzipTextFile: ...
+
+
+@overload
+def open(
+    filename: _Filename,
+    mode: _BinaryMode = ...,
+    *,
+    chunk_size: int = ...,
+    compresslevel: int = ...,
+    mtime: Optional[Union[int, float]] = ...,
+    original_filename: Optional[Union[str, bytes]] = ...,
+    fileobj: _FileObj = ...,
+    closefd: Optional[bool] = ...,
+    max_decompressed_size: Optional[int] = ...,
+    max_rewind_cache_size: Optional[int] = ...,
+    strict_size: bool = ...,
+    fast_compress: bool = ...,
+) -> AsyncGzipBinaryFile: ...
+
+
+@overload
+def open(
+    filename: _Filename,
+    mode: str,
+    **kwargs: Any,
+) -> Union[AsyncGzipBinaryFile, AsyncGzipTextFile]: ...
+
+
+def open(
+    filename: _Filename, mode: str = "rb", **kwargs: Any
+) -> Union[AsyncGzipBinaryFile, AsyncGzipTextFile]:
+    """Open a gzip stream in binary or text mode.
+
+    This is the recommended public entry point. ``AsyncGzipFile`` remains
+    available and has identical behavior.
+    """
+    return AsyncGzipFile(filename, mode, **kwargs)
+
+
 __all__ = [
     "__version__",
     "AsyncGzipBinaryFile",
@@ -212,4 +270,5 @@ __all__ = [
     "GZIP_FLAG_FCOMMENT",
     "GZIP_METHOD_DEFLATE",
     "GZIP_OS_UNKNOWN",
+    "open",
 ]

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -5,6 +5,7 @@ from typing import Any, Literal, Optional, Union, overload
 
 from ._binary import AsyncGzipBinaryFile
 from ._common import (
+    _MAX_CHUNK_SIZE,
     GZIP_FLAG_FCOMMENT,
     GZIP_FLAG_FEXTRA,
     GZIP_FLAG_FHCRC,
@@ -110,6 +111,8 @@ _BinaryMode = Literal[
 
 _Filename = Union[str, bytes, Path, None]
 _FileObj = Optional[Union[WithAsyncRead, WithAsyncWrite, WithAsyncReadWrite]]
+_ReadFileObj = Optional[Union[WithAsyncRead, WithAsyncReadWrite]]
+_WriteFileObj = Optional[Union[WithAsyncWrite, WithAsyncReadWrite]]
 
 
 @overload
@@ -254,6 +257,57 @@ def open(
     return AsyncGzipFile(filename, mode, **kwargs)
 
 
+async def read(
+    filename: _Filename,
+    *,
+    chunk_size: int = AsyncGzipBinaryFile.DEFAULT_CHUNK_SIZE,
+    fileobj: _ReadFileObj = None,
+    closefd: Optional[bool] = None,
+    max_decompressed_size: Optional[int] = None,
+    max_rewind_cache_size: Optional[int] = _MAX_CHUNK_SIZE,
+) -> bytes:
+    """Read and decompress an entire gzip stream into memory."""
+    async with open(
+        filename,
+        "rb",
+        chunk_size=chunk_size,
+        fileobj=fileobj,
+        closefd=closefd,
+        max_decompressed_size=max_decompressed_size,
+        max_rewind_cache_size=max_rewind_cache_size,
+    ) as stream:
+        return await stream.read()
+
+
+async def write(
+    filename: _Filename,
+    data: Union[bytes, bytearray, memoryview],
+    *,
+    chunk_size: int = AsyncGzipBinaryFile.DEFAULT_CHUNK_SIZE,
+    compresslevel: int = 6,
+    mtime: Optional[Union[int, float]] = None,
+    original_filename: Optional[Union[str, bytes]] = None,
+    fileobj: _WriteFileObj = None,
+    closefd: Optional[bool] = None,
+    strict_size: bool = False,
+    fast_compress: bool = False,
+) -> None:
+    """Compress and write an entire bytes-like payload to a gzip stream."""
+    async with open(
+        filename,
+        "wb",
+        chunk_size=chunk_size,
+        compresslevel=compresslevel,
+        mtime=mtime,
+        original_filename=original_filename,
+        fileobj=fileobj,
+        closefd=closefd,
+        strict_size=strict_size,
+        fast_compress=fast_compress,
+    ) as stream:
+        await stream.write(data)
+
+
 __all__ = [
     "__version__",
     "AsyncGzipBinaryFile",
@@ -271,4 +325,6 @@ __all__ = [
     "GZIP_METHOD_DEFLATE",
     "GZIP_OS_UNKNOWN",
     "open",
+    "read",
+    "write",
 ]

--- a/src/aiogzip/_engine.py
+++ b/src/aiogzip/_engine.py
@@ -16,6 +16,7 @@ reproducible error behaviour or debugging).
 import importlib
 import os
 import zlib
+from dataclasses import dataclass
 from typing import Any, Tuple, Type
 
 from ._common import ZlibEngine
@@ -40,6 +41,15 @@ _FORCE_STDLIB = os.environ.get("AIOGZIP_ENGINE", "").strip().lower() == "stdlib"
 
 # Whether zlib-ng is available *and* permitted as the active engine.
 _HAVE_ZNG = _zng is not None and not _FORCE_STDLIB
+
+
+@dataclass(frozen=True)
+class EngineInfo:
+    """Human-readable codec selections used by aiogzip by default."""
+
+    compression: str
+    decompression: str
+
 
 # Errors raised by the deflate engines. zlib-ng's (and isal's) error type is
 # NOT zlib.error nor a subclass of it, so callers that mean to catch decode
@@ -94,3 +104,16 @@ def have_fast_engine() -> bool:
 def decompress_engine_name() -> str:
     """Name of the engine backing decompression: ``"zlib-ng"`` or ``"stdlib"``."""
     return "zlib-ng" if _HAVE_ZNG else "stdlib"
+
+
+def engine_info() -> EngineInfo:
+    """Return the default compression and active decompression engines.
+
+    Compression remains on stdlib zlib unless a writer opts into zlib-ng with
+    ``fast_compress=True``. The returned strings are intended for diagnostics,
+    not machine-readable feature detection.
+    """
+    return EngineInfo(
+        compression="stdlib-zlib",
+        decompression="zlib-ng" if _HAVE_ZNG else "stdlib-zlib",
+    )

--- a/tests/test_convenience.py
+++ b/tests/test_convenience.py
@@ -1,0 +1,95 @@
+"""Tests for the whole-file read() and write() convenience functions."""
+
+import gzip
+import io
+
+import pytest
+
+import aiogzip
+
+
+@pytest.mark.parametrize("payload", [b"", b"hello world", bytes(range(256)) * 20])
+async def test_path_roundtrip(tmp_path, payload):
+    path = tmp_path / "payload.gz"
+
+    result = await aiogzip.write(path, payload)
+
+    assert result is None
+    assert await aiogzip.read(path) == payload
+
+
+async def test_write_accepts_declared_bytes_like_inputs(tmp_path):
+    inputs = [bytearray(b"mutable"), memoryview(b"view")]
+
+    for index, payload in enumerate(inputs):
+        path = tmp_path / f"payload-{index}.gz"
+        await aiogzip.write(path, payload)
+        assert await aiogzip.read(path) == bytes(payload)
+
+
+async def test_async_file_objects_roundtrip():
+    class AsyncBuffer:
+        def __init__(self, data=b""):
+            self.buffer = io.BytesIO(data)
+            self.closed = False
+
+        async def read(self, size=-1):
+            return self.buffer.read(size)
+
+        async def write(self, data):
+            return self.buffer.write(data)
+
+        async def close(self):
+            self.closed = True
+
+    writer = AsyncBuffer()
+    await aiogzip.write(None, b"stream payload", fileobj=writer, closefd=True, mtime=0)
+
+    assert writer.closed
+    compressed = writer.buffer.getvalue()
+    reader = AsyncBuffer(compressed)
+    assert await aiogzip.read(None, fileobj=reader, closefd=True) == b"stream payload"
+    assert reader.closed
+
+
+async def test_read_limit_failure_closes_owned_file_object():
+    class TrackingReader:
+        def __init__(self, data):
+            self.buffer = io.BytesIO(data)
+            self.closed = False
+
+        async def read(self, size=-1):
+            return self.buffer.read(size)
+
+        async def close(self):
+            self.closed = True
+
+    reader = TrackingReader(gzip.compress(b"x" * 1024))
+
+    with pytest.raises(OSError, match="max_decompressed_size"):
+        await aiogzip.read(
+            None,
+            fileobj=reader,
+            closefd=True,
+            max_decompressed_size=100,
+        )
+
+    assert reader.closed
+
+
+async def test_write_finalizes_gzip_stream(tmp_path):
+    path = tmp_path / "finalized.gz"
+    await aiogzip.write(path, b"complete payload", mtime=0)
+
+    assert gzip.decompress(path.read_bytes()) == b"complete payload"
+
+
+async def test_explicit_metadata_produces_deterministic_output(tmp_path):
+    path = tmp_path / "deterministic.gz"
+    kwargs = {"mtime": 0, "original_filename": "payload.bin"}
+
+    await aiogzip.write(path, b"stable payload", **kwargs)
+    first = path.read_bytes()
+    await aiogzip.write(path, b"stable payload", **kwargs)
+
+    assert path.read_bytes() == first

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -9,10 +9,11 @@ zlib.error.
 import gzip
 import importlib
 import zlib
+from dataclasses import FrozenInstanceError
 
 import pytest
 
-from aiogzip import AsyncGzipBinaryFile, _engine
+from aiogzip import AsyncGzipBinaryFile, EngineInfo, _engine, engine_info
 from aiogzip._common import GZIP_WBITS
 
 ZNG_AVAILABLE = _engine._zng is not None
@@ -47,6 +48,36 @@ class TestEngineSelection:
 
     def test_crc32_is_stdlib(self):
         assert _engine.crc32 is zlib.crc32
+
+
+class TestEngineInfo:
+    def test_reports_default_configuration(self):
+        expected_decompression = "zlib-ng" if _engine._HAVE_ZNG else "stdlib-zlib"
+
+        assert engine_info() == EngineInfo(
+            compression="stdlib-zlib",
+            decompression=expected_decompression,
+        )
+
+    @pytest.mark.parametrize(
+        ("have_zng", "expected_decompression"),
+        [(False, "stdlib-zlib"), (True, "zlib-ng")],
+    )
+    def test_tracks_optional_decompression_engine(
+        self, monkeypatch, have_zng, expected_decompression
+    ):
+        monkeypatch.setattr(_engine, "_HAVE_ZNG", have_zng)
+
+        info = engine_info()
+
+        assert info.compression == "stdlib-zlib"
+        assert info.decompression == expected_decompression
+
+    def test_result_is_immutable(self):
+        info = engine_info()
+
+        with pytest.raises(FrozenInstanceError):
+            info.compression = "changed"
 
 
 class TestEnvEscapeHatch:

--- a/tests/test_factory_api.py
+++ b/tests/test_factory_api.py
@@ -5,6 +5,44 @@ import gzip
 import pytest
 
 from aiogzip import AsyncGzipBinaryFile, AsyncGzipFile, AsyncGzipTextFile
+from aiogzip import open as gzip_open
+
+
+class TestOpenFactory:
+    """Tests for the recommended package-level open() entry point."""
+
+    async def test_binary_roundtrip(self, temp_file, sample_data):
+        async with gzip_open(temp_file, "wb") as stream:
+            assert isinstance(stream, AsyncGzipBinaryFile)
+            await stream.write(sample_data)
+
+        async with gzip_open(temp_file, "rb") as stream:
+            assert isinstance(stream, AsyncGzipBinaryFile)
+            assert await stream.read() == sample_data
+
+    async def test_text_roundtrip(self, temp_file):
+        async with gzip_open(temp_file, "wt", encoding="utf-8") as stream:
+            assert isinstance(stream, AsyncGzipTextFile)
+            await stream.write("hello\nworld\n")
+
+        async with gzip_open(temp_file, "rt", encoding="utf-8") as stream:
+            assert isinstance(stream, AsyncGzipTextFile)
+            assert [line async for line in stream] == ["hello\n", "world\n"]
+
+    def test_matches_async_gzip_file_factory(self):
+        alias_result = gzip_open("test.gz", "rt", newline="\n", chunk_size=1024)
+        compatibility_result = AsyncGzipFile(
+            "test.gz", "rt", newline="\n", chunk_size=1024
+        )
+
+        assert type(alias_result) is type(compatibility_result)
+        assert alias_result._mode == compatibility_result._mode
+        assert alias_result._chunk_size == compatibility_result._chunk_size
+        assert alias_result._newline == compatibility_result._newline
+
+    def test_preserves_factory_validation(self):
+        with pytest.raises(ValueError, match="Invalid mode"):
+            gzip_open("test.gz", "invalid")
 
 
 class TestAsyncGzipFile:

--- a/tests/test_public_exports.py
+++ b/tests/test_public_exports.py
@@ -22,9 +22,11 @@ def test_key_re_exports_are_stable():
         AsyncGzipBinaryFile,
         AsyncGzipFile,
         AsyncGzipTextFile,
+        EngineInfo,
         WithAsyncRead,
         WithAsyncReadWrite,
         WithAsyncWrite,
+        engine_info,
         open,
         read,
         write,
@@ -33,9 +35,11 @@ def test_key_re_exports_are_stable():
     assert AsyncGzipBinaryFile is aiogzip.AsyncGzipBinaryFile
     assert AsyncGzipTextFile is aiogzip.AsyncGzipTextFile
     assert AsyncGzipFile is aiogzip.AsyncGzipFile
+    assert EngineInfo is aiogzip.EngineInfo
     assert WithAsyncRead is aiogzip.WithAsyncRead
     assert WithAsyncWrite is aiogzip.WithAsyncWrite
     assert WithAsyncReadWrite is aiogzip.WithAsyncReadWrite
     assert open is aiogzip.open
     assert read is aiogzip.read
     assert write is aiogzip.write
+    assert engine_info is aiogzip.engine_info

--- a/tests/test_public_exports.py
+++ b/tests/test_public_exports.py
@@ -26,6 +26,8 @@ def test_key_re_exports_are_stable():
         WithAsyncReadWrite,
         WithAsyncWrite,
         open,
+        read,
+        write,
     )
 
     assert AsyncGzipBinaryFile is aiogzip.AsyncGzipBinaryFile
@@ -35,3 +37,5 @@ def test_key_re_exports_are_stable():
     assert WithAsyncWrite is aiogzip.WithAsyncWrite
     assert WithAsyncReadWrite is aiogzip.WithAsyncReadWrite
     assert open is aiogzip.open
+    assert read is aiogzip.read
+    assert write is aiogzip.write

--- a/tests/test_public_exports.py
+++ b/tests/test_public_exports.py
@@ -25,6 +25,7 @@ def test_key_re_exports_are_stable():
         WithAsyncRead,
         WithAsyncReadWrite,
         WithAsyncWrite,
+        open,
     )
 
     assert AsyncGzipBinaryFile is aiogzip.AsyncGzipBinaryFile
@@ -33,3 +34,4 @@ def test_key_re_exports_are_stable():
     assert WithAsyncRead is aiogzip.WithAsyncRead
     assert WithAsyncWrite is aiogzip.WithAsyncWrite
     assert WithAsyncReadWrite is aiogzip.WithAsyncReadWrite
+    assert open is aiogzip.open

--- a/tests/typing/check_factory_overloads.py
+++ b/tests/typing/check_factory_overloads.py
@@ -15,6 +15,8 @@ from aiogzip import (
     AsyncGzipBinaryFile,
     AsyncGzipFile,
     AsyncGzipTextFile,
+    EngineInfo,
+    engine_info,
     read,
     write,
 )
@@ -77,3 +79,10 @@ async def _check_whole_file_helpers() -> None:
     assert_type(await write(p, b"payload"), None)
     assert_type(await write(p, bytearray(b"payload")), None)
     assert_type(await write(p, memoryview(b"payload")), None)
+
+
+def _check_engine_info() -> None:
+    info = engine_info()
+    assert_type(info, EngineInfo)
+    assert_type(info.compression, str)
+    assert_type(info.decompression, str)

--- a/tests/typing/check_factory_overloads.py
+++ b/tests/typing/check_factory_overloads.py
@@ -12,11 +12,13 @@ from typing import Union
 from typing_extensions import assert_type
 
 from aiogzip import AsyncGzipBinaryFile, AsyncGzipFile, AsyncGzipTextFile
+from aiogzip import open as gzip_open
 
 p = Path("data.gz")
 
 # --- Text modes narrow to AsyncGzipTextFile ---------------------------------
 assert_type(AsyncGzipFile(p, "rt"), AsyncGzipTextFile)
+assert_type(gzip_open(p, "rt"), AsyncGzipTextFile)
 assert_type(AsyncGzipFile(p, "wt"), AsyncGzipTextFile)
 assert_type(AsyncGzipFile(p, "at"), AsyncGzipTextFile)
 assert_type(AsyncGzipFile(p, "xt"), AsyncGzipTextFile)
@@ -31,6 +33,7 @@ assert_type(
 
 # --- Binary modes narrow to AsyncGzipBinaryFile -----------------------------
 assert_type(AsyncGzipFile(p), AsyncGzipBinaryFile)  # default mode "rb"
+assert_type(gzip_open(p), AsyncGzipBinaryFile)
 assert_type(AsyncGzipFile(p, "rb"), AsyncGzipBinaryFile)
 assert_type(AsyncGzipFile(p, "wb"), AsyncGzipBinaryFile)
 assert_type(AsyncGzipFile(p, "ab"), AsyncGzipBinaryFile)
@@ -50,6 +53,9 @@ async def _check_reads() -> None:
     async with AsyncGzipFile(p, "rb") as binary_file:
         assert_type(binary_file, AsyncGzipBinaryFile)
         assert_type(await binary_file.read(), bytes)
+    async with gzip_open(p, "rt") as text_file:
+        assert_type(text_file, AsyncGzipTextFile)
+        assert_type(await text_file.read(), str)
 
 
 # --- A non-literal (dynamic) mode falls back to the union -------------------

--- a/tests/typing/check_factory_overloads.py
+++ b/tests/typing/check_factory_overloads.py
@@ -11,7 +11,13 @@ from typing import Union
 
 from typing_extensions import assert_type
 
-from aiogzip import AsyncGzipBinaryFile, AsyncGzipFile, AsyncGzipTextFile
+from aiogzip import (
+    AsyncGzipBinaryFile,
+    AsyncGzipFile,
+    AsyncGzipTextFile,
+    read,
+    write,
+)
 from aiogzip import open as gzip_open
 
 p = Path("data.gz")
@@ -64,3 +70,10 @@ def _dynamic(mode: str) -> None:
         AsyncGzipFile(p, mode),
         Union[AsyncGzipBinaryFile, AsyncGzipTextFile],
     )
+
+
+async def _check_whole_file_helpers() -> None:
+    assert_type(await read(p), bytes)
+    assert_type(await write(p, b"payload"), None)
+    assert_type(await write(p, bytearray(b"payload")), None)
+    assert_type(await write(p, memoryview(b"payload")), None)


### PR DESCRIPTION
## Summary

Usability improvements to the public API surface plus a documentation rework:

- **`aiogzip.open()`** — recommended typed package-level entry point, a thin wrapper delegating to `AsyncGzipFile` with the same overload structure (text modes narrow to `AsyncGzipTextFile`, binary to `AsyncGzipBinaryFile`, dynamic `str` falls back to the union). `AsyncGzipFile` remains fully supported with identical behavior.
- **`aiogzip.read()` / `aiogzip.write()`** — async whole-file helpers for binary payloads that fit in memory, exposing only mode-appropriate parameters; defaults match the underlying class (`compresslevel=6`, bounded rewind cache).
- **`engine_info()` / `EngineInfo`** — immutable diagnostic report of the default compression engine and active decompression engine (stdlib vs zlib-ng).
- **Docs** — README reorganized around installation and immediate quickstarts with a `gzip` migration table; new focused recipes page (JSON Lines, untrusted input, reproducible output, append mode, seeking, cancellation recovery, external async file objects).

## Testing

- 952 tests pass locally (Python 3.12), coverage 91.66% (floor 85%)
- New tests: `test_convenience.py` (roundtrips, bytes-like inputs, fileobj ownership, close-on-error, deterministic output), `TestOpenFactory`, `TestEngineInfo`, public-export stability, and mypy `assert_type` checks for the new overloads
- ruff check/format and `mypy src/` clean; Python 3.8 PEP 585 greps clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)