### PR TITLE
Add gzip inspection and async iterable streaming APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.
   binary payloads that fit in memory.
 - Added the immutable `EngineInfo` result and `engine_info()` diagnostic API,
   which report the default compression and active decompression engines.
+- Added `aiogzip.inspect()` and `aiogzip.verify()` for complete gzip integrity
+  scans that discard decompressed payload data, plus immutable
+  `GzipMemberInfo`, `GzipInfo`, and `VerificationResult` result types.
+- Added shared bounded-memory incremental gzip decoding internals with
+  concatenated-member, metadata, CRC-32, `ISIZE`, and size-limit validation.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to this project will be documented in this file.
   `GzipMemberInfo`, `GzipInfo`, and `VerificationResult` result types.
 - Added shared bounded-memory incremental gzip decoding internals with
   concatenated-member, metadata, CRC-32, `ISIZE`, and size-limit validation.
+- Added `aiogzip.decompress_chunks()` for pull-driven, bounded-output gzip
+  decompression from asynchronous byte iterables, including cumulative output
+  limits and complete-stream integrity validation.
 
 ### Documentation
 
@@ -26,6 +29,8 @@ All notable changes to this project will be documented in this file.
 - Added a migration guide for users of standard-library `gzip` and a focused
   recipes page covering JSON Lines, untrusted input, reproducible output,
   append mode, seeking, cancellation, and external async file objects.
+- Added an async-iterable streaming guide covering backpressure, validation
+  timing, untrusted-input limits, cancellation, and early exit.
 
 ### Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ All notable changes to this project will be documented in this file.
 - Added `aiogzip.decompress_chunks()` for pull-driven, bounded-output gzip
   decompression from asynchronous byte iterables, including cumulative output
   limits and complete-stream integrity validation.
+- Added `aiogzip.compress_chunks()` for pull-driven, bounded-output creation of
+  one gzip member from asynchronous byte iterables, with existing compression,
+  metadata, reproducibility, strict-size, and optional zlib-ng controls.
+- Added a shared private incremental gzip encoder alongside the incremental
+  decoder so iterable streaming uses the same header, trailer, engine,
+  executor-offload, CRC-32, and `ISIZE` rules as file operations.
 
 ### Documentation
 
@@ -30,7 +36,15 @@ All notable changes to this project will be documented in this file.
   recipes page covering JSON Lines, untrusted input, reproducible output,
   append mode, seeking, cancellation, and external async file objects.
 - Added an async-iterable streaming guide covering backpressure, validation
-  timing, untrusted-input limits, cancellation, and early exit.
+  timing, untrusted-input limits, reproducible compression, cancellation,
+  incomplete-output handling, direct pipelines, and early exit.
+
+### Security
+
+- Complete-stream decompression APIs share cumulative decompressed-size limits
+  that cap every inflate call to the remaining allowance plus one byte.
+  Iterable compression and decompression retain bounded codec/parser state and
+  do not introduce producer tasks or unbounded queues.
 
 ### Maintenance
 

--- a/README.md
+++ b/README.md
@@ -56,17 +56,22 @@ await aiogzip.write("copy.bin.gz", data)
 into memory. Use `open()` to stream large files. The existing
 `AsyncGzipFile()` factory remains fully supported for compatibility.
 
-For compressed bytes arriving from an arbitrary asynchronous source, stream
-bounded decompressed chunks without adapting the source to a file object:
+For arbitrary asynchronous byte sources, compress or decompress without
+adapting the source to a file object:
 
 ```python
 async for data in aiogzip.decompress_chunks(compressed_source()):
     await consume(data)
+
+async for data in aiogzip.compress_chunks(raw_source(), mtime=0):
+    await send(data)
 ```
 
-Complete integrity validation occurs only if the iterator is consumed to the
-end. See the [async-iterable streaming guide](https://geoff-davis.github.io/aiogzip/streaming/)
-for backpressure, limits, cancellation, and early-exit behavior.
+Complete decompression integrity validation occurs only if the iterator is
+consumed to the end. Compression output is incomplete if its source fails or
+the consumer exits early. See the
+[async-iterable streaming guide](https://geoff-davis.github.io/aiogzip/streaming/)
+for backpressure, limits, cancellation, metadata, and lifecycle behavior.
 
 See the [recipes](https://geoff-davis.github.io/aiogzip/recipes/) for JSON
 Lines, untrusted input, reproducible output, append mode, seeking,
@@ -82,7 +87,7 @@ cancellation recovery, and external async streams.
 - Configurable gzip metadata for reproducible archives.
 - Bounded decompression and rewind-cache controls for untrusted or
   non-seekable input.
-- Pull-driven decompression from arbitrary `AsyncIterable[bytes]` sources.
+- Pull-driven compression and decompression for `AsyncIterable[bytes]` sources.
 - Optional zlib-ng acceleration without a required runtime dependency.
 - Verified tarfile-style access patterns and `aiocsv` workflows.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ await aiogzip.write("copy.bin.gz", data)
 into memory. Use `open()` to stream large files. The existing
 `AsyncGzipFile()` factory remains fully supported for compatibility.
 
+For compressed bytes arriving from an arbitrary asynchronous source, stream
+bounded decompressed chunks without adapting the source to a file object:
+
+```python
+async for data in aiogzip.decompress_chunks(compressed_source()):
+    await consume(data)
+```
+
+Complete integrity validation occurs only if the iterator is consumed to the
+end. See the [async-iterable streaming guide](https://geoff-davis.github.io/aiogzip/streaming/)
+for backpressure, limits, cancellation, and early-exit behavior.
+
 See the [recipes](https://geoff-davis.github.io/aiogzip/recipes/) for JSON
 Lines, untrusted input, reproducible output, append mode, seeking,
 cancellation recovery, and external async streams.
@@ -70,6 +82,7 @@ cancellation recovery, and external async streams.
 - Configurable gzip metadata for reproducible archives.
 - Bounded decompression and rewind-cache controls for untrusted or
   non-seekable input.
+- Pull-driven decompression from arbitrary `AsyncIterable[bytes]` sources.
 - Optional zlib-ng acceleration without a required runtime dependency.
 - Verified tarfile-style access patterns and `aiocsv` workflows.
 

--- a/benchmarks/bench_inspection.py
+++ b/benchmarks/bench_inspection.py
@@ -1,0 +1,60 @@
+"""Benchmarks for complete-stream gzip inspection and verification."""
+
+import gzip
+import time
+import tracemalloc
+
+from bench_common import BenchmarkBase
+
+import aiogzip
+
+
+class InspectionBenchmarks(BenchmarkBase):
+    """Compare scan time and Python allocation peaks with full reads."""
+
+    def setup(self):
+        super().setup()
+        size = max(self.data_size_bytes, 1)
+        fixtures = {
+            "compressible": b"A" * size,
+            "incompressible": self.data_gen.generate_binary(self.data_size_mb),
+            "many-members": b"member payload\n" * max(1, size // 15),
+        }
+        self.paths = {}
+        for name, payload in fixtures.items():
+            path = self.temp_mgr.get_path(f"{name}.gz")
+            if name == "many-members":
+                member_size = max(1, len(payload) // 1000)
+                raw = b"".join(
+                    gzip.compress(payload[offset : offset + member_size], mtime=0)
+                    for offset in range(0, len(payload), member_size)
+                )
+            else:
+                raw = gzip.compress(payload, mtime=0)
+            path.write_bytes(raw)
+            self.paths[name] = path
+
+    async def _measure(self, name, operation):
+        tracemalloc.start()
+        start = time.perf_counter()
+        await operation(self.paths[name])
+        duration = time.perf_counter() - start
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        self.add_result(
+            f"{operation.__name__} ({name})",
+            "inspection",
+            duration,
+            peak_python_mb=peak / (1024 * 1024),
+            engine=aiogzip.engine_info().decompression,
+        )
+
+    async def _read_discard(self, path):
+        await aiogzip.read(path)
+
+    async def run_all(self):
+        """Benchmark verification, inspection, and full read-and-discard."""
+        for name in self.paths:
+            await self._measure(name, aiogzip.verify)
+            await self._measure(name, aiogzip.inspect)
+            await self._measure(name, self._read_discard)

--- a/benchmarks/bench_streaming.py
+++ b/benchmarks/bench_streaming.py
@@ -1,4 +1,4 @@
-"""Benchmarks for async-iterable gzip decompression."""
+"""Benchmarks for async-iterable gzip compression and decompression."""
 
 import asyncio
 import gzip
@@ -8,10 +8,11 @@ import tracemalloc
 from bench_common import BenchmarkBase
 
 import aiogzip
+from aiogzip import _engine
 
 
 class StreamingBenchmarks(BenchmarkBase):
-    """Compare iterable chunk sizes, file reads, responsiveness, and memory."""
+    """Compare iterable chunk sizes, file APIs, responsiveness, and memory."""
 
     def setup(self):
         super().setup()
@@ -21,9 +22,11 @@ class StreamingBenchmarks(BenchmarkBase):
         self.path = self.temp_mgr.get_path("streaming.gz")
         self.path.write_bytes(self.compressed)
         self.compressible_size = size
-        self.compressible = gzip.compress(b"A" * size, mtime=0)
+        self.compressible_payload = b"A" * size
+        self.compressible = gzip.compress(self.compressible_payload, mtime=0)
         self.compressible_path = self.temp_mgr.get_path("compressible.gz")
         self.compressible_path.write_bytes(self.compressible)
+        self.output_path = self.temp_mgr.get_path("streaming-output.gz")
 
     async def _source(self, data, chunk_size):
         for offset in range(0, len(data), chunk_size):
@@ -77,6 +80,62 @@ class StreamingBenchmarks(BenchmarkBase):
             engine=aiogzip.engine_info().decompression,
         )
 
+    async def _consume_compression(self, data, input_size, output_size, *, fast=False):
+        total = 0
+        async for chunk in aiogzip.compress_chunks(
+            self._source(data, input_size),
+            mtime=0,
+            fast_compress=fast,
+            output_chunk_size=output_size,
+        ):
+            total += len(chunk)
+        return total
+
+    async def _measure_compression(self, input_size, output_size, *, fast=False):
+        stop = asyncio.Event()
+        ticks = 0
+
+        async def ticker():
+            nonlocal ticks
+            while not stop.is_set():
+                ticks += 1
+                await asyncio.sleep(0)
+
+        ticker_task = asyncio.create_task(ticker())
+        start = time.perf_counter()
+        total = await self._consume_compression(
+            self.payload, input_size, output_size, fast=fast
+        )
+        duration = time.perf_counter() - start
+        stop.set()
+        await ticker_task
+        assert total > 0
+        engine = "zlib-ng" if fast and _have_fast_compression() else "stdlib-zlib"
+        label = " fast" if fast else ""
+        self.add_result(
+            f"compress_chunks{label} ({input_size // 1024}K in, "
+            f"{output_size // 1024}K out)",
+            "streaming",
+            duration,
+            compressed_bytes=total,
+            event_loop_ticks=ticks,
+            engine=engine,
+        )
+
+    async def _measure_file_writer(self):
+        start = time.perf_counter()
+        async with aiogzip.open(self.output_path, "wb", mtime=0) as stream:
+            async for chunk in self._source(self.payload, 64 * 1024):
+                await stream.write(chunk)
+        duration = time.perf_counter() - start
+        self.add_result(
+            "file writer (64K input)",
+            "streaming",
+            duration,
+            compressed_bytes=self.output_path.stat().st_size,
+            engine=aiogzip.engine_info().compression,
+        )
+
     async def _measure_memory(self, name, operation):
         tracemalloc.start()
         start = time.perf_counter()
@@ -99,8 +158,30 @@ class StreamingBenchmarks(BenchmarkBase):
     async def _read_compressible(self):
         return len(await aiogzip.read(self.compressible_path))
 
+    async def _compress_compressible(self):
+        return await self._consume_compression(
+            self.compressible_payload, 64 * 1024, 64 * 1024
+        )
+
+    async def _measure_compression_memory(self):
+        tracemalloc.start()
+        start = time.perf_counter()
+        total = await self._compress_compressible()
+        duration = time.perf_counter() - start
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        assert total > 0
+        self.add_result(
+            "compress_chunks compressible peak",
+            "streaming",
+            duration,
+            peak_python_mb=peak / (1024 * 1024),
+            compressed_bytes=total,
+            engine=aiogzip.engine_info().compression,
+        )
+
     async def run_all(self):
-        """Benchmark streaming chunk choices and the file-reader baseline."""
+        """Benchmark both iterable codecs and their file-API baselines."""
         await self._measure_stream(64 * 1024, 64 * 1024)
         await self._measure_stream(512 * 1024, 256 * 1024)
         await self._measure_file_reader()
@@ -110,3 +191,14 @@ class StreamingBenchmarks(BenchmarkBase):
         await self._measure_memory(
             "full read compressible peak", self._read_compressible
         )
+        await self._measure_compression(64 * 1024, 64 * 1024)
+        await self._measure_compression(512 * 1024, 256 * 1024)
+        if _have_fast_compression():
+            await self._measure_compression(512 * 1024, 256 * 1024, fast=True)
+        await self._measure_file_writer()
+        await self._measure_compression_memory()
+
+
+def _have_fast_compression():
+    """Return whether the optional compression engine is active."""
+    return _engine.have_fast_engine()

--- a/benchmarks/bench_streaming.py
+++ b/benchmarks/bench_streaming.py
@@ -1,0 +1,112 @@
+"""Benchmarks for async-iterable gzip decompression."""
+
+import asyncio
+import gzip
+import time
+import tracemalloc
+
+from bench_common import BenchmarkBase
+
+import aiogzip
+
+
+class StreamingBenchmarks(BenchmarkBase):
+    """Compare iterable chunk sizes, file reads, responsiveness, and memory."""
+
+    def setup(self):
+        super().setup()
+        size = max(self.data_size_bytes, 1)
+        self.payload = self.data_gen.generate_binary(self.data_size_mb)
+        self.compressed = gzip.compress(self.payload, mtime=0)
+        self.path = self.temp_mgr.get_path("streaming.gz")
+        self.path.write_bytes(self.compressed)
+        self.compressible_size = size
+        self.compressible = gzip.compress(b"A" * size, mtime=0)
+        self.compressible_path = self.temp_mgr.get_path("compressible.gz")
+        self.compressible_path.write_bytes(self.compressible)
+
+    async def _source(self, data, chunk_size):
+        for offset in range(0, len(data), chunk_size):
+            yield data[offset : offset + chunk_size]
+
+    async def _consume_stream(self, data, input_size, output_size):
+        total = 0
+        async for chunk in aiogzip.decompress_chunks(
+            self._source(data, input_size), output_chunk_size=output_size
+        ):
+            total += len(chunk)
+        return total
+
+    async def _measure_stream(self, input_size, output_size):
+        stop = asyncio.Event()
+        ticks = 0
+
+        async def ticker():
+            nonlocal ticks
+            while not stop.is_set():
+                ticks += 1
+                await asyncio.sleep(0)
+
+        ticker_task = asyncio.create_task(ticker())
+        start = time.perf_counter()
+        total = await self._consume_stream(self.compressed, input_size, output_size)
+        duration = time.perf_counter() - start
+        stop.set()
+        await ticker_task
+        assert total == len(self.payload)
+        self.add_result(
+            f"decompress_chunks ({input_size // 1024}K in, {output_size // 1024}K out)",
+            "streaming",
+            duration,
+            event_loop_ticks=ticks,
+            engine=aiogzip.engine_info().decompression,
+        )
+
+    async def _measure_file_reader(self):
+        start = time.perf_counter()
+        total = 0
+        async with aiogzip.open(self.path, "rb") as stream:
+            while chunk := await stream.read(64 * 1024):
+                total += len(chunk)
+        duration = time.perf_counter() - start
+        assert total == len(self.payload)
+        self.add_result(
+            "file reader (64K output)",
+            "streaming",
+            duration,
+            engine=aiogzip.engine_info().decompression,
+        )
+
+    async def _measure_memory(self, name, operation):
+        tracemalloc.start()
+        start = time.perf_counter()
+        total = await operation()
+        duration = time.perf_counter() - start
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        assert total == self.compressible_size
+        self.add_result(
+            name,
+            "streaming",
+            duration,
+            peak_python_mb=peak / (1024 * 1024),
+            engine=aiogzip.engine_info().decompression,
+        )
+
+    async def _stream_compressible(self):
+        return await self._consume_stream(self.compressible, 4096, 64 * 1024)
+
+    async def _read_compressible(self):
+        return len(await aiogzip.read(self.compressible_path))
+
+    async def run_all(self):
+        """Benchmark streaming chunk choices and the file-reader baseline."""
+        await self._measure_stream(64 * 1024, 64 * 1024)
+        await self._measure_stream(512 * 1024, 256 * 1024)
+        await self._measure_file_reader()
+        await self._measure_memory(
+            "decompress_chunks compressible peak", self._stream_compressible
+        )
+        await self._measure_memory(
+            "full read compressible peak", self._read_compressible
+        )

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -28,6 +28,7 @@ CATEGORIES = {
     "compression": "bench_compression",
     "scenarios": "bench_scenarios",
     "errors": "bench_errors",
+    "inspection": "bench_inspection",
     "micro": "bench_micro",
 }
 

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -29,6 +29,7 @@ CATEGORIES = {
     "scenarios": "bench_scenarios",
     "errors": "bench_errors",
     "inspection": "bench_inspection",
+    "streaming": "bench_streaming",
     "micro": "bench_micro",
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,7 @@
 - `EngineInfo` and `engine_info` — immutable diagnostic information about the default compression and active decompression engines
 - `GzipMemberInfo`, `GzipInfo`, and `inspect` — validated per-member metadata and aggregate sizes from a complete decompression scan
 - `VerificationResult` and `verify` — lightweight aggregate counts after complete integrity verification
+- `decompress_chunks` — pull-driven decompression from an `AsyncIterable[bytes]` with bounded output chunks
 - `WithAsyncRead`, `WithAsyncWrite`, `WithAsyncReadWrite` — runtime-checkable protocols describing the async file objects accepted via `fileobj=`
 - `ZlibEngine` — type alias for zlib compressor/decompressor objects (currently `Any`; the concrete C types are not exposed in type stubs)
 - `GZIP_WBITS`, `GZIP_METHOD_DEFLATE`, `GZIP_OS_UNKNOWN`, and the `GZIP_FLAG_FNAME` / `GZIP_FLAG_FHCRC` / `GZIP_FLAG_FEXTRA` / `GZIP_FLAG_FCOMMENT` header-flag constants — useful when inspecting gzip headers alongside this library
@@ -83,6 +84,28 @@ Successful return means the entire stream is valid. Corruption raises
 Zero-byte input is valid and returns zero members and zero sizes. NUL padding
 after a valid member is accepted and included in the aggregate compressed size;
 other trailing data is treated as a malformed next member.
+
+## Async-iterable decompression
+
+`decompress_chunks()` accepts only an asynchronous iterable of `bytes` and
+returns an `AsyncIterator[bytes]`. Empty source chunks are ignored, yielded
+chunks are non-empty, and `output_chunk_size` is a strict upper bound.
+
+```python
+async for data in aiogzip.decompress_chunks(
+    compressed_source(),
+    output_chunk_size=64 * 1024,
+    max_decompressed_size=1024**3,
+):
+    await consume(data)
+```
+
+The stream is validated incrementally. Payload can be yielded before its final
+CRC and trailer are available, so complete integrity validation occurs only
+when iteration ends normally. Corruption raises `gzip.BadGzipFile`, output
+limit violations raise `OSError`, invalid source items raise `TypeError`, and
+source exceptions and cancellation propagate. See the
+[streaming guide](streaming.md) for backpressure and lifecycle details.
 
 When writing through an external asynchronous `fileobj`, its `write()` method
 may accept fewer bytes than requested as long as it returns the accepted byte

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,6 +9,8 @@
 - `read` — read and decompress a complete binary stream into memory
 - `write` — compress and write a complete bytes-like payload
 - `EngineInfo` and `engine_info` — immutable diagnostic information about the default compression and active decompression engines
+- `GzipMemberInfo`, `GzipInfo`, and `inspect` — validated per-member metadata and aggregate sizes from a complete decompression scan
+- `VerificationResult` and `verify` — lightweight aggregate counts after complete integrity verification
 - `WithAsyncRead`, `WithAsyncWrite`, `WithAsyncReadWrite` — runtime-checkable protocols describing the async file objects accepted via `fileobj=`
 - `ZlibEngine` — type alias for zlib compressor/decompressor objects (currently `Any`; the concrete C types are not exposed in type stubs)
 - `GZIP_WBITS`, `GZIP_METHOD_DEFLATE`, `GZIP_OS_UNKNOWN`, and the `GZIP_FLAG_FNAME` / `GZIP_FLAG_FHCRC` / `GZIP_FLAG_FEXTRA` / `GZIP_FLAG_FCOMMENT` header-flag constants — useful when inspecting gzip headers alongside this library
@@ -51,6 +53,36 @@ zlib-ng is installed. A writer created with `fast_compress=True` opts that
 individual stream into zlib-ng; that per-stream choice is not reflected by
 `engine_info()`. The strings are human-readable diagnostics and are not a
 stable machine-readable feature-detection API.
+
+## Inspection and verification
+
+`inspect()` scans and validates the complete gzip stream but discards its
+decompressed payload. It returns one immutable `GzipMemberInfo` per member,
+including exact compressed offsets and sizes, actual uncompressed sizes,
+literal trailer `ISIZE` values, and optional header metadata. Header `mtime=0`
+is preserved as `0`; `FNAME` and `FCOMMENT` use deterministic Latin-1 decoding.
+
+```python
+import aiogzip
+
+info = await aiogzip.inspect("events.gz", max_decompressed_size=1024**3)
+for member in info.members:
+    print(member.index, member.compressed_offset, member.uncompressed_size)
+```
+
+`verify()` performs the same complete structural, deflate, CRC-32, and `ISIZE`
+validation without retaining per-member metadata:
+
+```python
+result = await aiogzip.verify("events.gz")
+print(result.member_count, result.uncompressed_size)
+```
+
+Successful return means the entire stream is valid. Corruption raises
+`gzip.BadGzipFile`; I/O and decompression-limit failures raise `OSError`.
+Zero-byte input is valid and returns zero members and zero sizes. NUL padding
+after a valid member is accepted and included in the aggregate compressed size;
+other trailing data is treated as a malformed next member.
 
 When writing through an external asynchronous `fileobj`, its `write()` method
 may accept fewer bytes than requested as long as it returns the accepted byte

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,12 +12,15 @@
 - `GzipMemberInfo`, `GzipInfo`, and `inspect` — validated per-member metadata and aggregate sizes from a complete decompression scan
 - `VerificationResult` and `verify` — lightweight aggregate counts after complete integrity verification
 - `decompress_chunks` — pull-driven decompression from an `AsyncIterable[bytes]` with bounded output chunks
+- `compress_chunks` — one-member gzip compression from an `AsyncIterable[bytes]` with bounded output chunks
 - `WithAsyncRead`, `WithAsyncWrite`, `WithAsyncReadWrite` — runtime-checkable protocols describing the async file objects accepted via `fileobj=`
 - `ZlibEngine` — type alias for zlib compressor/decompressor objects (currently `Any`; the concrete C types are not exposed in type stubs)
 - `GZIP_WBITS`, `GZIP_METHOD_DEFLATE`, `GZIP_OS_UNKNOWN`, and the `GZIP_FLAG_FNAME` / `GZIP_FLAG_FHCRC` / `GZIP_FLAG_FEXTRA` / `GZIP_FLAG_FCOMMENT` header-flag constants — useful when inspecting gzip headers alongside this library
 - `__version__`
 
-Implementation internals live in `aiogzip._common`, `aiogzip._binary`, and `aiogzip._text`. Treat those modules as private and unstable.
+Implementation internals live in `aiogzip._common`, `aiogzip._binary`,
+`aiogzip._text`, `aiogzip._inspection`, and `aiogzip._streaming`. Treat those
+modules as private and unstable.
 
 ```python
 import aiogzip
@@ -106,6 +109,25 @@ when iteration ends normally. Corruption raises `gzip.BadGzipFile`, output
 limit violations raise `OSError`, invalid source items raise `TypeError`, and
 source exceptions and cancellation propagate. See the
 [streaming guide](streaming.md) for backpressure and lifecycle details.
+
+`compress_chunks()` accepts an asynchronous iterable of uncompressed `bytes`
+and yields exactly one gzip member. It emits the header promptly, before
+requesting the first source item. Empty sources therefore produce a valid empty
+member rather than zero bytes.
+
+```python
+async for data in aiogzip.compress_chunks(
+    raw_source(),
+    mtime=0,
+    output_chunk_size=64 * 1024,
+):
+    await send(data)
+```
+
+The trailer is emitted only after the source ends normally. If the source
+raises, compression is cancelled, or output consumption stops early, bytes
+already yielded form an incomplete member and must be discarded. Compression
+levels, metadata, `strict_size`, and `fast_compress` match the file writer.
 
 When writing through an external asynchronous `fileobj`, its `write()` method
 may accept fewer bytes than requested as long as it returns the accepted byte

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,7 +132,8 @@ Backward seeks restart decompression from the beginning of the gzip stream. For 
 
 **Note:** `aiogzip` does not provide whole-buffer `compress()` or
 `decompress()` helpers analogous to `gzip.compress()` and `gzip.decompress()`.
-For asynchronous byte sources, use [`decompress_chunks()`](streaming.md).
+For asynchronous byte sources, use [`compress_chunks()` and
+`decompress_chunks()`](streaming.md).
 
 ## Resumable text processing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ It is designed for high-performance I/O operations, especially for text-based da
 
 - [Installation & Usage](examples.md)
 - [Focused Recipes](recipes.md)
+- [Async-iterable Streaming](streaming.md)
 - [Performance Benchmarks](performance.md)
 - [API Reference](api.md)
 - [Contributing](contributing.md)
@@ -129,7 +130,9 @@ Backward seeks restart decompression from the beginning of the gzip stream. For 
 
 **Concurrency:** An open `aiogzip` file is not safe for concurrent use by multiple `asyncio` tasks. Its internal buffers and decoder/compressor state are mutated without locking — the same contract as standard-library file objects. Give each task its own file object, or serialize access behind your own lock.
 
-**Note:** `aiogzip` focuses on file-based operations and does not currently support in-memory compression/decompression (e.g., `gzip.compress`/`gzip.decompress`).
+**Note:** `aiogzip` does not provide whole-buffer `compress()` or
+`decompress()` helpers analogous to `gzip.compress()` and `gzip.decompress()`.
+For asynchronous byte sources, use [`decompress_chunks()`](streaming.md).
 
 ## Resumable text processing
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -73,6 +73,24 @@ pip install "aiogzip[fast]"
 
 ## Optimization Tips
 
+### Async-iterable streaming benchmarks
+
+The focused streaming benchmark compares source and output chunk sizes,
+file-reader/file-writer baselines, event-loop ticker progress, and peak Python
+allocations for highly compressible data. It also includes zlib-ng compression
+when the optional engine is installed:
+
+```bash
+uv run python benchmarks/run_benchmarks.py \
+  --category streaming --size 32 --repeat 3
+```
+
+Inputs below the 256 KiB codec-offload threshold often maximize raw throughput
+for short operations but may complete inline without giving an independent
+event-loop task a turn. Larger codec calls are offloaded, trading a thread hop
+for event-loop responsiveness. Measure with source chunk sizes representative
+of the real producer rather than selecting solely from synthetic throughput.
+
 ### 1. Choose the Right Chunk Size
 
 The default `chunk_size` is 256 KiB. Values must be positive and no larger than

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -62,6 +62,17 @@ resources. Crossing it raises `OSError`; the inflater is bounded to the
 remaining allowance plus one byte for overflow detection instead of first
 allocating the complete expanded payload.
 
+When the payload is not needed, use `verify()` to perform the same complete
+validation scan while discarding decompressed bytes:
+
+```python
+result = await aiogzip.verify(
+    "uploaded-data.gz",
+    max_decompressed_size=100 * 1024 * 1024,
+)
+print(result.uncompressed_size)
+```
+
 ## Reproducible gzip output
 
 The gzip header timestamp and embedded filename both affect output bytes. Set

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,9 +1,12 @@
 # Async-iterable streaming
 
-Use `decompress_chunks()` when compressed gzip bytes arrive as an
+Use `decompress_chunks()` and `compress_chunks()` when bytes arrive as an
 `AsyncIterable[bytes]` rather than through a file object's `read()` method.
-Paths and file objects belong with `open()`, `read()`, `inspect()`, or
-`verify()`; this API is deliberately limited to asynchronous iterables.
+Paths and file objects belong with `open()`, `read()`, `write()`, `inspect()`,
+or `verify()`; the chunk APIs are deliberately limited to asynchronous
+iterables.
+
+## Decompressing
 
 ```python
 import aiogzip
@@ -109,3 +112,90 @@ Argument validation for `source`, `output_chunk_size`, and
 `max_decompressed_size` happens when `decompress_chunks()` is called. Source
 item errors, corruption, I/O-like source failures, and cancellation occur while
 the iterator is consumed.
+
+## Compressing
+
+`compress_chunks()` accepts an asynchronous iterable of uncompressed `bytes`
+and yields the complete bytes for exactly one gzip member:
+
+```python
+import aiogzip
+
+
+async def raw_source():
+    yield b"hello "
+    yield b"world"
+
+
+async for data in aiogzip.compress_chunks(raw_source(), mtime=0):
+    await send(data)
+```
+
+The gzip header is yielded promptly when iteration begins, before the first
+source item is requested. An empty source therefore produces a valid empty
+member rather than zero bytes. Empty source chunks are ignored, input order is
+preserved, output chunks are non-empty, and `output_chunk_size` is a strict
+upper bound.
+
+Compression is pull-driven and reads no farther ahead than the input currently
+needed to produce output. Each source item must be `bytes`; synchronous
+iterables, strings, and implicit bytes-like conversions are not accepted.
+
+### Metadata and reproducibility
+
+Compression options match the binary file writer: `compresslevel=6`, `mtime`,
+`original_filename`, `fast_compress`, and `strict_size`. Set deterministic
+metadata explicitly when output bytes must be reproducible:
+
+```python
+stream = aiogzip.compress_chunks(
+    raw_source(),
+    mtime=0,
+    original_filename="payload.bin",
+)
+async for data in stream:
+    await send(data)
+```
+
+With `mtime=None`, the header uses the time at which streaming begins. Unlike a
+path-based writer, the iterable API has no destination filename to infer, so
+the original-filename header field is absent unless `original_filename` is
+provided. The filename is reduced to its basename and a trailing `.gz` is
+removed, matching the existing writer.
+
+`strict_size=False` stores uncompressed size modulo 2³² in the trailer, as gzip
+requires. Set `strict_size=True` to reject a member that would exceed the
+32-bit `ISIZE` field. `fast_compress=True` opts into zlib-ng when installed and
+otherwise emits the same fallback warning as the file writer.
+
+### Failure, cancellation, and early exit
+
+The final deflate bytes and eight-byte trailer are emitted only after the
+source ends normally. If the source raises, compression fails, cancellation
+occurs, or the consumer exits early, bytes already yielded are an incomplete
+gzip member and must be discarded. Streaming output cannot retract bytes that
+have already been transmitted.
+
+The iterator stops consuming its source and does not attempt to finalize during
+cleanup because there would be no consumer for those bytes. Cancellation during
+executor-backed compression propagates `asyncio.CancelledError`; the encoder is
+discarded, no trailer is emitted, and the source is not read again.
+
+No public deflate flush control is provided. One call creates one finite member;
+append-style member boundaries and `Z_SYNC_FLUSH` controls remain file-writer
+concerns.
+
+## Direct pipeline
+
+The two APIs compose without a queue or adapter:
+
+```python
+async for data in aiogzip.decompress_chunks(
+    aiogzip.compress_chunks(raw_source(), mtime=0)
+):
+    await consume(data)
+```
+
+Input boundaries, compressed output boundaries, and restored output boundaries
+are all independent. Consume each iterator from only one task and never issue
+overlapping `anext()` calls.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,0 +1,111 @@
+# Async-iterable streaming
+
+Use `decompress_chunks()` when compressed gzip bytes arrive as an
+`AsyncIterable[bytes]` rather than through a file object's `read()` method.
+Paths and file objects belong with `open()`, `read()`, `inspect()`, or
+`verify()`; this API is deliberately limited to asynchronous iterables.
+
+```python
+import aiogzip
+
+
+async def compressed_source():
+    async for chunk in receive_compressed_bytes():
+        yield chunk
+
+
+async for data in aiogzip.decompress_chunks(compressed_source()):
+    await consume(data)
+```
+
+The source must yield `bytes`. Empty byte chunks are ignored. Synchronous
+iterables and other item types are rejected rather than being converted
+implicitly.
+
+## Chunking and backpressure
+
+Input and output boundaries are independent. A gzip header, deflate block, or
+trailer may span any number of input items, and one input item may produce many
+output chunks. Every yielded chunk is non-empty and no larger than
+`output_chunk_size` (256 KiB by default).
+
+The iterator is pull-driven: it requests compressed input only when the
+consumer requests more decompressed output. It creates no producer task or
+queue and holds only the current source item, incomplete gzip structure, codec
+state, and bounded output. Concatenated gzip members are decoded transparently.
+
+```python
+async for data in aiogzip.decompress_chunks(
+    compressed_source(),
+    output_chunk_size=64 * 1024,
+):
+    await consume(data)
+```
+
+A zero-byte compressed source produces no output, matching a zero-byte file.
+This differs intentionally from streaming compression, where an empty payload
+must still produce a valid empty gzip member.
+
+## Integrity validation
+
+The iterator validates gzip headers, optional header CRCs, deflate data,
+per-member CRC-32 values, trailer `ISIZE` values, concatenated members, and
+final stream completeness. Complete validation requires consuming the iterator
+to normal completion.
+
+Payload bytes can be yielded before the corresponding member trailer is
+available. A later corrupt trailer or truncated source therefore raises after
+the consumer has already processed earlier output. This is inherent to
+streaming validation; use `verify()` first when output must not be acted on
+until the entire stream is known to be valid.
+
+For untrusted input, set an application-specific cumulative output limit:
+
+```python
+async for data in aiogzip.decompress_chunks(
+    compressed_source(),
+    max_decompressed_size=100 * 1024 * 1024,
+):
+    await consume(data)
+```
+
+The codec is limited to the remaining allowance plus one byte on each inflate
+call, so overflow is detected without first materializing an arbitrarily large
+expansion. Exceeding the limit raises `OSError`.
+
+## Early exit and cancellation
+
+Stopping iteration stops source consumption immediately. The unconsumed gzip
+tail is not drained or validated. For deterministic cleanup when breaking
+early, explicitly close the returned async generator:
+
+```python
+import aiogzip
+
+
+stream = aiogzip.decompress_chunks(compressed_source())
+try:
+    async for data in stream:
+        if await consume_until_done(data):
+            break
+finally:
+    await stream.aclose()
+```
+
+Finalization discards decoder buffers and calls `aclose()` on the source
+iterator when it provides that async-generator lifecycle method. It does not
+promise to close an unrelated transport or resource owned by the source.
+
+Cancellation while waiting for input or codec work propagates
+`asyncio.CancelledError`, stops pulling the source, and discards decoder state.
+Unlike a reusable file reader, a one-shot streaming iterator has no recovery
+state: discard it and start a new stream if needed.
+
+Each returned iterator is single-consumer. Do not issue overlapping `anext()`
+calls from multiple tasks; normal async-generator concurrency protection raises
+`RuntimeError` instead of allowing codec-state corruption.
+
+Argument validation for `source`, `output_chunk_size`, and
+`max_decompressed_size` happens when `decompress_chunks()` is called. Source
+item errors, corruption, I/O-like source failures, and cancellation occur while
+the iterator is consumed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
   - Home: index.md
   - Examples: examples.md
   - Recipes: recipes.md
+  - Async-iterable streaming: streaming.md
   - Performance: performance.md
   - API Reference: api.md
   - Contributing: contributing.md

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -1,7 +1,7 @@
 """Async gzip file reader/writer public API."""
 
 from pathlib import Path
-from typing import Any, Literal, Optional, Union, overload
+from typing import Any, AsyncIterable, AsyncIterator, Literal, Optional, Union, overload
 
 from ._binary import AsyncGzipBinaryFile
 from ._common import (
@@ -25,6 +25,7 @@ from ._inspection import (
     VerificationResult,
     _scan_gzip,
 )
+from ._streaming import _decompress_chunks
 from ._text import AsyncGzipTextFile
 
 __version__ = "1.9.1"
@@ -372,6 +373,25 @@ async def verify(
     )
 
 
+def decompress_chunks(
+    source: AsyncIterable[bytes],
+    *,
+    output_chunk_size: int = AsyncGzipBinaryFile.DEFAULT_CHUNK_SIZE,
+    max_decompressed_size: Optional[int] = None,
+) -> AsyncIterator[bytes]:
+    """Incrementally decompress gzip bytes from an asynchronous iterable.
+
+    Output chunks are non-empty and no larger than ``output_chunk_size``.
+    Complete CRC and trailer validation occurs only when the returned iterator
+    is consumed to completion.
+    """
+    return _decompress_chunks(
+        source,
+        output_chunk_size=output_chunk_size,
+        max_decompressed_size=max_decompressed_size,
+    )
+
+
 __all__ = [
     "__version__",
     "AsyncGzipBinaryFile",
@@ -398,4 +418,5 @@ __all__ = [
     "engine_info",
     "inspect",
     "verify",
+    "decompress_chunks",
 ]

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -25,7 +25,7 @@ from ._inspection import (
     VerificationResult,
     _scan_gzip,
 )
-from ._streaming import _decompress_chunks
+from ._streaming import _compress_chunks, _decompress_chunks
 from ._text import AsyncGzipTextFile
 
 __version__ = "1.9.1"
@@ -392,6 +392,32 @@ def decompress_chunks(
     )
 
 
+def compress_chunks(
+    source: AsyncIterable[bytes],
+    *,
+    compresslevel: int = 6,
+    mtime: Optional[Union[int, float]] = None,
+    original_filename: Optional[Union[str, bytes]] = None,
+    fast_compress: bool = False,
+    strict_size: bool = False,
+    output_chunk_size: int = AsyncGzipBinaryFile.DEFAULT_CHUNK_SIZE,
+) -> AsyncIterator[bytes]:
+    """Incrementally compress an asynchronous byte iterable as one gzip member.
+
+    The header is emitted before the first source item is requested. Output
+    chunks are non-empty and no larger than ``output_chunk_size``.
+    """
+    return _compress_chunks(
+        source,
+        compresslevel=compresslevel,
+        mtime=mtime,
+        original_filename=original_filename,
+        fast_compress=fast_compress,
+        strict_size=strict_size,
+        output_chunk_size=output_chunk_size,
+    )
+
+
 __all__ = [
     "__version__",
     "AsyncGzipBinaryFile",
@@ -419,4 +445,5 @@ __all__ = [
     "inspect",
     "verify",
     "decompress_chunks",
+    "compress_chunks",
 ]

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -19,6 +19,7 @@ from ._common import (
     ZlibEngine,
 )
 from ._engine import EngineInfo, engine_info
+from ._inspection import GzipInfo, GzipMemberInfo, VerificationResult
 from ._text import AsyncGzipTextFile
 
 __version__ = "1.9.1"
@@ -315,6 +316,9 @@ __all__ = [
     "AsyncGzipFile",
     "AsyncGzipTextFile",
     "EngineInfo",
+    "GzipInfo",
+    "GzipMemberInfo",
+    "VerificationResult",
     "WithAsyncRead",
     "WithAsyncReadWrite",
     "WithAsyncWrite",

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -316,7 +316,7 @@ async def write(
 
 
 async def inspect(
-    filename: _Filename = None,
+    filename: _Filename,
     *,
     chunk_size: int = AsyncGzipBinaryFile.DEFAULT_CHUNK_SIZE,
     fileobj: _ReadFileObj = None,
@@ -345,7 +345,7 @@ async def inspect(
 
 
 async def verify(
-    filename: _Filename = None,
+    filename: _Filename,
     *,
     chunk_size: int = AsyncGzipBinaryFile.DEFAULT_CHUNK_SIZE,
     fileobj: _ReadFileObj = None,

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -384,6 +384,20 @@ def decompress_chunks(
     Output chunks are non-empty and no larger than ``output_chunk_size``.
     Complete CRC and trailer validation occurs only when the returned iterator
     is consumed to completion.
+
+    Args:
+        source: Asynchronous iterable yielding compressed ``bytes``.
+        output_chunk_size: Strict upper bound for each yielded chunk.
+        max_decompressed_size: Optional cumulative decompressed-byte limit.
+
+    Returns:
+        A single-consumer asynchronous iterator of decompressed ``bytes``.
+
+    Raises:
+        TypeError: If call-time arguments or a source item have invalid types.
+        ValueError: If a size argument is outside its supported range.
+        gzip.BadGzipFile: If the consumed gzip stream is malformed or corrupt.
+        OSError: If the cumulative output limit is exceeded.
     """
     return _decompress_chunks(
         source,
@@ -406,6 +420,23 @@ def compress_chunks(
 
     The header is emitted before the first source item is requested. Output
     chunks are non-empty and no larger than ``output_chunk_size``.
+
+    Args:
+        source: Asynchronous iterable yielding uncompressed ``bytes``.
+        compresslevel: Compression level from ``-1`` through ``9``.
+        mtime: Optional gzip header timestamp. Use zero for reproducibility.
+        original_filename: Optional filename stored in the gzip header.
+        fast_compress: Opt into zlib-ng compression when available.
+        strict_size: Reject payloads exceeding gzip's 32-bit ``ISIZE`` field.
+        output_chunk_size: Strict upper bound for each yielded chunk.
+
+    Returns:
+        A single-consumer asynchronous iterator containing one gzip member.
+
+    Raises:
+        TypeError: If call-time arguments or a source item have invalid types.
+        ValueError: If an option is outside its supported range.
+        OSError: If compression fails or ``strict_size`` rejects the payload.
     """
     return _compress_chunks(
         source,

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -19,7 +19,12 @@ from ._common import (
     ZlibEngine,
 )
 from ._engine import EngineInfo, engine_info
-from ._inspection import GzipInfo, GzipMemberInfo, VerificationResult
+from ._inspection import (
+    GzipInfo,
+    GzipMemberInfo,
+    VerificationResult,
+    _scan_gzip,
+)
 from ._text import AsyncGzipTextFile
 
 __version__ = "1.9.1"
@@ -310,6 +315,63 @@ async def write(
         await stream.write(data)
 
 
+async def inspect(
+    filename: _Filename = None,
+    *,
+    chunk_size: int = AsyncGzipBinaryFile.DEFAULT_CHUNK_SIZE,
+    fileobj: _ReadFileObj = None,
+    closefd: Optional[bool] = None,
+    max_decompressed_size: Optional[int] = None,
+) -> GzipInfo:
+    """Inspect and validate every member in a complete gzip stream.
+
+    This performs a full decompression scan while discarding payload bytes.
+    ``mtime`` preserves the literal header value, including zero; filename and
+    comment metadata use Latin-1 decoding.
+    """
+    result = await _scan_gzip(
+        filename,
+        fileobj=fileobj,
+        closefd=closefd,
+        max_decompressed_size=max_decompressed_size,
+        chunk_size=chunk_size,
+        collect_members=True,
+    )
+    return GzipInfo(
+        members=result.members,
+        compressed_size=result.compressed_size,
+        uncompressed_size=result.uncompressed_size,
+    )
+
+
+async def verify(
+    filename: _Filename = None,
+    *,
+    chunk_size: int = AsyncGzipBinaryFile.DEFAULT_CHUNK_SIZE,
+    fileobj: _ReadFileObj = None,
+    closefd: Optional[bool] = None,
+    max_decompressed_size: Optional[int] = None,
+) -> VerificationResult:
+    """Validate a complete gzip stream and return aggregate counts.
+
+    Successful return means every header, deflate payload, CRC, and ``ISIZE``
+    was valid. Invalid input and resource-limit failures raise instead.
+    """
+    result = await _scan_gzip(
+        filename,
+        fileobj=fileobj,
+        closefd=closefd,
+        max_decompressed_size=max_decompressed_size,
+        chunk_size=chunk_size,
+        collect_members=False,
+    )
+    return VerificationResult(
+        member_count=result.member_count,
+        compressed_size=result.compressed_size,
+        uncompressed_size=result.uncompressed_size,
+    )
+
+
 __all__ = [
     "__version__",
     "AsyncGzipBinaryFile",
@@ -334,4 +396,6 @@ __all__ = [
     "read",
     "write",
     "engine_info",
+    "inspect",
+    "verify",
 ]

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -40,7 +40,7 @@ from ._common import (
 # KiB, decompressing a single chunk is faster than the hop, so the
 # event-loop benefit does not pay for itself. Above it, the CPU work
 # dominates and the hop is amortised.
-_ZLIB_OFFLOAD_THRESHOLD = 256 * 1024
+_ZLIB_OFFLOAD_THRESHOLD = _engine.ZLIB_OFFLOAD_THRESHOLD
 
 
 async def _run_zlib_in_thread(method: Callable[[bytes], bytes], data: bytes) -> bytes:
@@ -51,8 +51,7 @@ async def _run_zlib_in_thread(method: Callable[[bytes], bytes], data: bytes) -> 
     the GIL internally, so offloading large chunks keeps the event loop
     responsive during CPU-bound work.
     """
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, method, data)
+    return await _engine.run_zlib_in_thread(method, data)
 
 
 class AsyncGzipBinaryFile:

--- a/src/aiogzip/_engine.py
+++ b/src/aiogzip/_engine.py
@@ -13,11 +13,12 @@ Set ``AIOGZIP_ENGINE=stdlib`` to force stdlib everywhere (useful for
 reproducible error behaviour or debugging).
 """
 
+import asyncio
 import importlib
 import os
 import zlib
 from dataclasses import dataclass
-from typing import Any, Tuple, Type
+from typing import Any, Callable, Tuple, Type
 
 from ._common import ZlibEngine
 
@@ -41,6 +42,16 @@ _FORCE_STDLIB = os.environ.get("AIOGZIP_ENGINE", "").strip().lower() == "stdlib"
 
 # Whether zlib-ng is available *and* permitted as the active engine.
 _HAVE_ZNG = _zng is not None and not _FORCE_STDLIB
+
+# Inputs below this size run inline; above it, a thread hop is amortized and
+# keeps the event loop responsive during CPU-heavy codec work.
+ZLIB_OFFLOAD_THRESHOLD = 256 * 1024
+
+
+async def run_zlib_in_thread(method: Callable[[bytes], bytes], data: bytes) -> bytes:
+    """Run one codec call in the event loop's default executor."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, method, data)
 
 
 @dataclass(frozen=True)

--- a/src/aiogzip/_inspection.py
+++ b/src/aiogzip/_inspection.py
@@ -5,7 +5,10 @@ import gzip
 import struct
 from dataclasses import dataclass
 from functools import partial
-from typing import AsyncIterator, List, Optional, Tuple, cast
+from pathlib import Path
+from typing import Any, AsyncIterator, List, Optional, Tuple, Union, cast
+
+import aiofiles
 
 from . import _engine
 from ._common import (
@@ -15,12 +18,16 @@ from ._common import (
     GZIP_FLAG_FHCRC,
     GZIP_FLAG_FNAME,
     GZIP_METHOD_DEFLATE,
+    WithAsyncRead,
+    WithAsyncReadWrite,
     ZlibEngine,
     _validate_chunk_size,
     _validate_optional_positive_int,
 )
 
 _RESERVED_FLAGS = 0xE0
+_Filename = Union[str, bytes, Path, None]
+_ReadFileObj = Optional[Union[WithAsyncRead, WithAsyncReadWrite]]
 
 
 @dataclass(frozen=True)
@@ -387,3 +394,82 @@ class _IncrementalGzipDecoder:
             if finalizing and not completed:
                 self._pending.clear()
                 self._engine = None
+
+
+@dataclass(frozen=True)
+class _ScanResult:
+    members: Tuple[GzipMemberInfo, ...]
+    member_count: int
+    compressed_size: int
+    uncompressed_size: int
+
+
+async def _scan_gzip(
+    filename: _Filename,
+    *,
+    fileobj: _ReadFileObj,
+    closefd: Optional[bool],
+    max_decompressed_size: Optional[int],
+    chunk_size: int,
+    collect_members: bool,
+) -> _ScanResult:
+    """Read and validate a complete gzip source without retaining payload."""
+    from ._common import _validate_filename
+
+    _validate_filename(filename, fileobj)
+    _validate_chunk_size(chunk_size)
+    _validate_optional_positive_int(max_decompressed_size, "max_decompressed_size")
+
+    source: Any
+    owns_source = fileobj is None
+    if fileobj is None:
+        assert filename is not None
+        source = await aiofiles.open(filename, "rb")
+    else:
+        source = fileobj
+    should_close = owns_source or bool(closefd)
+
+    decoder = _IncrementalGzipDecoder(
+        max_decompressed_size=max_decompressed_size,
+        output_chunk_size=chunk_size,
+        collect_member_info=collect_members,
+    )
+    scan_failed = False
+    try:
+        while True:
+            try:
+                chunk = await source.read(chunk_size)
+            except OSError:
+                raise
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                raise OSError(f"Error reading from file: {error}") from error
+            if not chunk:
+                break
+            if not isinstance(chunk, bytes):
+                raise TypeError("binary gzip source read() must return bytes")
+            async for _ in decoder.feed(chunk):
+                pass
+        async for _ in decoder.finish():
+            pass
+        return _ScanResult(
+            members=decoder.members,
+            member_count=decoder.member_count,
+            compressed_size=decoder.compressed_size,
+            uncompressed_size=decoder.uncompressed_size,
+        )
+    except BaseException:
+        scan_failed = True
+        raise
+    finally:
+        if should_close:
+            close_method = getattr(source, "close", None)
+            if callable(close_method):
+                try:
+                    result = close_method()
+                    if hasattr(result, "__await__"):
+                        await result
+                except BaseException:
+                    if not scan_failed:
+                        raise

--- a/src/aiogzip/_inspection.py
+++ b/src/aiogzip/_inspection.py
@@ -208,7 +208,12 @@ class _IncrementalGzipDecoder:
         return self._uncompressed_size
 
     def discard(self) -> None:
-        """Release codec state and buffered data without final validation."""
+        """Irreversibly release codec state without performing validation.
+
+        This is a one-way teardown used when a streaming operation completes
+        or is abandoned, so even a successfully finalized decoder is marked
+        unusable rather than retaining buffers for accidental reuse.
+        """
         self._failed = True
         self._pending.clear()
         self._engine = None

--- a/src/aiogzip/_inspection.py
+++ b/src/aiogzip/_inspection.py
@@ -22,6 +22,7 @@ from ._common import (
     WithAsyncReadWrite,
     ZlibEngine,
     _validate_chunk_size,
+    _validate_filename,
     _validate_optional_positive_int,
 )
 
@@ -43,7 +44,7 @@ class GzipMemberInfo:
     compressed_offset: int
     compressed_size: int
     uncompressed_size: int
-    mtime: Optional[int]
+    mtime: int
     original_filename: Optional[str]
     comment: Optional[str]
     extra: Optional[bytes]
@@ -414,8 +415,6 @@ async def _scan_gzip(
     collect_members: bool,
 ) -> _ScanResult:
     """Read and validate a complete gzip source without retaining payload."""
-    from ._common import _validate_filename
-
     _validate_filename(filename, fileobj)
     _validate_chunk_size(chunk_size)
     _validate_optional_positive_int(max_decompressed_size, "max_decompressed_size")

--- a/src/aiogzip/_inspection.py
+++ b/src/aiogzip/_inspection.py
@@ -1,0 +1,49 @@
+"""Gzip stream inspection result types and private scanner internals."""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class GzipMemberInfo:
+    """Validated metadata and sizes for one gzip member.
+
+    ``mtime`` preserves the literal unsigned header value, including zero.
+    Filename and comment fields are decoded one-to-one with Latin-1; absent
+    fields are ``None``, while present empty fields are empty strings.
+    """
+
+    index: int
+    compressed_offset: int
+    compressed_size: int
+    uncompressed_size: int
+    mtime: Optional[int]
+    original_filename: Optional[str]
+    comment: Optional[str]
+    extra: Optional[bytes]
+    flags: int
+    crc32: int
+    trailer_isize: int
+
+
+@dataclass(frozen=True)
+class GzipInfo:
+    """Aggregate information for a completely validated gzip stream."""
+
+    members: Tuple[GzipMemberInfo, ...]
+    compressed_size: int
+    uncompressed_size: int
+
+    @property
+    def member_count(self) -> int:
+        """Return the number of gzip members in stream order."""
+        return len(self.members)
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Aggregate counts returned after successful integrity verification."""
+
+    member_count: int
+    compressed_size: int
+    uncompressed_size: int

--- a/src/aiogzip/_inspection.py
+++ b/src/aiogzip/_inspection.py
@@ -207,6 +207,14 @@ class _IncrementalGzipDecoder:
     def uncompressed_size(self) -> int:
         return self._uncompressed_size
 
+    def discard(self) -> None:
+        """Release codec state and buffered data without final validation."""
+        self._failed = True
+        self._pending.clear()
+        self._engine = None
+        self._header = None
+        self._members.clear()
+
     def feed(self, data: bytes) -> AsyncIterator[bytes]:
         """Accept compressed bytes and return a bounded-output async iterator."""
         if self._finished:

--- a/src/aiogzip/_inspection.py
+++ b/src/aiogzip/_inspection.py
@@ -1,7 +1,26 @@
 """Gzip stream inspection result types and private scanner internals."""
 
+import asyncio
+import gzip
+import struct
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from functools import partial
+from typing import AsyncIterator, List, Optional, Tuple, cast
+
+from . import _engine
+from ._common import (
+    _MAX_CHUNK_SIZE,
+    GZIP_FLAG_FCOMMENT,
+    GZIP_FLAG_FEXTRA,
+    GZIP_FLAG_FHCRC,
+    GZIP_FLAG_FNAME,
+    GZIP_METHOD_DEFLATE,
+    ZlibEngine,
+    _validate_chunk_size,
+    _validate_optional_positive_int,
+)
+
+_RESERVED_FLAGS = 0xE0
 
 
 @dataclass(frozen=True)
@@ -47,3 +66,324 @@ class VerificationResult:
     member_count: int
     compressed_size: int
     uncompressed_size: int
+
+
+@dataclass(frozen=True)
+class _ParsedHeader:
+    size: int
+    mtime: int
+    original_filename: Optional[str]
+    comment: Optional[str]
+    extra: Optional[bytes]
+    flags: int
+
+
+def _parse_header(data: bytes, collect_metadata: bool) -> Optional[_ParsedHeader]:
+    """Parse one complete gzip header, returning ``None`` when incomplete."""
+    if len(data) < 2:
+        return None
+    if data[:2] != b"\x1f\x8b":
+        raise gzip.BadGzipFile("Not a gzipped file")
+    if len(data) < 3:
+        return None
+    if data[2] != GZIP_METHOD_DEFLATE:
+        raise gzip.BadGzipFile(f"Unknown compression method {data[2]}")
+    if len(data) < 4:
+        return None
+
+    flags = data[3]
+    if flags & _RESERVED_FLAGS:
+        raise gzip.BadGzipFile(f"Reserved flags are set in gzip header: {flags:#04x}")
+    if len(data) < 10:
+        return None
+
+    mtime = struct.unpack("<I", data[4:8])[0]
+    position = 10
+    extra: Optional[bytes] = None
+    filename: Optional[str] = None
+    comment: Optional[str] = None
+
+    if flags & GZIP_FLAG_FEXTRA:
+        if len(data) < position + 2:
+            return None
+        extra_length = struct.unpack("<H", data[position : position + 2])[0]
+        position += 2
+        if len(data) < position + extra_length:
+            return None
+        if collect_metadata:
+            extra = data[position : position + extra_length]
+        position += extra_length
+
+    if flags & GZIP_FLAG_FNAME:
+        terminator = data.find(b"\x00", position)
+        if terminator < 0:
+            return None
+        if collect_metadata:
+            filename = data[position:terminator].decode("latin-1")
+        position = terminator + 1
+
+    if flags & GZIP_FLAG_FCOMMENT:
+        terminator = data.find(b"\x00", position)
+        if terminator < 0:
+            return None
+        if collect_metadata:
+            comment = data[position:terminator].decode("latin-1")
+        position = terminator + 1
+
+    if flags & GZIP_FLAG_FHCRC:
+        if len(data) < position + 2:
+            return None
+        expected = struct.unpack("<H", data[position : position + 2])[0]
+        actual = _engine.crc32(data[:position]) & 0xFFFF
+        if actual != expected:
+            raise gzip.BadGzipFile(
+                f"Header CRC check failed ({actual:#06x} != {expected:#06x})"
+            )
+        position += 2
+
+    return _ParsedHeader(
+        size=position,
+        mtime=mtime,
+        original_filename=filename,
+        comment=comment,
+        extra=extra,
+        flags=flags,
+    )
+
+
+class _IncrementalGzipDecoder:
+    """Incrementally validate gzip members and yield bounded output chunks."""
+
+    def __init__(
+        self,
+        *,
+        max_decompressed_size: Optional[int],
+        output_chunk_size: int,
+        collect_member_info: bool,
+    ) -> None:
+        _validate_chunk_size(output_chunk_size)
+        _validate_optional_positive_int(max_decompressed_size, "max_decompressed_size")
+        self._max_decompressed_size = max_decompressed_size
+        self._output_chunk_size = output_chunk_size
+        self._collect_member_info = collect_member_info
+        self._pending = bytearray()
+        self._state = "header"
+        self._engine: ZlibEngine = None
+        self._header: Optional[_ParsedHeader] = None
+        self._members: List[GzipMemberInfo] = []
+        self._member_count = 0
+        self._member_offset = 0
+        self._member_crc = 0
+        self._member_size = 0
+        self._compressed_size = 0
+        self._consumed_size = 0
+        self._uncompressed_size = 0
+        self._allow_padding = False
+        self._finished = False
+        self._failed = False
+        self._active = False
+
+    @property
+    def members(self) -> Tuple[GzipMemberInfo, ...]:
+        return tuple(self._members)
+
+    @property
+    def member_count(self) -> int:
+        return self._member_count
+
+    @property
+    def compressed_size(self) -> int:
+        return self._compressed_size
+
+    @property
+    def uncompressed_size(self) -> int:
+        return self._uncompressed_size
+
+    def feed(self, data: bytes) -> AsyncIterator[bytes]:
+        """Accept compressed bytes and return a bounded-output async iterator."""
+        if self._finished:
+            raise ValueError("gzip decoder is already finalized")
+        if self._failed:
+            raise OSError("gzip decoder is unusable after a prior failure")
+        if not isinstance(data, bytes):
+            raise TypeError("gzip decoder input must be bytes")
+        self._compressed_size += len(data)
+        self._pending.extend(data)
+        return self._process(finalizing=False)
+
+    def finish(self) -> AsyncIterator[bytes]:
+        """Finalize parsing and reject any incomplete gzip structure."""
+        if self._finished:
+            raise ValueError("gzip decoder is already finalized")
+        if self._failed:
+            raise OSError("gzip decoder is unusable after a prior failure")
+        return self._process(finalizing=True)
+
+    def _consume(self, size: int) -> None:
+        del self._pending[:size]
+        self._consumed_size += size
+
+    def _account_output(self, output: bytes) -> None:
+        size = len(output)
+        self._member_crc = _engine.crc32(output, self._member_crc)
+        self._member_size += size
+        self._uncompressed_size += size
+        limit = self._max_decompressed_size
+        if limit is not None and self._uncompressed_size > limit:
+            raise OSError(
+                f"decompressed output exceeded max_decompressed_size "
+                f"({self._uncompressed_size} > {limit} bytes)"
+            )
+
+    def _output_limit(self) -> int:
+        limit = self._max_decompressed_size
+        if limit is None:
+            return self._output_chunk_size
+        remaining = limit - self._uncompressed_size
+        return min(self._output_chunk_size, remaining + 1)
+
+    async def _inflate(self, data: bytes) -> bytes:
+        decompress = partial(self._engine.decompress, max_length=self._output_limit())
+        try:
+            if len(data) >= _engine.ZLIB_OFFLOAD_THRESHOLD:
+                return await _engine.run_zlib_in_thread(decompress, data)
+            return cast(bytes, decompress(data))
+        except asyncio.CancelledError:
+            self._failed = True
+            self._engine = None
+            self._pending.clear()
+            raise
+        except _engine.ZLIB_ERRORS as error:
+            raise gzip.BadGzipFile(
+                f"Error decompressing gzip member {self._member_count} at "
+                f"compressed offset {self._member_offset}: {error}"
+            ) from error
+
+    def _complete_member(self, trailer: bytes) -> None:
+        expected_crc, trailer_isize = struct.unpack("<II", trailer)
+        actual_crc = self._member_crc & 0xFFFFFFFF
+        if actual_crc != expected_crc:
+            raise gzip.BadGzipFile(
+                f"CRC check failed in gzip member {self._member_count} at "
+                f"compressed offset {self._member_offset}"
+            )
+        if self._member_size & 0xFFFFFFFF != trailer_isize:
+            raise gzip.BadGzipFile(
+                f"ISIZE check failed in gzip member {self._member_count} at "
+                f"compressed offset {self._member_offset}"
+            )
+
+        header = self._header
+        assert header is not None
+        self._consume(8)
+        if self._collect_member_info:
+            self._members.append(
+                GzipMemberInfo(
+                    index=self._member_count,
+                    compressed_offset=self._member_offset,
+                    compressed_size=self._consumed_size - self._member_offset,
+                    uncompressed_size=self._member_size,
+                    mtime=header.mtime,
+                    original_filename=header.original_filename,
+                    comment=header.comment,
+                    extra=header.extra,
+                    flags=header.flags,
+                    crc32=actual_crc,
+                    trailer_isize=trailer_isize,
+                )
+            )
+        self._member_count += 1
+        self._header = None
+        self._engine = None
+        self._state = "header"
+        self._allow_padding = True
+
+    async def _process(self, finalizing: bool) -> AsyncIterator[bytes]:
+        if self._active:
+            raise RuntimeError("gzip decoder cannot be advanced concurrently")
+        self._active = True
+        completed = False
+        try:
+            while True:
+                if self._state == "header":
+                    if self._allow_padding:
+                        padding = len(self._pending) - len(
+                            self._pending.lstrip(b"\x00")
+                        )
+                        if padding:
+                            self._consume(padding)
+                        if not self._pending:
+                            break
+
+                    parsed = _parse_header(
+                        bytes(self._pending), self._collect_member_info
+                    )
+                    if parsed is None:
+                        if len(self._pending) > _MAX_CHUNK_SIZE:
+                            raise gzip.BadGzipFile(
+                                "gzip header exceeds the 128 MiB safety limit"
+                            )
+                        break
+                    self._member_offset = self._consumed_size
+                    self._header = parsed
+                    self._consume(parsed.size)
+                    self._engine = _engine.decompressobj(-_engine.MAX_WBITS)
+                    self._member_crc = 0
+                    self._member_size = 0
+                    self._state = "body"
+                    self._allow_padding = False
+                    continue
+
+                if self._state == "body":
+                    if not self._pending:
+                        break
+                    payload = bytes(self._pending)
+                    output = await self._inflate(payload)
+                    if self._engine.eof:
+                        remaining = self._engine.unused_data
+                    else:
+                        remaining = self._engine.unconsumed_tail
+                    consumed = len(payload) - len(remaining)
+                    if consumed:
+                        self._consume(consumed)
+                    if output:
+                        self._account_output(output)
+                        yield output
+                    if self._engine.eof:
+                        self._state = "trailer"
+                        continue
+                    if not consumed and not output:
+                        break
+                    continue
+
+                if self._state == "trailer":
+                    if len(self._pending) < 8:
+                        break
+                    self._complete_member(bytes(self._pending[:8]))
+                    continue
+
+                raise AssertionError(f"unknown gzip decoder state: {self._state}")
+
+            if finalizing:
+                if self._state == "body":
+                    raise gzip.BadGzipFile(
+                        f"gzip member {self._member_count} at compressed offset "
+                        f"{self._member_offset} ended before the deflate stream completed"
+                    )
+                if self._state == "trailer":
+                    raise gzip.BadGzipFile(
+                        f"gzip member {self._member_count} at compressed offset "
+                        f"{self._member_offset} has a truncated trailer"
+                    )
+                if self._pending:
+                    raise gzip.BadGzipFile("truncated gzip member header")
+                self._finished = True
+            completed = True
+        except BaseException:
+            self._failed = True
+            raise
+        finally:
+            self._active = False
+            if finalizing and not completed:
+                self._pending.clear()
+                self._engine = None

--- a/src/aiogzip/_streaming.py
+++ b/src/aiogzip/_streaming.py
@@ -1,9 +1,194 @@
 """Private async-iterable gzip streaming implementations."""
 
-from typing import Any, AsyncIterable, AsyncIterator, Optional
+import asyncio
+import warnings
+from typing import (
+    Any,
+    AsyncIterable,
+    AsyncIterator,
+    Iterator,
+    Optional,
+    Union,
+    cast,
+)
 
-from ._common import _validate_chunk_size, _validate_optional_positive_int
+from . import _engine
+from ._common import (
+    ZlibEngine,
+    _build_gzip_header,
+    _build_gzip_trailer,
+    _derive_header_filename,
+    _normalize_mtime,
+    _validate_chunk_size,
+    _validate_compresslevel,
+    _validate_optional_positive_int,
+    _validate_original_filename,
+)
 from ._inspection import _IncrementalGzipDecoder
+
+
+class _IncrementalGzipEncoder:
+    """Incrementally encode exactly one gzip member with bounded output."""
+
+    def __init__(
+        self,
+        *,
+        compresslevel: int,
+        mtime: Optional[Union[int, float]],
+        original_filename: Optional[Union[str, bytes]],
+        fast_compress: bool,
+        strict_size: bool,
+        output_chunk_size: int,
+    ) -> None:
+        _validate_compresslevel(compresslevel)
+        _validate_chunk_size(output_chunk_size)
+        self._compresslevel = compresslevel
+        self._mtime = _normalize_mtime(mtime)
+        validated_filename = _validate_original_filename(original_filename)
+        self._filename = _derive_header_filename(validated_filename, None)
+        self._fast_compress = bool(fast_compress)
+        self._strict_size = bool(strict_size)
+        self._output_chunk_size = output_chunk_size
+        if self._fast_compress and not _engine.have_fast_engine():
+            warnings.warn(
+                "fast_compress=True requested but zlib-ng is not available; "
+                "falling back to stdlib zlib. Install the extra with "
+                "'pip install aiogzip[fast]' to enable faster compression.",
+                stacklevel=3,
+            )
+        self._engine: ZlibEngine = _engine.compressobj(
+            compresslevel,
+            -_engine.MAX_WBITS,
+            fast=self._fast_compress,
+        )
+        self._crc = 0
+        self._input_size = 0
+        self._started = False
+        self._finished = False
+        self._failed = False
+        self._active = False
+
+    @property
+    def input_size(self) -> int:
+        return self._input_size
+
+    @property
+    def crc32(self) -> int:
+        return self._crc
+
+    def _output_chunks(self, data: bytes) -> Iterator[bytes]:
+        for offset in range(0, len(data), self._output_chunk_size):
+            yield data[offset : offset + self._output_chunk_size]
+
+    def _check_available(self) -> None:
+        if self._finished:
+            raise ValueError("gzip encoder is already finalized")
+        if self._failed:
+            raise OSError("gzip encoder is unusable after a prior failure")
+
+    def start(self) -> Iterator[bytes]:
+        """Start the member and return bounded chunks of its gzip header."""
+        self._check_available()
+        if self._started:
+            raise ValueError("gzip encoder is already started")
+        self._started = True
+        header = _build_gzip_header(self._filename, self._mtime, self._compresslevel)
+        return self._output_chunks(header)
+
+    def feed(self, data: bytes) -> AsyncIterator[bytes]:
+        """Consume one uncompressed bytes chunk and yield compressed output."""
+        self._check_available()
+        if not self._started:
+            raise ValueError("gzip encoder must be started before feeding data")
+        if not isinstance(data, bytes):
+            raise TypeError("gzip encoder input must be bytes")
+        if self._strict_size and self._input_size + len(data) > 0xFFFFFFFF:
+            raise OSError(
+                f"uncompressed member size would exceed the gzip ISIZE "
+                f"field's 4 GiB limit ({self._input_size} + {len(data)} > "
+                f"{0xFFFFFFFF}); drop strict_size to allow ISIZE "
+                f"truncation or split the payload into multiple members"
+            )
+        return self._feed(data)
+
+    def finish(self) -> AsyncIterator[bytes]:
+        """Finalize deflate exactly once and emit the gzip trailer."""
+        self._check_available()
+        if not self._started:
+            raise ValueError("gzip encoder must be started before finalizing")
+        return self._finish()
+
+    def discard(self) -> None:
+        """Irreversibly release codec state without emitting final bytes."""
+        self._failed = True
+        self._engine = None
+
+    async def _feed(self, data: bytes) -> AsyncIterator[bytes]:
+        if self._active:
+            raise RuntimeError("gzip encoder cannot be advanced concurrently")
+        self._active = True
+        completed = False
+        try:
+            try:
+                if len(data) >= _engine.ZLIB_OFFLOAD_THRESHOLD:
+                    compressed = await _engine.run_zlib_in_thread(
+                        self._engine.compress, data
+                    )
+                else:
+                    compressed = cast(bytes, self._engine.compress(data))
+            except asyncio.CancelledError:
+                raise
+            except _engine.ZLIB_ERRORS as error:
+                raise OSError(f"Error compressing data: {error}") from error
+            except Exception as error:
+                raise OSError(
+                    f"Unexpected error during compression: {error}"
+                ) from error
+
+            self._crc = _engine.crc32(data, self._crc) & 0xFFFFFFFF
+            self._input_size += len(data)
+            for output in self._output_chunks(compressed):
+                yield output
+            completed = True
+        except BaseException:
+            self._failed = True
+            self._engine = None
+            raise
+        finally:
+            self._active = False
+            if not completed:
+                self._failed = True
+                self._engine = None
+
+    async def _finish(self) -> AsyncIterator[bytes]:
+        if self._active:
+            raise RuntimeError("gzip encoder cannot be advanced concurrently")
+        self._active = True
+        completed = False
+        try:
+            try:
+                remaining = cast(bytes, self._engine.flush())
+            except _engine.ZLIB_ERRORS as error:
+                raise OSError(f"Error finalizing compressed data: {error}") from error
+            except Exception as error:
+                raise OSError(
+                    f"Unexpected error during compression finalization: {error}"
+                ) from error
+            trailer = _build_gzip_trailer(self._crc, self._input_size)
+            self._finished = True
+            for output in self._output_chunks(remaining):
+                yield output
+            for output in self._output_chunks(trailer):
+                yield output
+            completed = True
+        except BaseException:
+            self._failed = True
+            raise
+        finally:
+            self._active = False
+            self._engine = None
+            if not completed:
+                self._failed = True
 
 
 def _decompress_chunks(

--- a/src/aiogzip/_streaming.py
+++ b/src/aiogzip/_streaming.py
@@ -12,7 +12,7 @@ def _decompress_chunks(
     output_chunk_size: int,
     max_decompressed_size: Optional[int],
 ) -> AsyncIterator[bytes]:
-    """Validate arguments eagerly and return the decompression generator."""
+    """Validate call-time arguments and return the decompression generator."""
     if not callable(getattr(source, "__aiter__", None)):
         raise TypeError("source must be an asynchronous iterable of bytes")
     _validate_chunk_size(output_chunk_size)

--- a/src/aiogzip/_streaming.py
+++ b/src/aiogzip/_streaming.py
@@ -54,7 +54,7 @@ class _IncrementalGzipEncoder:
                 "fast_compress=True requested but zlib-ng is not available; "
                 "falling back to stdlib zlib. Install the extra with "
                 "'pip install aiogzip[fast]' to enable faster compression.",
-                stacklevel=3,
+                stacklevel=4,
             )
         self._engine: ZlibEngine = _engine.compressobj(
             compresslevel,

--- a/src/aiogzip/_streaming.py
+++ b/src/aiogzip/_streaming.py
@@ -223,6 +223,7 @@ async def _decompress_chunks_impl(
     )
     iterator = source.__aiter__()
     if not callable(getattr(iterator, "__anext__", None)):
+        decoder.discard()
         raise TypeError("source.__aiter__() must return an asynchronous iterator")
     failed = False
     try:
@@ -245,12 +246,77 @@ async def _decompress_chunks_impl(
         raise
     finally:
         decoder.discard()
-        close = getattr(iterator, "aclose", None)
-        if callable(close):
+        await _close_async_iterator(iterator, failed=failed)
+
+
+def _compress_chunks(
+    source: AsyncIterable[bytes],
+    *,
+    compresslevel: int,
+    mtime: Optional[Union[int, float]],
+    original_filename: Optional[Union[str, bytes]],
+    fast_compress: bool,
+    strict_size: bool,
+    output_chunk_size: int,
+) -> AsyncIterator[bytes]:
+    """Validate arguments and return the one-member compression generator."""
+    if not callable(getattr(source, "__aiter__", None)):
+        raise TypeError("source must be an asynchronous iterable of bytes")
+    encoder = _IncrementalGzipEncoder(
+        compresslevel=compresslevel,
+        mtime=mtime,
+        original_filename=original_filename,
+        fast_compress=fast_compress,
+        strict_size=strict_size,
+        output_chunk_size=output_chunk_size,
+    )
+    return _compress_chunks_impl(source, encoder)
+
+
+async def _compress_chunks_impl(
+    source: AsyncIterable[bytes], encoder: _IncrementalGzipEncoder
+) -> AsyncIterator[bytes]:
+    """Emit one gzip member without reading ahead from the async source."""
+    iterator = source.__aiter__()
+    if not callable(getattr(iterator, "__anext__", None)):
+        encoder.discard()
+        raise TypeError("source.__aiter__() must return an asynchronous iterator")
+    failed = False
+    try:
+        for output in encoder.start():
+            yield output
+
+        while True:
             try:
-                result: Any = close()
-                if hasattr(result, "__await__"):
-                    await result
-            except BaseException:
-                if not failed:
-                    raise
+                uncompressed = await iterator.__anext__()
+            except StopAsyncIteration:
+                break
+            if not isinstance(uncompressed, bytes):
+                raise TypeError("compress_chunks() source items must be bytes")
+            if not uncompressed:
+                continue
+            async for output in encoder.feed(uncompressed):
+                yield output
+
+        async for output in encoder.finish():
+            yield output
+    except BaseException:
+        failed = True
+        raise
+    finally:
+        encoder.discard()
+        await _close_async_iterator(iterator, failed=failed)
+
+
+async def _close_async_iterator(iterator: Any, *, failed: bool) -> None:
+    """Close a source iterator without replacing an active operation error."""
+    close = getattr(iterator, "aclose", None)
+    if not callable(close):
+        return
+    try:
+        result: Any = close()
+        if hasattr(result, "__await__"):
+            await result
+    except BaseException:
+        if not failed:
+            raise

--- a/src/aiogzip/_streaming.py
+++ b/src/aiogzip/_streaming.py
@@ -1,0 +1,71 @@
+"""Private async-iterable gzip streaming implementations."""
+
+from typing import Any, AsyncIterable, AsyncIterator, Optional
+
+from ._common import _validate_chunk_size, _validate_optional_positive_int
+from ._inspection import _IncrementalGzipDecoder
+
+
+def _decompress_chunks(
+    source: AsyncIterable[bytes],
+    *,
+    output_chunk_size: int,
+    max_decompressed_size: Optional[int],
+) -> AsyncIterator[bytes]:
+    """Validate arguments eagerly and return the decompression generator."""
+    if not callable(getattr(source, "__aiter__", None)):
+        raise TypeError("source must be an asynchronous iterable of bytes")
+    _validate_chunk_size(output_chunk_size)
+    _validate_optional_positive_int(max_decompressed_size, "max_decompressed_size")
+    return _decompress_chunks_impl(
+        source,
+        output_chunk_size=output_chunk_size,
+        max_decompressed_size=max_decompressed_size,
+    )
+
+
+async def _decompress_chunks_impl(
+    source: AsyncIterable[bytes],
+    *,
+    output_chunk_size: int,
+    max_decompressed_size: Optional[int],
+) -> AsyncIterator[bytes]:
+    """Pull compressed input only as bounded decompressed output is requested."""
+    decoder = _IncrementalGzipDecoder(
+        max_decompressed_size=max_decompressed_size,
+        output_chunk_size=output_chunk_size,
+        collect_member_info=False,
+    )
+    iterator = source.__aiter__()
+    if not callable(getattr(iterator, "__anext__", None)):
+        raise TypeError("source.__aiter__() must return an asynchronous iterator")
+    failed = False
+    try:
+        while True:
+            try:
+                compressed = await iterator.__anext__()
+            except StopAsyncIteration:
+                break
+            if not isinstance(compressed, bytes):
+                raise TypeError("decompress_chunks() source items must be bytes")
+            if not compressed:
+                continue
+            async for output in decoder.feed(compressed):
+                yield output
+
+        async for output in decoder.finish():
+            yield output
+    except BaseException:
+        failed = True
+        raise
+    finally:
+        decoder.discard()
+        close = getattr(iterator, "aclose", None)
+        if callable(close):
+            try:
+                result: Any = close()
+                if hasattr(result, "__await__"):
+                    await result
+            except BaseException:
+                if not failed:
+                    raise

--- a/tests/test_compress_chunks.py
+++ b/tests/test_compress_chunks.py
@@ -180,10 +180,13 @@ class TestCompressChunks:
         if _engine.have_fast_engine():
             output = await _collect(_items([b"payload"]), mtime=0, fast_compress=True)
         else:
-            with pytest.warns(UserWarning, match="zlib-ng is not available"):
+            with pytest.warns(
+                UserWarning, match="zlib-ng is not available"
+            ) as warnings:
                 output = await _collect(
                     _items([b"payload"]), mtime=0, fast_compress=True
                 )
+            assert warnings[0].filename == __file__
 
         assert calls == [True]
         assert gzip.decompress(b"".join(output)) == b"payload"

--- a/tests/test_compress_chunks.py
+++ b/tests/test_compress_chunks.py
@@ -1,0 +1,432 @@
+"""Tests for asynchronous iterable gzip compression."""
+
+import asyncio
+import gzip
+import os
+import random
+import struct
+import tracemalloc
+import zlib
+
+import pytest
+
+import aiogzip
+from aiogzip import _engine
+
+
+async def _items(values):
+    for value in values:
+        yield value
+
+
+async def _collect(source, **kwargs):
+    return [chunk async for chunk in aiogzip.compress_chunks(source, **kwargs)]
+
+
+class InstrumentedSource:
+    def __init__(self, values):
+        self.values = iter(values)
+        self.pulls = 0
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        self.pulls += 1
+        try:
+            return next(self.values)
+        except StopIteration as error:
+            raise StopAsyncIteration from error
+
+    async def aclose(self):
+        self.closed = True
+
+
+class NoCloseSource:
+    def __init__(self, values):
+        self.values = iter(values)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self.values)
+        except StopIteration as error:
+            raise StopAsyncIteration from error
+
+
+class NoisyCloseSource(NoCloseSource):
+    async def aclose(self):
+        raise RuntimeError("source close failed")
+
+
+def _assert_incomplete(compressed):
+    with pytest.raises((EOFError, gzip.BadGzipFile, zlib.error)):
+        gzip.decompress(compressed)
+
+
+class TestCompressChunks:
+    @pytest.mark.parametrize("values", [[], [b""], [b"", b"", b""]])
+    async def test_empty_source_produces_valid_empty_member(self, values):
+        output = await _collect(_items(values), mtime=0)
+        compressed = b"".join(output)
+
+        assert output
+        assert all(output)
+        assert gzip.decompress(compressed) == b""
+        assert compressed.startswith(b"\x1f\x8b")
+
+    async def test_one_and_many_input_chunks(self):
+        values = [b"first", b"", os.urandom(10000), b"last"]
+
+        output = await _collect(_items(values), mtime=0, output_chunk_size=31)
+
+        assert gzip.decompress(b"".join(output)) == b"".join(values)
+        assert all(0 < len(chunk) <= 31 for chunk in output)
+
+    @pytest.mark.parametrize("output_chunk_size", [1, 2, 9, 10, 17, 65536])
+    async def test_output_chunk_size_is_a_strict_bound(self, output_chunk_size):
+        payload = os.urandom(300000)
+
+        output = await _collect(
+            _items([payload]),
+            mtime=0,
+            output_chunk_size=output_chunk_size,
+        )
+
+        assert gzip.decompress(b"".join(output)) == payload
+        assert output
+        assert all(0 < len(chunk) <= output_chunk_size for chunk in output)
+
+    @pytest.mark.parametrize("seed", range(10))
+    async def test_random_input_boundaries(self, seed):
+        randomizer = random.Random(seed)
+        payload = bytes(randomizer.getrandbits(8) for _ in range(100000))
+        values = []
+        offset = 0
+        while offset < len(payload):
+            size = randomizer.randint(1, 2003)
+            values.append(payload[offset : offset + size])
+            offset += size
+
+        output = await _collect(_items(values), mtime=seed, output_chunk_size=997)
+
+        assert gzip.decompress(b"".join(output)) == payload
+
+    async def test_matches_existing_writer(self, tmp_path):
+        payload = (b"compressible data" * 10000) + os.urandom(50000)
+        output = await _collect(
+            _items([payload]),
+            mtime=0,
+            original_filename="payload.bin",
+        )
+        path = tmp_path / "writer.gz"
+        await aiogzip.write(
+            path,
+            payload,
+            mtime=0,
+            original_filename="payload.bin",
+        )
+
+        assert b"".join(output) == path.read_bytes()
+        assert gzip.decompress(b"".join(output)) == await aiogzip.read(path)
+
+    async def test_streaming_apis_pipeline_directly(self):
+        values = [b"hello ", b"", b"world", os.urandom(10000)]
+        compressed = aiogzip.compress_chunks(
+            _items(values), mtime=0, output_chunk_size=7
+        )
+
+        restored = b"".join(
+            [
+                chunk
+                async for chunk in aiogzip.decompress_chunks(
+                    compressed, output_chunk_size=5
+                )
+            ]
+        )
+
+        assert restored == b"".join(values)
+
+    async def test_metadata_and_deterministic_output(self):
+        payload = os.urandom(100000)
+        options = {
+            "mtime": 123,
+            "original_filename": "directory/events.jsonl.gz",
+            "output_chunk_size": 19,
+        }
+
+        first = b"".join(await _collect(_items([payload]), **options))
+        second = b"".join(await _collect(_items([payload]), **options))
+
+        assert first == second
+        assert struct.unpack("<I", first[4:8])[0] == 123
+        assert first[3] & 0x08
+        assert b"events.jsonl\x00" in first[:40]
+        assert gzip.decompress(first) == payload
+
+    async def test_fast_compression_option_reaches_engine(self, monkeypatch):
+        calls = []
+        real_compressobj = _engine.compressobj
+
+        def recording_compressobj(level, wbits, fast=False):
+            calls.append(fast)
+            return real_compressobj(level, wbits, fast=fast)
+
+        monkeypatch.setattr(_engine, "compressobj", recording_compressobj)
+
+        if _engine.have_fast_engine():
+            output = await _collect(_items([b"payload"]), mtime=0, fast_compress=True)
+        else:
+            with pytest.warns(UserWarning, match="zlib-ng is not available"):
+                output = await _collect(
+                    _items([b"payload"]), mtime=0, fast_compress=True
+                )
+
+        assert calls == [True]
+        assert gzip.decompress(b"".join(output)) == b"payload"
+
+    async def test_large_input_uses_executor(self, monkeypatch):
+        calls = []
+
+        async def recording_offload(method, data):
+            calls.append(len(data))
+            return method(data)
+
+        monkeypatch.setattr(_engine, "run_zlib_in_thread", recording_offload)
+        payload = os.urandom(_engine.ZLIB_OFFLOAD_THRESHOLD + 1)
+
+        output = await _collect(_items([payload]), mtime=0)
+
+        assert calls == [len(payload)]
+        assert gzip.decompress(b"".join(output)) == payload
+
+    def test_argument_validation_is_eager(self):
+        source = InstrumentedSource([])
+
+        with pytest.raises(TypeError):
+            aiogzip.compress_chunks(source, compresslevel=True)
+        with pytest.raises(ValueError):
+            aiogzip.compress_chunks(source, compresslevel=10)
+        with pytest.raises(TypeError):
+            aiogzip.compress_chunks(source, output_chunk_size=1.5)
+        with pytest.raises(ValueError):
+            aiogzip.compress_chunks(source, output_chunk_size=0)
+        with pytest.raises(ValueError):
+            aiogzip.compress_chunks(source, mtime=-1)
+        with pytest.raises(ValueError):
+            aiogzip.compress_chunks(source, original_filename="nul\x00name")
+
+        assert source.pulls == 0
+
+    @pytest.mark.parametrize("source", [[], iter([]), b""])
+    def test_synchronous_sources_are_rejected_eagerly(self, source):
+        with pytest.raises(TypeError, match="asynchronous iterable"):
+            aiogzip.compress_chunks(source)
+
+    async def test_aiter_must_return_async_iterator(self):
+        class InvalidAsyncIterable:
+            def __aiter__(self):
+                return object()
+
+        stream = aiogzip.compress_chunks(InvalidAsyncIterable(), mtime=0)
+        with pytest.raises(TypeError, match="must return an asynchronous iterator"):
+            await stream.__anext__()
+
+    @pytest.mark.parametrize("invalid", [bytearray(), memoryview(b"data"), "data", 1])
+    async def test_invalid_source_item_types(self, invalid):
+        with pytest.raises(TypeError, match="source items must be bytes"):
+            await _collect(_items([invalid]), mtime=0)
+
+    async def test_strict_size_rejects_synthetic_overflow(self):
+        class HugeBytes(bytes):
+            def __len__(self):
+                return 2**32
+
+        with pytest.raises(OSError, match="4 GiB limit"):
+            await _collect(_items([HugeBytes(b"x")]), mtime=0, strict_size=True)
+
+    async def test_source_failure_before_payload_emits_no_trailer(self):
+        expected = LookupError("source failed")
+
+        async def source():
+            if False:
+                yield b""
+            raise expected
+
+        emitted = []
+        with pytest.raises(LookupError) as caught:
+            async for chunk in aiogzip.compress_chunks(source(), mtime=0):
+                emitted.append(chunk)
+
+        assert caught.value is expected
+        assert b"".join(emitted).startswith(b"\x1f\x8b")
+        _assert_incomplete(b"".join(emitted))
+
+    async def test_source_failure_after_compressed_output_emits_no_trailer(self):
+        expected = LookupError("source failed")
+        payload = os.urandom(300000)
+
+        async def source():
+            yield payload
+            raise expected
+
+        emitted = []
+        with pytest.raises(LookupError) as caught:
+            async for chunk in aiogzip.compress_chunks(
+                source(), mtime=0, output_chunk_size=1024
+            ):
+                emitted.append(chunk)
+
+        assert caught.value is expected
+        assert len(emitted) > 1
+        _assert_incomplete(b"".join(emitted))
+
+    async def test_header_is_prompt_and_early_exit_does_not_pull_source(self):
+        source = InstrumentedSource([b"payload"])
+        stream = aiogzip.compress_chunks(source, mtime=0, output_chunk_size=4)
+
+        assert source.pulls == 0
+        assert await stream.__anext__() == b"\x1f\x8b\x08\x00"
+        assert source.pulls == 0
+
+        await stream.aclose()
+
+        assert source.pulls == 0
+        assert source.closed
+
+    async def test_complete_consumption_closes_source_iterator(self):
+        source = InstrumentedSource([b"payload"])
+
+        output = await _collect(source, mtime=0)
+
+        assert gzip.decompress(b"".join(output)) == b"payload"
+        assert source.closed
+
+    async def test_source_without_aclose_is_supported(self):
+        source = NoCloseSource([b"payload"])
+
+        output = await _collect(source, mtime=0)
+
+        assert gzip.decompress(b"".join(output)) == b"payload"
+
+    async def test_source_close_error_propagates_after_success(self):
+        source = NoisyCloseSource([b"payload"])
+
+        with pytest.raises(RuntimeError, match="source close failed"):
+            await _collect(source, mtime=0)
+
+    async def test_close_error_does_not_replace_source_failure(self):
+        source = NoisyCloseSource(["not bytes"])
+
+        with pytest.raises(TypeError, match="source items must be bytes"):
+            await _collect(source, mtime=0)
+
+    async def test_cancellation_while_waiting_on_source(self):
+        started = asyncio.Event()
+        closed = asyncio.Event()
+
+        async def source():
+            try:
+                started.set()
+                await asyncio.Event().wait()
+                yield b"unreachable"
+            finally:
+                closed.set()
+
+        stream = aiogzip.compress_chunks(source(), mtime=0)
+        assert await stream.__anext__()
+        task = asyncio.create_task(stream.__anext__())
+        await started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert closed.is_set()
+        with pytest.raises(StopAsyncIteration):
+            await stream.__anext__()
+
+    async def test_cancellation_during_offloaded_compression(self, monkeypatch):
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def blocked_offload(method, data):
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+
+        monkeypatch.setattr(_engine, "run_zlib_in_thread", blocked_offload)
+        payload = os.urandom(_engine.ZLIB_OFFLOAD_THRESHOLD + 1)
+        stream = aiogzip.compress_chunks(_items([payload]), mtime=0)
+        assert await stream.__anext__()
+        task = asyncio.create_task(stream.__anext__())
+        await started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert cancelled.is_set()
+        with pytest.raises(StopAsyncIteration):
+            await stream.__anext__()
+
+    async def test_early_exit_after_compressed_output_stops_source(self):
+        source = InstrumentedSource([os.urandom(300000), b"unexpected"])
+        stream = aiogzip.compress_chunks(source, mtime=0, output_chunk_size=1024)
+        emitted = [await stream.__anext__()]
+        while source.pulls == 0:
+            emitted.append(await stream.__anext__())
+        emitted.append(await stream.__anext__())
+
+        await stream.aclose()
+
+        assert source.pulls == 1
+        assert source.closed
+        _assert_incomplete(b"".join(emitted))
+
+    async def test_concurrent_advancement_is_rejected(self):
+        started = asyncio.Event()
+
+        async def source():
+            started.set()
+            await asyncio.Event().wait()
+            yield b"unreachable"
+
+        stream = aiogzip.compress_chunks(source(), mtime=0)
+        assert await stream.__anext__()
+        first = asyncio.create_task(stream.__anext__())
+        await started.wait()
+
+        with pytest.raises(RuntimeError):
+            await stream.__anext__()
+
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+    @pytest.mark.slow
+    async def test_highly_compressible_input_has_bounded_allocations(self):
+        payload_size = 8 * 1024 * 1024
+
+        async def source():
+            chunk = b"A" * (64 * 1024)
+            for _ in range(payload_size // len(chunk)):
+                yield chunk
+
+        total = 0
+        tracemalloc.start()
+        try:
+            async for chunk in aiogzip.compress_chunks(
+                source(), mtime=0, output_chunk_size=8192
+            ):
+                total += len(chunk)
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+
+        assert total > 0
+        assert total < payload_size
+        assert peak < 3 * 1024 * 1024

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -1,0 +1,50 @@
+"""Tests for gzip stream inspection contracts and behavior."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from aiogzip import GzipInfo, GzipMemberInfo, VerificationResult
+
+
+def _member() -> GzipMemberInfo:
+    return GzipMemberInfo(
+        index=0,
+        compressed_offset=0,
+        compressed_size=25,
+        uncompressed_size=5,
+        mtime=0,
+        original_filename="data.bin",
+        comment=None,
+        extra=None,
+        flags=8,
+        crc32=0x3610A686,
+        trailer_isize=5,
+    )
+
+
+def test_gzip_info_member_count():
+    member = _member()
+    info = GzipInfo(members=(member,), compressed_size=25, uncompressed_size=5)
+
+    assert info.member_count == 1
+    assert info.members == (member,)
+
+
+def test_empty_gzip_info_contract():
+    info = GzipInfo(members=(), compressed_size=0, uncompressed_size=0)
+
+    assert info.member_count == 0
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        _member(),
+        GzipInfo(members=(_member(),), compressed_size=25, uncompressed_size=5),
+        VerificationResult(member_count=1, compressed_size=25, uncompressed_size=5),
+    ],
+)
+def test_result_types_are_immutable(value):
+    with pytest.raises(FrozenInstanceError):
+        value.compressed_size = 0

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -1,10 +1,69 @@
 """Tests for gzip stream inspection contracts and behavior."""
 
+import asyncio
+import os
+import struct
+import zlib
 from dataclasses import FrozenInstanceError
 
 import pytest
 
-from aiogzip import GzipInfo, GzipMemberInfo, VerificationResult
+from aiogzip import GzipInfo, GzipMemberInfo, VerificationResult, _engine
+from aiogzip._inspection import _IncrementalGzipDecoder
+
+
+def _gzip_member(
+    payload,
+    *,
+    mtime=0,
+    filename=None,
+    comment=None,
+    extra=None,
+    header_crc=False,
+):
+    flags = 0
+    if extra is not None:
+        flags |= 0x04
+    if filename is not None:
+        flags |= 0x08
+    if comment is not None:
+        flags |= 0x10
+    if header_crc:
+        flags |= 0x02
+
+    header = bytearray(b"\x1f\x8b\x08")
+    header.append(flags)
+    header.extend(struct.pack("<I", mtime))
+    header.extend(b"\x00\xff")
+    if extra is not None:
+        header.extend(struct.pack("<H", len(extra)))
+        header.extend(extra)
+    if filename is not None:
+        header.extend(filename.encode("latin-1") + b"\x00")
+    if comment is not None:
+        header.extend(comment.encode("latin-1") + b"\x00")
+    if header_crc:
+        header.extend(struct.pack("<H", zlib.crc32(header) & 0xFFFF))
+
+    compressor = zlib.compressobj(6, zlib.DEFLATED, -zlib.MAX_WBITS)
+    body = compressor.compress(payload) + compressor.flush()
+    trailer = struct.pack("<II", zlib.crc32(payload), len(payload) & 0xFFFFFFFF)
+    return bytes(header) + body + trailer
+
+
+async def _decode(raw, *, input_chunk_size, output_chunk_size=64, limit=None):
+    decoder = _IncrementalGzipDecoder(
+        max_decompressed_size=limit,
+        output_chunk_size=output_chunk_size,
+        collect_member_info=True,
+    )
+    output = []
+    for offset in range(0, len(raw), input_chunk_size):
+        async for piece in decoder.feed(raw[offset : offset + input_chunk_size]):
+            output.append(piece)
+    async for piece in decoder.finish():
+        output.append(piece)
+    return decoder, output
 
 
 def _member() -> GzipMemberInfo:
@@ -48,3 +107,140 @@ def test_empty_gzip_info_contract():
 def test_result_types_are_immutable(value):
     with pytest.raises(FrozenInstanceError):
         value.compressed_size = 0
+
+
+class TestIncrementalGzipDecoder:
+    async def test_empty_input(self):
+        decoder, output = await _decode(b"", input_chunk_size=1)
+
+        assert output == []
+        assert decoder.members == ()
+        assert decoder.member_count == 0
+        assert decoder.compressed_size == 0
+        assert decoder.uncompressed_size == 0
+
+    async def test_metadata_members_offsets_and_padding_bytewise(self):
+        first_payload = b"first member"
+        second_payload = bytes(range(256)) * 3
+        first = _gzip_member(
+            first_payload,
+            mtime=0,
+            filename="café.bin",
+            comment="comment",
+            extra=b"\x01\x02\x03",
+            header_crc=True,
+        )
+        second = _gzip_member(second_payload, mtime=123456)
+        raw = first + b"\x00\x00\x00" + second
+
+        decoder, output = await _decode(raw, input_chunk_size=1, output_chunk_size=17)
+
+        assert b"".join(output) == first_payload + second_payload
+        assert output and all(0 < len(piece) <= 17 for piece in output)
+        assert decoder.compressed_size == len(raw)
+        assert decoder.uncompressed_size == len(first_payload) + len(second_payload)
+        assert decoder.member_count == 2
+        one, two = decoder.members
+        assert one.compressed_offset == 0
+        assert one.compressed_size == len(first)
+        assert one.uncompressed_size == len(first_payload)
+        assert one.mtime == 0
+        assert one.original_filename == "café.bin"
+        assert one.comment == "comment"
+        assert one.extra == b"\x01\x02\x03"
+        assert one.flags == 0x1E
+        assert one.crc32 == zlib.crc32(first_payload)
+        assert one.trailer_isize == len(first_payload)
+        assert two.compressed_offset == len(first) + 3
+        assert two.compressed_size == len(second)
+        assert two.mtime == 123456
+
+    @pytest.mark.parametrize("input_chunk_size", [2, 3, 7, 17, 257, 4096])
+    async def test_arbitrary_input_and_strict_output_chunks(self, input_chunk_size):
+        payload = (b"highly compressible data\n" * 10000) + os.urandom(4096)
+        raw = _gzip_member(payload)
+
+        decoder, output = await _decode(
+            raw,
+            input_chunk_size=input_chunk_size,
+            output_chunk_size=31,
+        )
+
+        assert b"".join(output) == payload
+        assert output and all(0 < len(piece) <= 31 for piece in output)
+        assert decoder.members[0].uncompressed_size == len(payload)
+
+    async def test_metadata_collection_can_be_disabled(self):
+        decoder = _IncrementalGzipDecoder(
+            max_decompressed_size=None,
+            output_chunk_size=1024,
+            collect_member_info=False,
+        )
+        raw = _gzip_member(b"one") + _gzip_member(b"two")
+
+        async for _ in decoder.feed(raw):
+            pass
+        async for _ in decoder.finish():
+            pass
+
+        assert decoder.members == ()
+        assert decoder.member_count == 2
+        assert decoder.uncompressed_size == 6
+
+    async def test_decompression_limit_is_cumulative(self):
+        raw = _gzip_member(b"abc") + _gzip_member(b"def")
+
+        decoder, output = await _decode(raw, input_chunk_size=5, limit=6)
+        assert b"".join(output) == b"abcdef"
+        assert decoder.uncompressed_size == 6
+
+        with pytest.raises(OSError, match="max_decompressed_size"):
+            await _decode(raw, input_chunk_size=5, limit=5)
+
+    @pytest.mark.parametrize("damage", ["crc", "isize", "header-crc"])
+    async def test_integrity_errors(self, damage):
+        raw = bytearray(_gzip_member(b"payload", header_crc=True))
+        if damage == "crc":
+            raw[-8] ^= 0x01
+            match = "CRC check failed"
+        elif damage == "isize":
+            raw[-4] ^= 0x01
+            match = "ISIZE check failed"
+        else:
+            raw[10] ^= 0x01
+            match = "Header CRC check failed"
+
+        with pytest.raises(OSError, match=match):
+            await _decode(bytes(raw), input_chunk_size=3)
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            b"not gzip",
+            b"\x1f\x8b",
+            _gzip_member(b"payload")[:-1],
+            _gzip_member(b"payload") + b"junk",
+        ],
+    )
+    async def test_malformed_or_truncated_input(self, raw):
+        with pytest.raises(OSError):
+            await _decode(raw, input_chunk_size=2)
+
+    async def test_cancelled_offload_discards_decoder(self, monkeypatch):
+        raw = _gzip_member(os.urandom(_engine.ZLIB_OFFLOAD_THRESHOLD + 1024))
+        decoder = _IncrementalGzipDecoder(
+            max_decompressed_size=None,
+            output_chunk_size=1024,
+            collect_member_info=False,
+        )
+
+        async def cancel_offload(method, data):
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(_engine, "run_zlib_in_thread", cancel_offload)
+
+        with pytest.raises(asyncio.CancelledError):
+            async for _ in decoder.feed(raw):
+                pass
+        with pytest.raises(OSError, match="unusable"):
+            decoder.feed(b"")

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -1,14 +1,19 @@
 """Tests for gzip stream inspection contracts and behavior."""
 
 import asyncio
+import gzip
+import io
 import os
 import struct
 import zlib
 from dataclasses import FrozenInstanceError
 
+import aiofiles
 import pytest
 
+import aiogzip
 from aiogzip import GzipInfo, GzipMemberInfo, VerificationResult, _engine
+from aiogzip import _inspection as inspection_module
 from aiogzip._inspection import _IncrementalGzipDecoder
 
 
@@ -244,3 +249,320 @@ class TestIncrementalGzipDecoder:
                 pass
         with pytest.raises(OSError, match="unusable"):
             decoder.feed(b"")
+
+
+class AsyncBytesReader:
+    def __init__(self, data, *, max_read=None):
+        self.buffer = io.BytesIO(data)
+        self.max_read = max_read
+        self.closed = False
+
+    async def read(self, size=-1):
+        if self.max_read is not None:
+            size = min(size, self.max_read)
+        return self.buffer.read(size)
+
+    async def close(self):
+        self.closed = True
+
+
+class TestInspectAndVerify:
+    @pytest.mark.parametrize("operation", [aiogzip.inspect, aiogzip.verify])
+    async def test_zero_byte_input(self, tmp_path, operation):
+        path = tmp_path / "empty-input.gz"
+        path.write_bytes(b"")
+
+        result = await operation(path)
+
+        assert result.member_count == 0
+        assert result.compressed_size == 0
+        assert result.uncompressed_size == 0
+        if isinstance(result, GzipInfo):
+            assert result.members == ()
+
+    async def test_empty_and_normal_members(self, tmp_path):
+        empty = gzip.compress(b"", mtime=0)
+        payload = bytes(range(256)) * 500
+        normal = gzip.compress(payload, mtime=123)
+        path = tmp_path / "members.gz"
+        path.write_bytes(empty + normal)
+
+        info = await aiogzip.inspect(path, chunk_size=17)
+        verified = await aiogzip.verify(path, chunk_size=19)
+
+        assert info.member_count == verified.member_count == 2
+        assert info.compressed_size == verified.compressed_size == len(empty + normal)
+        assert info.uncompressed_size == verified.uncompressed_size == len(payload)
+        assert info.members[0].uncompressed_size == 0
+        assert info.members[0].trailer_isize == 0
+        assert info.members[0].mtime == 0
+        assert info.members[1].uncompressed_size == len(payload)
+        assert info.members[1].mtime == 123
+
+    async def test_append_generated_members(self, tmp_path):
+        path = tmp_path / "append.gz"
+        await aiogzip.write(path, b"first", mtime=0)
+        async with aiogzip.open(path, "ab", mtime=1) as stream:
+            await stream.write(b"second")
+
+        info = await aiogzip.inspect(path)
+
+        assert info.member_count == 2
+        assert [member.uncompressed_size for member in info.members] == [5, 6]
+        assert info.members[1].compressed_offset == info.members[0].compressed_size
+        assert await aiogzip.read(path) == b"firstsecond"
+
+    async def test_all_header_metadata_and_exact_offsets(self):
+        first_payload = b"metadata payload"
+        second_payload = os.urandom(10000)
+        first = _gzip_member(
+            first_payload,
+            mtime=0,
+            filename="",
+            comment="café",
+            extra=b"\x00\xffextra",
+            header_crc=True,
+        )
+        second = _gzip_member(second_payload, filename="second.bin")
+        raw = first + b"\x00" * 5 + second + b"\x00" * 3
+        reader = AsyncBytesReader(raw, max_read=1)
+
+        info = await aiogzip.inspect(None, fileobj=reader, chunk_size=7)
+
+        assert not reader.closed
+        assert info.compressed_size == len(raw)
+        assert info.uncompressed_size == len(first_payload) + len(second_payload)
+        first_info, second_info = info.members
+        assert first_info.compressed_offset == 0
+        assert first_info.compressed_size == len(first)
+        assert first_info.original_filename == ""
+        assert first_info.comment == "café"
+        assert first_info.extra == b"\x00\xffextra"
+        assert first_info.mtime == 0
+        assert second_info.compressed_offset == len(first) + 5
+        assert second_info.compressed_size == len(second)
+        assert second_info.original_filename == "second.bin"
+
+    async def test_external_file_ownership(self):
+        raw = gzip.compress(b"payload", mtime=0)
+        default_reader = AsyncBytesReader(raw)
+        closing_reader = AsyncBytesReader(raw)
+
+        await aiogzip.verify(None, fileobj=default_reader)
+        await aiogzip.inspect(None, fileobj=closing_reader, closefd=True)
+
+        assert not default_reader.closed
+        assert closing_reader.closed
+
+    @pytest.mark.parametrize("operation", [aiogzip.inspect, aiogzip.verify])
+    async def test_exact_limit_succeeds_and_one_less_fails(self, operation):
+        raw = gzip.compress(b"abcdef", mtime=0)
+
+        result = await operation(
+            None,
+            fileobj=AsyncBytesReader(raw),
+            max_decompressed_size=6,
+            chunk_size=2,
+        )
+        assert result.uncompressed_size == 6
+
+        with pytest.raises(OSError, match="max_decompressed_size"):
+            await operation(
+                None,
+                fileobj=AsyncBytesReader(raw),
+                max_decompressed_size=5,
+                chunk_size=2,
+            )
+
+    async def test_limit_is_cumulative_across_members(self):
+        raw = gzip.compress(b"abc", mtime=0) + gzip.compress(b"def", mtime=0)
+
+        with pytest.raises(OSError, match="max_decompressed_size"):
+            await aiogzip.verify(
+                None,
+                fileobj=AsyncBytesReader(raw),
+                max_decompressed_size=5,
+                chunk_size=1,
+            )
+
+    @pytest.mark.parametrize("invalid", [True, 1.5, "10", 0, -1])
+    async def test_invalid_size_parameters(self, invalid):
+        expected = TypeError if invalid in (True, 1.5, "10") else ValueError
+        with pytest.raises(expected):
+            await aiogzip.inspect(
+                None,
+                fileobj=AsyncBytesReader(b""),
+                max_decompressed_size=invalid,
+            )
+
+        with pytest.raises(expected):
+            await aiogzip.verify(
+                None,
+                fileobj=AsyncBytesReader(b""),
+                chunk_size=invalid,
+            )
+
+    @pytest.mark.parametrize("operation", [aiogzip.inspect, aiogzip.verify])
+    async def test_trailing_nul_padding_accepted_other_data_rejected(self, operation):
+        member = gzip.compress(b"payload", mtime=0)
+
+        result = await operation(None, fileobj=AsyncBytesReader(member + b"\x00" * 9))
+        assert result.compressed_size == len(member) + 9
+
+        with pytest.raises(gzip.BadGzipFile):
+            await operation(None, fileobj=AsyncBytesReader(member + b"trailing"))
+
+    async def test_trailing_behavior_matches_existing_reader(self, tmp_path):
+        member = gzip.compress(b"payload", mtime=0)
+        padded = tmp_path / "padded.gz"
+        junk = tmp_path / "junk.gz"
+        padded.write_bytes(member + b"\x00" * 3)
+        junk.write_bytes(member + b"junk")
+
+        assert await aiogzip.read(padded) == b"payload"
+        await aiogzip.verify(padded)
+        with pytest.raises(OSError):
+            await aiogzip.read(junk)
+        with pytest.raises(OSError):
+            await aiogzip.verify(junk)
+
+    async def test_cross_implementation_consistency(self, tmp_path):
+        payload = (b"compressible\n" * 100000) + os.urandom(100000)
+        path = tmp_path / "cross.gz"
+        await aiogzip.write(path, payload, mtime=0)
+
+        info = await aiogzip.inspect(path)
+
+        raw = path.read_bytes()
+        assert gzip.decompress(raw) == payload
+        assert await aiogzip.read(path) == payload
+        assert info.uncompressed_size == len(payload)
+        assert info.members[0].crc32 == zlib.crc32(payload)
+
+    def test_actual_size_and_trailer_isize_are_distinct_fields(self):
+        member = GzipMemberInfo(
+            index=0,
+            compressed_offset=0,
+            compressed_size=1,
+            uncompressed_size=2**32 + 5,
+            mtime=None,
+            original_filename=None,
+            comment=None,
+            extra=None,
+            flags=0,
+            crc32=0,
+            trailer_isize=5,
+        )
+
+        assert member.uncompressed_size != member.trailer_isize
+
+
+class TestInspectionCorruption:
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            b"bad magic",
+            b"\x1f\x8b\x07\x00" + b"\x00" * 6,
+            b"\x1f\x8b\x08\xe0" + b"\x00" * 6,
+            b"\x1f\x8b\x08",
+            b"\x1f\x8b\x08\x04" + b"\x00" * 6 + b"\x05\x00ab",
+            b"\x1f\x8b\x08\x08" + b"\x00" * 6 + b"unterminated",
+            b"\x1f\x8b\x08\x10" + b"\x00" * 6 + b"unterminated",
+            b"\x1f\x8b\x08\x00" + b"\x00" * 6 + b"invalid deflate",
+            _gzip_member(b"payload")[:-8],
+            _gzip_member(b"payload")[:-3],
+        ],
+    )
+    async def test_malformed_boundaries(self, raw):
+        with pytest.raises(gzip.BadGzipFile):
+            await aiogzip.inspect(None, fileobj=AsyncBytesReader(raw), chunk_size=1)
+        with pytest.raises(gzip.BadGzipFile):
+            await aiogzip.verify(None, fileobj=AsyncBytesReader(raw), chunk_size=3)
+
+    @pytest.mark.parametrize("damage", ["header_crc", "crc", "isize", "body"])
+    async def test_integrity_corruption(self, damage):
+        raw = bytearray(_gzip_member(b"payload" * 100, header_crc=True))
+        if damage == "header_crc":
+            raw[10] ^= 0x80
+        elif damage == "crc":
+            raw[-8] ^= 0x80
+        elif damage == "isize":
+            raw[-4] ^= 0x80
+        else:
+            raw[20] ^= 0xFF
+
+        with pytest.raises(gzip.BadGzipFile):
+            await aiogzip.inspect(None, fileobj=AsyncBytesReader(bytes(raw)))
+
+    async def test_valid_first_member_corrupt_second_member(self):
+        raw = bytearray(_gzip_member(b"valid") + _gzip_member(b"corrupt"))
+        raw[-8] ^= 1
+
+        with pytest.raises(gzip.BadGzipFile, match="member 1"):
+            await aiogzip.inspect(None, fileobj=AsyncBytesReader(bytes(raw)))
+
+
+class TestInspectionLifecycle:
+    async def _tracking_internal_source(self, path, monkeypatch):
+        real_source = await aiofiles.open(path, "rb")
+        tracking = AsyncBytesReader(await real_source.read())
+        await real_source.close()
+
+        async def tracking_open(filename, mode):
+            return tracking
+
+        monkeypatch.setattr(inspection_module.aiofiles, "open", tracking_open)
+        return tracking
+
+    async def test_internal_source_closes_after_success(self, tmp_path, monkeypatch):
+        path = tmp_path / "valid.gz"
+        path.write_bytes(gzip.compress(b"payload"))
+        tracking = await self._tracking_internal_source(path, monkeypatch)
+
+        await aiogzip.inspect(path)
+
+        assert tracking.closed
+
+    async def test_internal_source_closes_after_corruption(self, tmp_path, monkeypatch):
+        path = tmp_path / "corrupt.gz"
+        path.write_bytes(b"not gzip")
+        tracking = await self._tracking_internal_source(path, monkeypatch)
+
+        with pytest.raises(gzip.BadGzipFile):
+            await aiogzip.verify(path)
+
+        assert tracking.closed
+
+    async def test_internal_source_closes_after_cancellation(
+        self, tmp_path, monkeypatch
+    ):
+        path = tmp_path / "cancel.gz"
+        path.write_bytes(b"")
+
+        class CancellingReader(AsyncBytesReader):
+            async def read(self, size=-1):
+                raise asyncio.CancelledError
+
+        tracking = CancellingReader(b"")
+
+        async def tracking_open(filename, mode):
+            return tracking
+
+        monkeypatch.setattr(inspection_module.aiofiles, "open", tracking_open)
+
+        with pytest.raises(asyncio.CancelledError):
+            await aiogzip.inspect(path)
+
+        assert tracking.closed
+
+    async def test_read_errors_propagate(self):
+        expected = OSError("source failed")
+
+        class FailingReader(AsyncBytesReader):
+            async def read(self, size=-1):
+                raise expected
+
+        with pytest.raises(OSError) as caught:
+            await aiogzip.verify(None, fileobj=FailingReader(b""))
+
+        assert caught.value is expected

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -268,6 +268,11 @@ class AsyncBytesReader:
 
 class TestInspectAndVerify:
     @pytest.mark.parametrize("operation", [aiogzip.inspect, aiogzip.verify])
+    def test_filename_argument_is_required(self, operation):
+        with pytest.raises(TypeError):
+            operation()
+
+    @pytest.mark.parametrize("operation", [aiogzip.inspect, aiogzip.verify])
     async def test_zero_byte_input(self, tmp_path, operation):
         path = tmp_path / "empty-input.gz"
         path.write_bytes(b"")
@@ -445,7 +450,7 @@ class TestInspectAndVerify:
             compressed_offset=0,
             compressed_size=1,
             uncompressed_size=2**32 + 5,
-            mtime=None,
+            mtime=0,
             original_filename=None,
             comment=None,
             extra=None,

--- a/tests/test_public_exports.py
+++ b/tests/test_public_exports.py
@@ -23,6 +23,9 @@ def test_key_re_exports_are_stable():
         AsyncGzipFile,
         AsyncGzipTextFile,
         EngineInfo,
+        GzipInfo,
+        GzipMemberInfo,
+        VerificationResult,
         WithAsyncRead,
         WithAsyncReadWrite,
         WithAsyncWrite,
@@ -36,6 +39,9 @@ def test_key_re_exports_are_stable():
     assert AsyncGzipTextFile is aiogzip.AsyncGzipTextFile
     assert AsyncGzipFile is aiogzip.AsyncGzipFile
     assert EngineInfo is aiogzip.EngineInfo
+    assert GzipInfo is aiogzip.GzipInfo
+    assert GzipMemberInfo is aiogzip.GzipMemberInfo
+    assert VerificationResult is aiogzip.VerificationResult
     assert WithAsyncRead is aiogzip.WithAsyncRead
     assert WithAsyncWrite is aiogzip.WithAsyncWrite
     assert WithAsyncReadWrite is aiogzip.WithAsyncReadWrite

--- a/tests/test_public_exports.py
+++ b/tests/test_public_exports.py
@@ -29,6 +29,7 @@ def test_key_re_exports_are_stable():
         WithAsyncRead,
         WithAsyncReadWrite,
         WithAsyncWrite,
+        decompress_chunks,
         engine_info,
         inspect,
         open,
@@ -53,3 +54,4 @@ def test_key_re_exports_are_stable():
     assert engine_info is aiogzip.engine_info
     assert inspect is aiogzip.inspect
     assert verify is aiogzip.verify
+    assert decompress_chunks is aiogzip.decompress_chunks

--- a/tests/test_public_exports.py
+++ b/tests/test_public_exports.py
@@ -30,8 +30,10 @@ def test_key_re_exports_are_stable():
         WithAsyncReadWrite,
         WithAsyncWrite,
         engine_info,
+        inspect,
         open,
         read,
+        verify,
         write,
     )
 
@@ -49,3 +51,5 @@ def test_key_re_exports_are_stable():
     assert read is aiogzip.read
     assert write is aiogzip.write
     assert engine_info is aiogzip.engine_info
+    assert inspect is aiogzip.inspect
+    assert verify is aiogzip.verify

--- a/tests/test_public_exports.py
+++ b/tests/test_public_exports.py
@@ -29,6 +29,7 @@ def test_key_re_exports_are_stable():
         WithAsyncRead,
         WithAsyncReadWrite,
         WithAsyncWrite,
+        compress_chunks,
         decompress_chunks,
         engine_info,
         inspect,
@@ -55,3 +56,4 @@ def test_key_re_exports_are_stable():
     assert inspect is aiogzip.inspect
     assert verify is aiogzip.verify
     assert decompress_chunks is aiogzip.decompress_chunks
+    assert compress_chunks is aiogzip.compress_chunks

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -12,6 +12,7 @@ import pytest
 
 import aiogzip
 from aiogzip import _engine
+from aiogzip import _streaming as streaming_module
 
 
 async def _chunks(data, size):
@@ -91,6 +92,35 @@ class TestDecompressChunks:
         output = await _collect(_items(values))
 
         assert output == []
+
+    async def test_final_decoder_output_is_forwarded(self, monkeypatch):
+        class FinalOutputDecoder:
+            def __init__(self, **kwargs):
+                pass
+
+            async def _empty(self):
+                if False:
+                    yield b""
+
+            def feed(self, data):
+                return self._empty()
+
+            async def _final(self):
+                yield b"final output"
+
+            def finish(self):
+                return self._final()
+
+            def discard(self):
+                pass
+
+        monkeypatch.setattr(
+            streaming_module, "_IncrementalGzipDecoder", FinalOutputDecoder
+        )
+
+        output = await _collect(_items([]))
+
+        assert output == [b"final output"]
 
     @pytest.mark.parametrize("input_chunk_size", [1, 2, 3, 7, 17, 257, 4096])
     async def test_one_member_arbitrary_input_chunks(self, input_chunk_size):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -66,6 +66,25 @@ class InstrumentedSource:
         self.closed = True
 
 
+class NoCloseSource:
+    def __init__(self, values):
+        self.values = iter(values)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self.values)
+        except StopIteration as error:
+            raise StopAsyncIteration from error
+
+
+class NoisyCloseSource(NoCloseSource):
+    async def aclose(self):
+        raise RuntimeError("source close failed")
+
+
 class TestDecompressChunks:
     @pytest.mark.parametrize("values", [[], [b""], [b"", b"", b""]])
     async def test_zero_byte_source(self, values):
@@ -250,6 +269,14 @@ class TestDecompressChunks:
         with pytest.raises(TypeError, match="asynchronous iterable"):
             aiogzip.decompress_chunks(source)
 
+    async def test_aiter_must_return_an_async_iterator(self):
+        class InvalidAsyncIterable:
+            def __aiter__(self):
+                return object()
+
+        with pytest.raises(TypeError, match="must return an asynchronous iterator"):
+            await _collect(InvalidAsyncIterable())
+
     @pytest.mark.parametrize("invalid", [bytearray(), memoryview(b"data"), "data", 1])
     async def test_invalid_source_item_types(self, invalid):
         with pytest.raises(TypeError, match="source items must be bytes"):
@@ -273,6 +300,23 @@ class TestDecompressChunks:
 
         assert b"".join(await _collect(source)) == b"payload"
         assert source.closed
+
+    async def test_source_without_aclose_is_supported(self):
+        source = NoCloseSource([gzip.compress(b"payload", mtime=0)])
+
+        assert b"".join(await _collect(source)) == b"payload"
+
+    async def test_source_close_error_propagates_after_success(self):
+        source = NoisyCloseSource([gzip.compress(b"payload", mtime=0)])
+
+        with pytest.raises(RuntimeError, match="source close failed"):
+            await _collect(source)
+
+    async def test_source_close_error_does_not_replace_operation_failure(self):
+        source = NoisyCloseSource(["not bytes"])
+
+        with pytest.raises(TypeError, match="source items must be bytes"):
+            await _collect(source)
 
     async def test_no_eager_source_consumption_and_early_close(self):
         compressed = gzip.compress(b"payload", mtime=0)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,395 @@
+"""Tests for asynchronous iterable gzip streaming APIs."""
+
+import asyncio
+import gzip
+import os
+import random
+import struct
+import tracemalloc
+import zlib
+
+import pytest
+
+import aiogzip
+from aiogzip import _engine
+
+
+async def _chunks(data, size):
+    for offset in range(0, len(data), size):
+        yield data[offset : offset + size]
+
+
+async def _items(values):
+    for value in values:
+        yield value
+
+
+async def _collect(source, **kwargs):
+    return [chunk async for chunk in aiogzip.decompress_chunks(source, **kwargs)]
+
+
+def _metadata_member(payload):
+    flags = 0x04 | 0x08 | 0x10 | 0x02
+    header = bytearray(b"\x1f\x8b\x08")
+    header.append(flags)
+    header.extend(struct.pack("<I", 123))
+    header.extend(b"\x00\xff")
+    extra = b"\x01\x02extra"
+    header.extend(struct.pack("<H", len(extra)))
+    header.extend(extra)
+    header.extend("café.bin".encode("latin-1") + b"\x00")
+    header.extend(b"streaming test\x00")
+    header.extend(struct.pack("<H", zlib.crc32(header) & 0xFFFF))
+    compressor = zlib.compressobj(6, zlib.DEFLATED, -zlib.MAX_WBITS)
+    body = compressor.compress(payload) + compressor.flush()
+    trailer = struct.pack("<II", zlib.crc32(payload), len(payload))
+    return bytes(header) + body + trailer
+
+
+class InstrumentedSource:
+    def __init__(self, values):
+        self.values = iter(values)
+        self.pulls = 0
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        self.pulls += 1
+        try:
+            return next(self.values)
+        except StopIteration as error:
+            raise StopAsyncIteration from error
+
+    async def aclose(self):
+        self.closed = True
+
+
+class TestDecompressChunks:
+    @pytest.mark.parametrize("values", [[], [b""], [b"", b"", b""]])
+    async def test_zero_byte_source(self, values):
+        output = await _collect(_items(values))
+
+        assert output == []
+
+    @pytest.mark.parametrize("input_chunk_size", [1, 2, 3, 7, 17, 257, 4096])
+    async def test_one_member_arbitrary_input_chunks(self, input_chunk_size):
+        payload = (b"streaming payload\n" * 5000) + os.urandom(4096)
+        compressed = gzip.compress(payload, mtime=0)
+
+        output = await _collect(
+            _chunks(compressed, input_chunk_size), output_chunk_size=113
+        )
+
+        assert b"".join(output) == payload
+        assert output
+        assert all(0 < len(chunk) <= 113 for chunk in output)
+
+    async def test_concatenated_members_and_empty_chunks(self):
+        payloads = [b"first", b"", os.urandom(10000)]
+        compressed = b"".join(gzip.compress(value, mtime=0) for value in payloads)
+        values = []
+        for offset in range(0, len(compressed), 11):
+            values.extend([b"", compressed[offset : offset + 11]])
+
+        output = await _collect(_items(values), output_chunk_size=7)
+
+        assert b"".join(output) == b"".join(payloads)
+        assert all(0 < len(chunk) <= 7 for chunk in output)
+
+    async def test_metadata_heavy_header_split_bytewise(self):
+        payload = b"metadata payload" * 100
+        compressed = _metadata_member(payload)
+
+        output = await _collect(_chunks(compressed, 1), output_chunk_size=13)
+
+        assert b"".join(output) == payload
+
+    @pytest.mark.parametrize("output_chunk_size", [1, 2, 9, 256 * 1024, 1024 * 1024])
+    async def test_output_chunk_size_is_a_strict_bound(self, output_chunk_size):
+        payload = os.urandom(300000)
+        compressed = gzip.compress(payload, mtime=0)
+
+        output = await _collect(
+            _chunks(compressed, 1009), output_chunk_size=output_chunk_size
+        )
+
+        assert b"".join(output) == payload
+        assert output
+        assert all(0 < len(chunk) <= output_chunk_size for chunk in output)
+
+    @pytest.mark.parametrize("seed", range(10))
+    async def test_random_input_boundaries(self, seed):
+        randomizer = random.Random(seed)
+        payload = bytes(randomizer.getrandbits(8) for _ in range(50000))
+        compressed = gzip.compress(payload, mtime=seed)
+
+        async def random_chunks():
+            offset = 0
+            while offset < len(compressed):
+                size = randomizer.randint(1, 997)
+                yield compressed[offset : offset + size]
+                offset += size
+
+        output = await _collect(random_chunks(), output_chunk_size=251)
+
+        assert b"".join(output) == payload
+        assert gzip.decompress(compressed) == payload
+
+    async def test_matches_file_reader_and_stdlib(self, tmp_path):
+        payload = (b"abc123" * 100000) + os.urandom(50000)
+        compressed = gzip.compress(payload, mtime=0)
+        path = tmp_path / "stream.gz"
+        path.write_bytes(compressed)
+
+        streamed = b"".join(await _collect(_chunks(compressed, 313)))
+
+        assert streamed == await aiogzip.read(path)
+        assert streamed == gzip.decompress(compressed)
+
+    @pytest.mark.parametrize(
+        "compressed",
+        [
+            b"not gzip",
+            b"\x1f\x8b",
+            gzip.compress(b"payload", mtime=0)[:-9],
+            gzip.compress(b"payload", mtime=0)[:-1],
+        ],
+    )
+    async def test_malformed_or_truncated_input(self, compressed):
+        with pytest.raises(gzip.BadGzipFile):
+            await _collect(_chunks(compressed, 2))
+
+    async def test_trailer_corruption_can_follow_yielded_payload(self):
+        payload = b"payload available before trailer validation"
+        compressed = bytearray(gzip.compress(payload, mtime=0))
+        compressed[-8] ^= 1
+        stream = aiogzip.decompress_chunks(_items([bytes(compressed)]))
+        output = []
+
+        with pytest.raises(gzip.BadGzipFile, match="CRC check failed"):
+            while True:
+                output.append(await stream.__anext__())
+
+        assert b"".join(output) == payload
+
+    async def test_corrupt_deflate_payload(self):
+        compressed = bytearray(gzip.compress(os.urandom(1000), mtime=0))
+        compressed[len(compressed) // 2] ^= 0xFF
+
+        with pytest.raises(gzip.BadGzipFile):
+            await _collect(_items([bytes(compressed)]))
+
+    @pytest.mark.parametrize("damage", ["reserved flags", "header crc"])
+    async def test_corrupt_header_fields(self, damage):
+        if damage == "reserved flags":
+            compressed = bytearray(gzip.compress(b"payload", mtime=0))
+            compressed[3] |= 0x20
+        else:
+            compressed = bytearray(_metadata_member(b"payload"))
+            compressed[4] ^= 1
+
+        with pytest.raises(gzip.BadGzipFile):
+            await _collect(_chunks(bytes(compressed), 1))
+
+    async def test_trailing_padding_matches_reader_behavior(self):
+        member = gzip.compress(b"payload", mtime=0)
+
+        assert b"".join(await _collect(_items([member + b"\x00" * 5]))) == b"payload"
+        with pytest.raises(gzip.BadGzipFile):
+            await _collect(_items([member + b"junk"]))
+
+    async def test_exact_and_cumulative_decompression_limits(self):
+        compressed = gzip.compress(b"abc", mtime=0) + gzip.compress(b"def", mtime=0)
+
+        output = await _collect(
+            _chunks(compressed, 3),
+            output_chunk_size=2,
+            max_decompressed_size=6,
+        )
+        assert b"".join(output) == b"abcdef"
+
+        with pytest.raises(OSError, match="max_decompressed_size"):
+            await _collect(
+                _chunks(compressed, 3),
+                output_chunk_size=2,
+                max_decompressed_size=5,
+            )
+
+    async def test_limit_failure_does_not_yield_over_limit_output(self):
+        compressed = gzip.compress(b"A" * (8 * 1024 * 1024), mtime=0)
+        emitted = 0
+
+        with pytest.raises(OSError, match="max_decompressed_size"):
+            async for chunk in aiogzip.decompress_chunks(
+                _chunks(compressed, 31),
+                output_chunk_size=128,
+                max_decompressed_size=1000,
+            ):
+                emitted += len(chunk)
+
+        assert emitted <= 1000
+
+    @pytest.mark.parametrize("invalid", [True, 1.5, "1", 0, -1, 128 * 1024 * 1024 + 1])
+    def test_invalid_output_chunk_size_is_rejected_eagerly(self, invalid):
+        expected = TypeError if invalid in (True, 1.5, "1") else ValueError
+
+        with pytest.raises(expected):
+            aiogzip.decompress_chunks(_items([]), output_chunk_size=invalid)
+
+    @pytest.mark.parametrize("invalid", [True, 1.5, "1", 0, -1])
+    def test_invalid_limit_is_rejected_eagerly(self, invalid):
+        expected = TypeError if invalid in (True, 1.5, "1") else ValueError
+
+        with pytest.raises(expected):
+            aiogzip.decompress_chunks(_items([]), max_decompressed_size=invalid)
+
+    @pytest.mark.parametrize("source", [[], iter([]), b""])
+    def test_synchronous_sources_are_rejected_eagerly(self, source):
+        with pytest.raises(TypeError, match="asynchronous iterable"):
+            aiogzip.decompress_chunks(source)
+
+    @pytest.mark.parametrize("invalid", [bytearray(), memoryview(b"data"), "data", 1])
+    async def test_invalid_source_item_types(self, invalid):
+        with pytest.raises(TypeError, match="source items must be bytes"):
+            await _collect(_items([invalid]))
+
+    async def test_source_exception_propagates(self):
+        expected = LookupError("source failed")
+
+        async def failing_source():
+            yield gzip.compress(b"first", mtime=0)
+            raise expected
+
+        stream = aiogzip.decompress_chunks(failing_source())
+        assert await stream.__anext__() == b"first"
+        with pytest.raises(LookupError) as caught:
+            await stream.__anext__()
+        assert caught.value is expected
+
+    async def test_source_iterator_closes_after_complete_consumption(self):
+        source = InstrumentedSource([gzip.compress(b"payload", mtime=0)])
+
+        assert b"".join(await _collect(source)) == b"payload"
+        assert source.closed
+
+    async def test_no_eager_source_consumption_and_early_close(self):
+        compressed = gzip.compress(b"payload", mtime=0)
+        source = InstrumentedSource([compressed, b"", b"unexpected"])
+
+        stream = aiogzip.decompress_chunks(source, output_chunk_size=1)
+        assert source.pulls == 0
+        assert await stream.__anext__() == b"p"
+        assert source.pulls == 1
+
+        await stream.aclose()
+
+        assert source.pulls == 1
+        assert source.closed
+
+    async def test_cancellation_while_waiting_on_source(self):
+        started = asyncio.Event()
+        closed = asyncio.Event()
+
+        async def waiting_source():
+            try:
+                started.set()
+                await asyncio.Event().wait()
+                yield b"unreachable"
+            finally:
+                closed.set()
+
+        stream = aiogzip.decompress_chunks(waiting_source())
+        task = asyncio.create_task(stream.__anext__())
+        await started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert closed.is_set()
+
+    async def test_cancellation_during_offloaded_codec_work(self, monkeypatch):
+        compressed = gzip.compress(
+            os.urandom(_engine.ZLIB_OFFLOAD_THRESHOLD + 1024), mtime=0
+        )
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def blocked_offload(method, data):
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+
+        monkeypatch.setattr(_engine, "run_zlib_in_thread", blocked_offload)
+        stream = aiogzip.decompress_chunks(_items([compressed]))
+        task = asyncio.create_task(stream.__anext__())
+        await started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert cancelled.is_set()
+
+    async def test_cancellation_after_output_has_been_yielded(self):
+        payload = b"output before cancellation"
+        compressed = gzip.compress(payload, mtime=0)
+        waiting = asyncio.Event()
+        closed = asyncio.Event()
+
+        async def source():
+            try:
+                yield compressed[:-8]
+                waiting.set()
+                await asyncio.Event().wait()
+            finally:
+                closed.set()
+
+        stream = aiogzip.decompress_chunks(source())
+        assert await stream.__anext__() == payload
+        task = asyncio.create_task(stream.__anext__())
+        await waiting.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert closed.is_set()
+
+    async def test_concurrent_advancement_has_a_clear_error(self):
+        started = asyncio.Event()
+
+        async def waiting_source():
+            started.set()
+            await asyncio.Event().wait()
+            yield b"unreachable"
+
+        stream = aiogzip.decompress_chunks(waiting_source())
+        first = asyncio.create_task(stream.__anext__())
+        await started.wait()
+
+        with pytest.raises(RuntimeError):
+            await stream.__anext__()
+
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+    @pytest.mark.slow
+    async def test_highly_compressible_input_has_bounded_python_allocations(self):
+        payload_size = 8 * 1024 * 1024
+        compressed = gzip.compress(b"A" * payload_size, mtime=0)
+        total = 0
+        tracemalloc.start()
+        try:
+            async for chunk in aiogzip.decompress_chunks(
+                _chunks(compressed, 97), output_chunk_size=8192
+            ):
+                total += len(chunk)
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+
+        assert total == payload_size
+        assert peak < 3 * 1024 * 1024

--- a/tests/test_streaming_encoder.py
+++ b/tests/test_streaming_encoder.py
@@ -128,7 +128,11 @@ class TestIncrementalGzipEncoder:
 
         monkeypatch.setattr(_engine, "compressobj", recording_compressobj)
 
-        _, output = await _encode([b"payload"], fast_compress=True)
+        if _engine.have_fast_engine():
+            _, output = await _encode([b"payload"], fast_compress=True)
+        else:
+            with pytest.warns(UserWarning, match="zlib-ng is not available"):
+                _, output = await _encode([b"payload"], fast_compress=True)
 
         assert calls == [True]
         assert gzip.decompress(b"".join(output)) == b"payload"
@@ -299,6 +303,10 @@ class TestIncrementalGzipEncoder:
         second_feed = encoder.feed(b"second")
         with pytest.raises(RuntimeError, match="concurrently"):
             await second_feed.__anext__()
+
+        finalization = encoder.finish()
+        with pytest.raises(RuntimeError, match="concurrently"):
+            await finalization.__anext__()
 
         first.cancel()
         with pytest.raises(asyncio.CancelledError):

--- a/tests/test_streaming_encoder.py
+++ b/tests/test_streaming_encoder.py
@@ -1,0 +1,375 @@
+"""Tests for the private incremental gzip encoder."""
+
+import asyncio
+import gzip
+import os
+import struct
+import zlib
+
+import pytest
+
+import aiogzip
+from aiogzip import _engine
+from aiogzip._streaming import _IncrementalGzipEncoder
+
+
+def _encoder(**overrides):
+    options = {
+        "compresslevel": 6,
+        "mtime": 0,
+        "original_filename": None,
+        "fast_compress": False,
+        "strict_size": False,
+        "output_chunk_size": 64,
+    }
+    options.update(overrides)
+    return _IncrementalGzipEncoder(**options)
+
+
+async def _encode(values, **overrides):
+    encoder = _encoder(**overrides)
+    output = list(encoder.start())
+    for value in values:
+        async for chunk in encoder.feed(value):
+            output.append(chunk)
+    async for chunk in encoder.finish():
+        output.append(chunk)
+    return encoder, output
+
+
+class TestIncrementalGzipEncoder:
+    async def test_empty_input_produces_one_valid_member(self):
+        encoder, output = await _encode([])
+        compressed = b"".join(output)
+
+        assert gzip.decompress(compressed) == b""
+        assert compressed.startswith(b"\x1f\x8b")
+        assert len(compressed) >= 20
+        assert encoder.input_size == 0
+        assert encoder.crc32 == 0
+
+    @pytest.mark.parametrize("output_chunk_size", [1, 2, 9, 10, 17, 256 * 1024])
+    async def test_strict_output_bound(self, output_chunk_size):
+        payload = os.urandom(300000)
+
+        _, output = await _encode([payload], output_chunk_size=output_chunk_size)
+
+        assert gzip.decompress(b"".join(output)) == payload
+        assert output
+        assert all(0 < len(chunk) <= output_chunk_size for chunk in output)
+
+    async def test_many_input_chunks_preserve_order(self):
+        values = [b"first", b"", os.urandom(10000), b"last"]
+
+        encoder, output = await _encode(values, output_chunk_size=31)
+
+        assert gzip.decompress(b"".join(output)) == b"".join(values)
+        assert encoder.input_size == sum(len(value) for value in values)
+        assert encoder.crc32 == zlib.crc32(b"".join(values))
+
+    async def test_metadata_matches_existing_writer(self, tmp_path):
+        payload = b"metadata payload" * 100
+        encoder, output = await _encode(
+            [payload],
+            mtime=123,
+            original_filename="directory/events.jsonl.gz",
+        )
+        streamed = b"".join(output)
+        path = tmp_path / "different.gz"
+        await aiogzip.write(
+            path,
+            payload,
+            mtime=123,
+            original_filename="directory/events.jsonl.gz",
+        )
+
+        assert streamed == path.read_bytes()
+        assert gzip.decompress(streamed) == payload
+        assert struct.unpack("<I", streamed[4:8])[0] == 123
+        assert streamed[3] & 0x08
+        assert b"events.jsonl\x00" in streamed[:40]
+        assert encoder.input_size == len(payload)
+
+    async def test_explicit_metadata_is_deterministic(self):
+        payload = os.urandom(100000)
+
+        _, first = await _encode([payload], mtime=0, original_filename="payload.bin")
+        _, second = await _encode([payload], mtime=0, original_filename="payload.bin")
+
+        assert b"".join(first) == b"".join(second)
+
+    async def test_default_filename_is_absent(self):
+        _, output = await _encode([b"payload"])
+
+        assert b"".join(output)[3] & 0x08 == 0
+
+    async def test_default_compression_uses_stdlib_selection(self, monkeypatch):
+        calls = []
+        real_compressobj = _engine.compressobj
+
+        def recording_compressobj(level, wbits, fast=False):
+            calls.append(fast)
+            return real_compressobj(level, wbits, fast=fast)
+
+        monkeypatch.setattr(_engine, "compressobj", recording_compressobj)
+
+        _, output = await _encode([b"payload"])
+
+        assert calls == [False]
+        assert gzip.decompress(b"".join(output)) == b"payload"
+
+    async def test_fast_compression_selection_roundtrips(self, monkeypatch):
+        calls = []
+        real_compressobj = _engine.compressobj
+
+        def recording_compressobj(level, wbits, fast=False):
+            calls.append(fast)
+            return real_compressobj(level, wbits, fast=fast)
+
+        monkeypatch.setattr(_engine, "compressobj", recording_compressobj)
+
+        _, output = await _encode([b"payload"], fast_compress=True)
+
+        assert calls == [True]
+        assert gzip.decompress(b"".join(output)) == b"payload"
+
+    def test_fast_compression_warns_when_unavailable(self, monkeypatch):
+        monkeypatch.setattr(_engine, "have_fast_engine", lambda: False)
+
+        with pytest.warns(UserWarning, match="zlib-ng is not available"):
+            _encoder(fast_compress=True)
+
+    async def test_large_feed_uses_executor_offload(self, monkeypatch):
+        calls = []
+
+        async def recording_offload(method, data):
+            calls.append(len(data))
+            return method(data)
+
+        monkeypatch.setattr(_engine, "run_zlib_in_thread", recording_offload)
+        payload = os.urandom(_engine.ZLIB_OFFLOAD_THRESHOLD + 1)
+
+        _, output = await _encode([payload])
+
+        assert calls == [len(payload)]
+        assert gzip.decompress(b"".join(output)) == payload
+
+    async def test_cancelled_offload_makes_encoder_unusable(self, monkeypatch):
+        started = asyncio.Event()
+
+        async def blocked_offload(method, data):
+            started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(_engine, "run_zlib_in_thread", blocked_offload)
+        encoder = _encoder()
+        list(encoder.start())
+        payload = os.urandom(_engine.ZLIB_OFFLOAD_THRESHOLD + 1)
+        feed = encoder.feed(payload)
+        task = asyncio.create_task(feed.__anext__())
+        await started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        with pytest.raises(OSError, match="unusable"):
+            encoder.finish()
+
+    async def test_codec_error_makes_encoder_unusable(self, monkeypatch):
+        class BrokenCompressor:
+            def compress(self, data):
+                raise zlib.error("broken codec")
+
+            def flush(self):
+                return b""
+
+        monkeypatch.setattr(
+            _engine, "compressobj", lambda *args, **kwargs: BrokenCompressor()
+        )
+        encoder = _encoder()
+        list(encoder.start())
+
+        with pytest.raises(OSError, match="Error compressing data"):
+            async for _ in encoder.feed(b"payload"):
+                pass
+        with pytest.raises(OSError, match="unusable"):
+            encoder.feed(b"more")
+
+    async def test_unexpected_codec_error_is_wrapped(self, monkeypatch):
+        class BrokenCompressor:
+            def compress(self, data):
+                raise RuntimeError("unexpected codec failure")
+
+            def flush(self):
+                return b""
+
+        monkeypatch.setattr(
+            _engine, "compressobj", lambda *args, **kwargs: BrokenCompressor()
+        )
+        encoder = _encoder()
+        list(encoder.start())
+
+        with pytest.raises(OSError, match="Unexpected error during compression"):
+            async for _ in encoder.feed(b"payload"):
+                pass
+
+    @pytest.mark.parametrize(
+        ("failure", "message"),
+        [
+            (zlib.error("flush failed"), "Error finalizing compressed data"),
+            (
+                RuntimeError("flush failed"),
+                "Unexpected error during compression finalization",
+            ),
+        ],
+    )
+    async def test_finalization_errors_make_encoder_unusable(
+        self, monkeypatch, failure, message
+    ):
+        class BrokenCompressor:
+            def compress(self, data):
+                return b""
+
+            def flush(self):
+                raise failure
+
+        monkeypatch.setattr(
+            _engine, "compressobj", lambda *args, **kwargs: BrokenCompressor()
+        )
+        encoder = _encoder()
+        list(encoder.start())
+
+        with pytest.raises(OSError, match=message):
+            async for _ in encoder.finish():
+                pass
+        assert encoder._failed
+
+    async def test_abandoned_feed_makes_encoder_unusable(self):
+        encoder = _encoder(output_chunk_size=1)
+        list(encoder.start())
+        feed = encoder.feed(os.urandom(300000))
+
+        assert await feed.__anext__()
+        await feed.aclose()
+
+        with pytest.raises(OSError, match="unusable"):
+            encoder.finish()
+
+    async def test_abandoned_finalization_is_rejected(self):
+        encoder = _encoder(output_chunk_size=1)
+        list(encoder.start())
+        async for _ in encoder.feed(b"payload"):
+            pass
+        finalization = encoder.finish()
+
+        assert await finalization.__anext__()
+        await finalization.aclose()
+
+        assert encoder._failed
+        with pytest.raises(ValueError, match="already finalized"):
+            encoder.finish()
+
+    async def test_finalizes_exactly_once_and_rejects_later_feeds(self):
+        encoder = _encoder()
+        list(encoder.start())
+        async for _ in encoder.feed(b"payload"):
+            pass
+        output = [chunk async for chunk in encoder.finish()]
+
+        assert output
+        with pytest.raises(ValueError, match="already finalized"):
+            encoder.finish()
+        with pytest.raises(ValueError, match="already finalized"):
+            encoder.feed(b"more")
+
+    async def test_concurrent_advancement_is_rejected(self, monkeypatch):
+        started = asyncio.Event()
+
+        async def blocked_offload(method, data):
+            started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(_engine, "run_zlib_in_thread", blocked_offload)
+        encoder = _encoder()
+        list(encoder.start())
+        first_feed = encoder.feed(os.urandom(_engine.ZLIB_OFFLOAD_THRESHOLD + 1))
+        first = asyncio.create_task(first_feed.__anext__())
+        await started.wait()
+
+        second_feed = encoder.feed(b"second")
+        with pytest.raises(RuntimeError, match="concurrently"):
+            await second_feed.__anext__()
+
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+    def test_start_and_finish_order_is_enforced(self):
+        encoder = _encoder()
+
+        with pytest.raises(ValueError, match="started before feeding"):
+            encoder.feed(b"payload")
+        with pytest.raises(ValueError, match="started before finalizing"):
+            encoder.finish()
+        list(encoder.start())
+        with pytest.raises(ValueError, match="already started"):
+            encoder.start()
+
+    def test_discard_is_one_way(self):
+        encoder = _encoder()
+        list(encoder.start())
+
+        encoder.discard()
+
+        assert encoder._engine is None
+        with pytest.raises(OSError, match="unusable"):
+            encoder.feed(b"payload")
+
+    @pytest.mark.parametrize("invalid", [bytearray(), memoryview(b"data"), "data", 1])
+    def test_feed_accepts_only_bytes(self, invalid):
+        encoder = _encoder()
+        list(encoder.start())
+
+        with pytest.raises(TypeError, match="input must be bytes"):
+            encoder.feed(invalid)
+
+    @pytest.mark.parametrize("invalid", [True, 1.5, "6", -2, 10])
+    def test_invalid_compression_level(self, invalid):
+        expected = TypeError if invalid in (True, 1.5, "6") else ValueError
+        with pytest.raises(expected):
+            _encoder(compresslevel=invalid)
+
+    @pytest.mark.parametrize("invalid", [True, 1.5, "1", 0, -1])
+    def test_invalid_output_chunk_size(self, invalid):
+        expected = TypeError if invalid in (True, 1.5, "1") else ValueError
+        with pytest.raises(expected):
+            _encoder(output_chunk_size=invalid)
+
+    @pytest.mark.parametrize("invalid", [-1, 2**32, "now", object()])
+    def test_invalid_mtime(self, invalid):
+        expected = TypeError if not isinstance(invalid, (int, float)) else ValueError
+        with pytest.raises(expected):
+            _encoder(mtime=invalid)
+
+    @pytest.mark.parametrize("invalid", [1, "nul\x00name", b"nul\x00name"])
+    def test_invalid_original_filename(self, invalid):
+        expected = TypeError if invalid == 1 else ValueError
+        with pytest.raises(expected):
+            _encoder(original_filename=invalid)
+
+    def test_strict_size_rejects_crossing_isize_limit(self):
+        encoder = _encoder(strict_size=True)
+        list(encoder.start())
+        encoder._input_size = 0xFFFFFFFF
+
+        with pytest.raises(OSError, match="4 GiB limit"):
+            encoder.feed(b"x")
+
+    async def test_non_strict_trailer_wraps_isize(self):
+        encoder = _encoder(strict_size=False)
+        list(encoder.start())
+        encoder._input_size = 2**32 + 5
+
+        output = [chunk async for chunk in encoder.finish()]
+
+        assert struct.unpack("<I", b"".join(output)[-4:])[0] == 5

--- a/tests/typing/check_factory_overloads.py
+++ b/tests/typing/check_factory_overloads.py
@@ -7,7 +7,7 @@ type by mode.
 """
 
 from pathlib import Path
-from typing import Union
+from typing import AsyncIterator, Union
 
 from typing_extensions import assert_type
 
@@ -19,6 +19,7 @@ from aiogzip import (
     GzipInfo,
     GzipMemberInfo,
     VerificationResult,
+    decompress_chunks,
     engine_info,
     inspect,
     read,
@@ -108,3 +109,11 @@ def _check_inspection_result_types(
 async def _check_inspection_functions() -> None:
     assert_type(await inspect(p), GzipInfo)
     assert_type(await verify(p), VerificationResult)
+
+
+async def _compressed_source() -> AsyncIterator[bytes]:
+    yield b"compressed"
+
+
+def _check_streaming_functions() -> None:
+    assert_type(decompress_chunks(_compressed_source()), AsyncIterator[bytes])

--- a/tests/typing/check_factory_overloads.py
+++ b/tests/typing/check_factory_overloads.py
@@ -19,6 +19,7 @@ from aiogzip import (
     GzipInfo,
     GzipMemberInfo,
     VerificationResult,
+    compress_chunks,
     decompress_chunks,
     engine_info,
     inspect,
@@ -117,3 +118,4 @@ async def _compressed_source() -> AsyncIterator[bytes]:
 
 def _check_streaming_functions() -> None:
     assert_type(decompress_chunks(_compressed_source()), AsyncIterator[bytes])
+    assert_type(compress_chunks(_compressed_source()), AsyncIterator[bytes])

--- a/tests/typing/check_factory_overloads.py
+++ b/tests/typing/check_factory_overloads.py
@@ -99,7 +99,7 @@ def _check_inspection_result_types(
     verified: VerificationResult,
 ) -> None:
     assert_type(member.index, int)
-    assert_type(member.mtime, Union[int, None])
+    assert_type(member.mtime, int)
     assert_type(info.members, tuple[GzipMemberInfo, ...])
     assert_type(info.member_count, int)
     assert_type(verified.uncompressed_size, int)

--- a/tests/typing/check_factory_overloads.py
+++ b/tests/typing/check_factory_overloads.py
@@ -16,6 +16,9 @@ from aiogzip import (
     AsyncGzipFile,
     AsyncGzipTextFile,
     EngineInfo,
+    GzipInfo,
+    GzipMemberInfo,
+    VerificationResult,
     engine_info,
     read,
     write,
@@ -86,3 +89,15 @@ def _check_engine_info() -> None:
     assert_type(info, EngineInfo)
     assert_type(info.compression, str)
     assert_type(info.decompression, str)
+
+
+def _check_inspection_result_types(
+    member: GzipMemberInfo,
+    info: GzipInfo,
+    verified: VerificationResult,
+) -> None:
+    assert_type(member.index, int)
+    assert_type(member.mtime, Union[int, None])
+    assert_type(info.members, tuple[GzipMemberInfo, ...])
+    assert_type(info.member_count, int)
+    assert_type(verified.uncompressed_size, int)

--- a/tests/typing/check_factory_overloads.py
+++ b/tests/typing/check_factory_overloads.py
@@ -20,7 +20,9 @@ from aiogzip import (
     GzipMemberInfo,
     VerificationResult,
     engine_info,
+    inspect,
     read,
+    verify,
     write,
 )
 from aiogzip import open as gzip_open
@@ -101,3 +103,8 @@ def _check_inspection_result_types(
     assert_type(info.members, tuple[GzipMemberInfo, ...])
     assert_type(info.member_count, int)
     assert_type(verified.uncompressed_size, int)
+
+
+async def _check_inspection_functions() -> None:
+    assert_type(await inspect(p), GzipInfo)
+    assert_type(await verify(p), VerificationResult)


### PR DESCRIPTION
## Summary

- add frozen gzip inspection result types plus `aiogzip.inspect()` and `aiogzip.verify()`
- add shared bounded-memory incremental gzip decoder and encoder internals
- add pull-driven `aiogzip.decompress_chunks()` and `aiogzip.compress_chunks()` APIs for `AsyncIterable[bytes]`
- document metadata, integrity validation, decompression limits, backpressure, cancellation, early exit, and incomplete compression output
- add focused inspection and bidirectional streaming benchmarks

Inspection and verification scan complete streams without retaining decompressed payload data. They validate headers, optional header CRCs, deflate data, per-member CRC-32 and `ISIZE`, concatenated members, truncation, and the existing trailing-NUL-padding behavior.

The chunk APIs use strict output-size bounds and do not create producer tasks or queues. Decompression applies a cumulative `max_decompressed_size`; compression emits exactly one member and finalizes it only after normal source completion.

## Validation

- `uv run pytest -q` — 1220 passed with zlib-ng active
- `AIOGZIP_ENGINE=stdlib uv run pytest -q` — 1220 passed
- `uv run pre-commit run --all-files`
- `uv run mkdocs build --strict`
- built and inspected wheel and source distributions
- installed-wheel smoke test on Python 3.14 covering file helpers, inspection, verification, both chunk APIs, and a direct streaming pipeline
- 32 MiB inspection and compression/decompression streaming benchmarks with stdlib and optional zlib-ng paths

## Stacked PR

This PR is intentionally based on `feat/usability-improvements` while #58 is open. Merge #58 first, then retarget this PR to `main`; its diff will contain only the inspection and streaming work.
