### PR TITLE
Prepare release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-07-13
+
 ### Added
 
 - Added `aiogzip.open()` as the recommended typed package-level entry point.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,12 +286,11 @@ Always include:
 ## Version History
 
 - **0.3** - Major refactoring, binary/text separation
-- **1.9.1 (current)** - See `CHANGELOG.md` for the full release history. Recent
-  work bounds decompression-bomb output before allocation, preserves stateful
-  text encoders across writes, rejects reuse after cancelled decompression,
-  completes short external writes, batches `writelines()`, tightens tuning
-  parameter validation, and reports median benchmark results from repeated
-  runs.
+- **1.10.0 (current)** - See `CHANGELOG.md` for the full release history. Recent
+  work adds package-level `open()`, whole-file helpers, engine diagnostics,
+  gzip inspection and verification, and bounded async-iterable compression and
+  decompression. It also expands migration, recipe, streaming, operational, and
+  benchmark documentation.
 
 ---
 

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -28,7 +28,7 @@ from ._inspection import (
 from ._streaming import _compress_chunks, _decompress_chunks
 from ._text import AsyncGzipTextFile
 
-__version__ = "1.9.1"
+__version__ = "1.10.0"
 
 # Mode strings that select a text stream (they contain a 't'). The factory
 # parses modes character-by-character and is permutation-tolerant, so these


### PR DESCRIPTION
## Summary

- move the accumulated Unreleased notes into the dated 1.10.0 changelog section
- bump the package version from 1.9.1 to 1.10.0
- refresh the current-version summary in CLAUDE.md

## Validation

- uv run pre-commit run --all-files
- uv run pytest tests/test_version_sync.py -q