### PR TITLE
Correct benchmark comparisons and performance claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Comparative benchmarks now use deterministic data, identical compressed
+  fixtures for reads, explicit compression level 6 for both writers, separate
+  read/write timings, realistic size-scaled line workloads, and median results.
+- JSON Lines benchmarks now isolate read-and-parse performance instead of
+  folding unequal-default compression into the reported speedup.
+
+### Documentation
+
+- Corrected performance claims that previously described combined text
+  read/write and JSON Lines timings as read-speed improvements. The README and
+  performance guide now distinguish synchronous single-file overhead, async
+  concurrency, and optional zlib-ng acceleration.
+- Added a required before/after benchmark workflow for performance-sensitive
+  changes, including engine-controlled runs and result comparison commands.
+
 ## [1.10.0] - 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ pip install aiogzip
 
 Python 3.8 through 3.14 are supported by the 1.x release line.
 
+> **Performance profile:** aiogzip can substantially outperform sequential
+> `gzip` when independent latency-bound steps overlap or optional zlib-ng
+> accelerates bulk decompression. In one representative run, ten files with
+> simulated 10 ms latency completed about 6x faster, and a highly compressible
+> bulk read with zlib-ng was about 5.6x faster. Direct single-file line
+> iteration remains faster with synchronous `gzip`; aiogzip's advantage there
+> is non-blocking integration and concurrency. See
+> [Performance and optional acceleration](#performance-and-optional-acceleration).
+
 ## Text-mode quickstart
 
 File methods are asynchronous, and line iteration uses `async for`:
@@ -79,7 +88,8 @@ cancellation recovery, and external async streams.
 
 ## Why use aiogzip?
 
-- Async file I/O built on `asyncio` and `aiofiles`.
+- Async file I/O built on `asyncio` and `aiofiles`, so independent streams can
+  overlap I/O waits.
 - Binary and text modes with distinct, typed concrete classes.
 - Async `read`, `write`, `readline`, `seek`, `tell`, `peek`, `readinto`, and
   line iteration.
@@ -174,11 +184,27 @@ replacement.
 
 ## Performance and optional acceleration
 
-Text bulk workflows are commonly faster than synchronous `gzip`; binary bulk
-writes are near parity, while very small calls can be slower due to async
-overhead. Large codec calls are offloaded to the default executor, allowing
-independent streams to make progress concurrently. Line iteration and
-`writelines()` use bounded batching.
+aiogzip's performance advantage comes from async concurrency and optional
+codec acceleration, not from being uniformly faster than synchronous `gzip`.
+Corrected comparisons use identical compressed fixtures for reads, compression
+level 6 for both writers, and median timings from repeated runs.
+
+On a representative Python 3.12 Linux run, the direct I/O cases used 8 MiB
+inputs and the concurrency case used ten 1 MiB files:
+
+- equal-level bulk text writes were at parity;
+- tuned single-file JSONL iteration was about 1.7-1.8x slower than `gzip`
+  because each line crosses an async-iterator boundary;
+- optional zlib-ng made a highly compressible bulk `read(-1)` about 5.6x
+  faster than `gzip`; and
+- overlapping ten files with simulated 10 ms latency was about 6x faster than
+  processing them sequentially with `gzip`.
+
+The concurrency result measures overlapped waiting, not a faster deflate
+codec, and benchmark ratios vary by hardware, storage, Python version, and
+data. Large codec calls are offloaded to the default executor so independent
+tasks can keep making progress. Line iteration and `writelines()` use bounded
+batching to reduce aiogzip's own coroutine overhead.
 
 For large UTF-8 JSON Lines files with `\n` terminators, the measured fast path
 uses `newline="\n"` and `chunk_size=512 * 1024`. Tune memory and throughput for
@@ -190,9 +216,11 @@ Install the optional codec with:
 pip install "aiogzip[fast]"
 ```
 
-When installed, zlib-ng is selected automatically for decompression.
-Compression remains on stdlib zlib so installation alone does not change gzip
-bytes; pass `fast_compress=True` per writer to opt in. Set
+When installed, zlib-ng is selected automatically for decompression. Its gain
+depends on the input and access pattern: it helps decompression-heavy bulk
+reads far more than per-line Python iteration. Compression remains on stdlib
+zlib so installation alone does not change gzip bytes; pass
+`fast_compress=True` per writer to opt in. Set
 `AIOGZIP_ENGINE=stdlib` to force stdlib behavior. Inspect the default selections
 for a diagnostic report:
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -25,9 +25,9 @@ uv run python benchmarks/bench_compare.py baseline.json current.json
 Core read/write performance:
 
 - Binary I/O with small (10-byte) chunks
-- Text I/O operations
+- Separate bulk text read and write comparisons
+- Default and tuned JSONL line iteration against the exact same gzip fixture
 - Flush operations (100 flushes)
-- Line-by-line reading with `readline()` (1000 lines)
 - Read-all isolated: `read(-1)` timed on its own (write excluded) on compressible data
 - Text large reads: a single large `read(size)` and a single long-line `readline()` (guards against O(n^2) accumulation regressions)
 
@@ -43,9 +43,9 @@ Memory usage and efficiency:
 
 Async concurrency benefits:
 
-- Concurrent file operations (50 files)
+- Concurrent file operations (10 files, 1 MiB each)
 - Comparison: async concurrent vs sync sequential
-- Real-world async performance gains
+- Explicit simulated-latency and mixed-operation results
 
 ### 4. 🗜️ Compression Benchmarks (`bench_compression.py`)
 
@@ -60,9 +60,8 @@ Compression analysis:
 
 Practical use cases:
 
-- JSONL processing (write → read → parse)
-- Complete workflows with realistic data
-- End-to-end performance testing
+- Read-only JSONL parsing from one identical fixture
+- JSON decoding and record validation with realistic data
 
 ### 6. 🛡️ Error Handling (`bench_errors.py`)
 
@@ -78,8 +77,8 @@ Robustness and error recovery:
 Fine-grained performance measurements:
 
 - read(-1) on 1MB files (100 iterations)
-- Line iteration efficiency (10K lines)
-- readline() loop performance (10K lines)
+- Line iteration efficiency (100K lines)
+- readline() loop performance (100K lines)
 - Small write operations (1000 x 120 bytes)
 - Binary readline stress case (200KB line, 17-byte chunks)
 
@@ -103,6 +102,51 @@ Each category runs three times by default. Reported durations are medians, and
 the displayed secondary metrics come from the sample closest to that median.
 Use `--repeat 1` for a faster smoke run or a larger odd count for more stable
 release comparisons.
+
+## Comparison Methodology
+
+Comparisons with stdlib `gzip` follow these rules:
+
+- Read benchmarks consume the exact same deterministic compressed bytes.
+- Comparative writes explicitly use compression level 6 for both libraries;
+  their different defaults (`aiogzip=6`, `gzip=9`) must not affect the result.
+- Reads and writes are timed and reported separately unless the benchmark is
+  explicitly labeled as an end-to-end workflow.
+- Correctness checks run outside or alongside the timed work so a fast but
+  incomplete result cannot be reported.
+- Results use the same Python process, engine selection, filesystem, and data
+  size. Absolute timings from different machines are not directly comparable.
+
+An async API is not expected to beat synchronous `gzip` in every single-file
+microbenchmark. Report event-loop concurrency, optional-codec throughput, and
+per-call async overhead as separate effects.
+
+## Before/After Regression Workflow
+
+For changes to codecs, buffering, text decoding, line iteration, executor
+offloading, or parser hot paths, capture a baseline before editing:
+
+```bash
+AIOGZIP_ENGINE=stdlib uv run python benchmarks/run_benchmarks.py \
+  --category io,scenarios,concurrency --size 8 --repeat 5 \
+  --output /tmp/aiogzip-before.json
+```
+
+Run the identical command after the change, using a different output file,
+then compare the results:
+
+```bash
+AIOGZIP_ENGINE=stdlib uv run python benchmarks/run_benchmarks.py \
+  --category io,scenarios,concurrency --size 8 --repeat 5 \
+  --output /tmp/aiogzip-after.json
+
+uv run python benchmarks/bench_compare.py \
+  /tmp/aiogzip-before.json /tmp/aiogzip-after.json
+```
+
+Repeat without `AIOGZIP_ENGINE=stdlib` when the change can affect zlib-ng.
+Record the command, environment, and any material wins or regressions in the
+review or pull request.
 
 ### Usage Examples
 
@@ -156,19 +200,28 @@ uv add psutil
 ### Sample Output
 
 ```
-Binary I/O (10-byte chunks): 0.060s
-  aiogzip_write: 0.058s
-  aiogzip_read: 0.002s
-  gzip_write: 0.075s
-  gzip_read: 0.001s
-  speedup: 1.27x faster
+Text line iteration (tuned, identical fixture): 0.021s
+  aiogzip_time: 0.0210s
+  gzip_time: 0.0124s
+  speedup: 1.69x slower
+  lines: 73849
+
+Read-all isolated (compressible, read-only timing): 0.003s
+  aiogzip_read_best: 2.67ms
+  gzip_read_best: 14.88ms
+  speedup: 5.57x faster
 ```
+
+These are illustrative results from one zlib-ng-enabled machine, not expected
+values or acceptance thresholds.
 
 ### Interpreting Results
 
-- **Local SSD**: Async benefits minimal due to fast I/O
-- **Network Storage**: Async shows significant advantages
-- **Concurrent Workloads**: Best performance with multiple files
+- **Local SSD / page cache**: synchronous `gzip` often wins small single-file
+  operations because it has no coroutine handoff.
+- **Latency-bound storage**: async can overlap waits across independent files.
+- **Concurrent workloads**: compare total completion time and event-loop
+  responsiveness, not only per-file codec time.
 - **Small Chunks**: Stress test for overhead measurement
 
 ## File Structure

--- a/benchmarks/bench_common.py
+++ b/benchmarks/bench_common.py
@@ -5,17 +5,29 @@ This module provides shared utilities, base classes, and data generators
 used across all benchmark modules.
 """
 
+import gzip
 import json
 import os
 import random
 import shutil
 import statistics
-import string
 import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
+
+COMPARISON_COMPRESSLEVEL = 6
+
+
+def write_comparison_fixture(
+    path: Path,
+    data: bytes,
+    *,
+    compresslevel: int = COMPARISON_COMPRESSLEVEL,
+) -> None:
+    """Write one deterministic gzip fixture for comparative read benchmarks."""
+    path.write_bytes(gzip.compress(data, compresslevel=compresslevel, mtime=0))
 
 
 @dataclass
@@ -121,7 +133,8 @@ class DataGenerator:
 
     @staticmethod
     def generate_text(size_mb: int) -> str:
-        """Generate realistic text data."""
+        """Generate deterministic, realistic text data."""
+        random_source = random.Random(0)
         words = [
             "hello",
             "world",
@@ -147,7 +160,9 @@ class DataGenerator:
         current_size = 0
 
         while current_size < target_size:
-            line = " ".join(random.choices(words, k=random.randint(5, 15)))
+            line = " ".join(
+                random_source.choices(words, k=random_source.randint(5, 15))
+            )
             lines.append(line)
             current_size += len(line) + 1  # +1 for newline
 
@@ -155,7 +170,7 @@ class DataGenerator:
 
     @staticmethod
     def generate_jsonl(size_mb: int) -> str:
-        """Generate JSONL (JSON Lines) data."""
+        """Generate deterministic JSONL (JSON Lines) data."""
         lines: List[str] = []
         target_size = size_mb * 1024 * 1024
         current_size = 0
@@ -165,9 +180,9 @@ class DataGenerator:
             record = {
                 "id": record_id,
                 "name": f"item_{record_id}",
-                "value": random.randint(1, 1000),
-                "description": "".join(random.choices(string.ascii_letters, k=20)),
-                "timestamp": time.time(),
+                "value": (record_id * 37) % 1000 + 1,
+                "description": f"benchmark-event-{record_id % 1000:04d}",
+                "timestamp": 1_700_000_000 + record_id,
             }
             line = json.dumps(record)
             lines.append(line)

--- a/benchmarks/bench_compression.py
+++ b/benchmarks/bench_compression.py
@@ -7,7 +7,7 @@ Tests compression ratios and format compatibility.
 import gzip
 import time
 
-from bench_common import BenchmarkBase, format_size
+from bench_common import COMPARISON_COMPRESSLEVEL, BenchmarkBase, format_size
 
 from aiogzip import AsyncGzipBinaryFile, _engine
 
@@ -28,11 +28,15 @@ class CompressionBenchmarks(BenchmarkBase):
             gzip_file = self.temp_mgr.get_path(f"{name}_gzip.gz")
 
             # Write with aiogzip
-            async with AsyncGzipBinaryFile(aiogzip_file, "wb") as f:
+            async with AsyncGzipBinaryFile(
+                aiogzip_file, "wb", compresslevel=COMPARISON_COMPRESSLEVEL
+            ) as f:
                 await f.write(data)
 
             # Write with gzip
-            with gzip.open(gzip_file, "wb") as f:
+            with gzip.open(
+                gzip_file, "wb", compresslevel=COMPARISON_COMPRESSLEVEL
+            ) as f:
                 f.write(data)
 
             # Compare sizes

--- a/benchmarks/bench_concurrency.py
+++ b/benchmarks/bench_concurrency.py
@@ -8,7 +8,7 @@ import asyncio
 import gzip
 import time
 
-from bench_common import BenchmarkBase
+from bench_common import COMPARISON_COMPRESSLEVEL, BenchmarkBase
 
 from aiogzip import AsyncGzipBinaryFile
 
@@ -24,7 +24,9 @@ class ConcurrencyBenchmarks(BenchmarkBase):
         # Async concurrent processing with simulated I/O delay
         async def process_file_async(idx):
             filepath = self.temp_mgr.get_path(f"async_{idx}.gz")
-            async with AsyncGzipBinaryFile(filepath, "wb") as f:
+            async with AsyncGzipBinaryFile(
+                filepath, "wb", compresslevel=COMPARISON_COMPRESSLEVEL
+            ) as f:
                 await f.write(test_data)
             # Simulate network/disk delay (e.g., waiting for upload)
             await asyncio.sleep(0.01)
@@ -38,7 +40,7 @@ class ConcurrencyBenchmarks(BenchmarkBase):
         # Sync sequential processing with simulated I/O delay
         def process_file_sync(idx):
             filepath = self.temp_mgr.get_path(f"sync_{idx}.gz")
-            with gzip.open(filepath, "wb") as f:
+            with gzip.open(filepath, "wb", compresslevel=COMPARISON_COMPRESSLEVEL) as f:
                 f.write(test_data)
             # Simulate network/disk delay (blocking)
             time.sleep(0.01)
@@ -75,7 +77,9 @@ class ConcurrencyBenchmarks(BenchmarkBase):
         # Create files first
         for i in range(num_tasks):
             filepath = self.temp_mgr.get_path(f"mixed_{i}.gz")
-            async with AsyncGzipBinaryFile(filepath, "wb") as f:
+            async with AsyncGzipBinaryFile(
+                filepath, "wb", compresslevel=COMPARISON_COMPRESSLEVEL
+            ) as f:
                 await f.write(test_data)
 
         # Mixed async operations (some read, some write)
@@ -88,7 +92,9 @@ class ConcurrencyBenchmarks(BenchmarkBase):
             else:
                 # Write
                 filepath = self.temp_mgr.get_path(f"mixed_new_{idx}.gz")
-                async with AsyncGzipBinaryFile(filepath, "wb") as f:
+                async with AsyncGzipBinaryFile(
+                    filepath, "wb", compresslevel=COMPARISON_COMPRESSLEVEL
+                ) as f:
                     await f.write(test_data)
 
         start = time.perf_counter()
@@ -103,7 +109,9 @@ class ConcurrencyBenchmarks(BenchmarkBase):
                     _ = f.read()
             else:
                 filepath = self.temp_mgr.get_path(f"mixed_new_{idx}.gz")
-                with gzip.open(filepath, "wb") as f:
+                with gzip.open(
+                    filepath, "wb", compresslevel=COMPARISON_COMPRESSLEVEL
+                ) as f:
                     f.write(test_data)
 
         start = time.perf_counter()

--- a/benchmarks/bench_io.py
+++ b/benchmarks/bench_io.py
@@ -7,7 +7,12 @@ Tests core read/write performance in binary and text modes.
 import gzip
 import time
 
-from bench_common import BenchmarkBase, format_speedup
+from bench_common import (
+    COMPARISON_COMPRESSLEVEL,
+    BenchmarkBase,
+    format_speedup,
+    write_comparison_fixture,
+)
 
 from aiogzip import AsyncGzipBinaryFile, AsyncGzipTextFile
 
@@ -25,7 +30,9 @@ class IoBenchmarks(BenchmarkBase):
 
         # Benchmark aiogzip write
         start = time.perf_counter()
-        async with AsyncGzipBinaryFile(aiogzip_file, "wb") as f:
+        async with AsyncGzipBinaryFile(
+            aiogzip_file, "wb", compresslevel=COMPARISON_COMPRESSLEVEL
+        ) as f:
             for i in range(0, len(binary_data), chunk_size):
                 await f.write(binary_data[i : i + chunk_size])
         aiogzip_write_time = time.perf_counter() - start
@@ -38,7 +45,7 @@ class IoBenchmarks(BenchmarkBase):
 
         # Benchmark gzip write
         start = time.perf_counter()
-        with gzip.open(gzip_file, "wb") as f:
+        with gzip.open(gzip_file, "wb", compresslevel=COMPARISON_COMPRESSLEVEL) as f:
             for i in range(0, len(binary_data), chunk_size):
                 f.write(binary_data[i : i + chunk_size])
         gzip_write_time = time.perf_counter() - start
@@ -78,7 +85,9 @@ class IoBenchmarks(BenchmarkBase):
 
         # Benchmark aiogzip bulk write
         start = time.perf_counter()
-        async with AsyncGzipBinaryFile(aiogzip_file, "wb") as f:
+        async with AsyncGzipBinaryFile(
+            aiogzip_file, "wb", compresslevel=COMPARISON_COMPRESSLEVEL
+        ) as f:
             await f.write(binary_data)
         aiogzip_write_time = time.perf_counter() - start
 
@@ -90,7 +99,7 @@ class IoBenchmarks(BenchmarkBase):
 
         # Benchmark gzip bulk write
         start = time.perf_counter()
-        with gzip.open(gzip_file, "wb") as f:
+        with gzip.open(gzip_file, "wb", compresslevel=COMPARISON_COMPRESSLEVEL) as f:
             f.write(binary_data)
         gzip_write_time = time.perf_counter() - start
 
@@ -131,7 +140,9 @@ class IoBenchmarks(BenchmarkBase):
 
         # Benchmark aiogzip chunked write
         start = time.perf_counter()
-        async with AsyncGzipBinaryFile(aiogzip_file, "wb") as f:
+        async with AsyncGzipBinaryFile(
+            aiogzip_file, "wb", compresslevel=COMPARISON_COMPRESSLEVEL
+        ) as f:
             for i in range(0, len(binary_data), chunk_size):
                 await f.write(binary_data[i : i + chunk_size])
         aiogzip_write_time = time.perf_counter() - start
@@ -149,7 +160,7 @@ class IoBenchmarks(BenchmarkBase):
 
         # Benchmark gzip chunked write
         start = time.perf_counter()
-        with gzip.open(gzip_file, "wb") as f:
+        with gzip.open(gzip_file, "wb", compresslevel=COMPARISON_COMPRESSLEVEL) as f:
             for i in range(0, len(binary_data), chunk_size):
                 f.write(binary_data[i : i + chunk_size])
         gzip_write_time = time.perf_counter() - start
@@ -180,113 +191,143 @@ class IoBenchmarks(BenchmarkBase):
         )
 
     async def benchmark_text_operations(self):
-        """Benchmark text read/write operations."""
+        """Benchmark bulk text reads and writes as separate operations."""
         text_data = self.data_gen.generate_text(self.data_size_mb)
-        aiogzip_file = self.temp_mgr.get_path("aiogzip_text.gz")
-        gzip_file = self.temp_mgr.get_path("gzip_text.gz")
+        encoded = text_data.encode("utf-8")
+        fixture = self.temp_mgr.get_path("text_read_fixture.gz")
+        aiogzip_output = self.temp_mgr.get_path("aiogzip_text_write.gz")
+        gzip_output = self.temp_mgr.get_path("gzip_text_write.gz")
+        write_comparison_fixture(fixture, encoded)
 
         # Benchmark aiogzip write
         start = time.perf_counter()
-        async with AsyncGzipTextFile(aiogzip_file, "wt") as f:
+        async with AsyncGzipTextFile(
+            aiogzip_output,
+            "wt",
+            compresslevel=COMPARISON_COMPRESSLEVEL,
+            mtime=0,
+        ) as f:
             await f.write(text_data)
         aiogzip_write_time = time.perf_counter() - start
 
-        # Benchmark aiogzip read
-        start = time.perf_counter()
-        async with AsyncGzipTextFile(aiogzip_file, "rt") as f:
-            _ = await f.read()
-        aiogzip_read_time = time.perf_counter() - start
-
         # Benchmark gzip write
         start = time.perf_counter()
-        with gzip.open(gzip_file, "wt") as f:
+        with gzip.open(
+            gzip_output,
+            "wt",
+            encoding="utf-8",
+            compresslevel=COMPARISON_COMPRESSLEVEL,
+        ) as f:
             f.write(text_data)
         gzip_write_time = time.perf_counter() - start
 
-        # Benchmark gzip read
+        # Benchmark both readers against the exact same gzip bytes.
         start = time.perf_counter()
-        with gzip.open(gzip_file, "rt") as f:
-            _ = f.read()
+        async with AsyncGzipTextFile(fixture, "rt", encoding="utf-8") as f:
+            aiogzip_text = await f.read()
+        aiogzip_read_time = time.perf_counter() - start
+
+        start = time.perf_counter()
+        with gzip.open(fixture, "rt", encoding="utf-8") as f:
+            gzip_text = f.read()
         gzip_read_time = time.perf_counter() - start
 
-        total_aiogzip = aiogzip_write_time + aiogzip_read_time
-        total_gzip = gzip_write_time + gzip_read_time
+        assert aiogzip_text == text_data
+        assert gzip_text == text_data
 
-        # Calculate throughput
-        text_size_mb = len(text_data.encode("utf-8")) / (1024 * 1024)
-        aiogzip_throughput = text_size_mb / total_aiogzip if total_aiogzip > 0 else 0
-        gzip_throughput = text_size_mb / total_gzip if total_gzip > 0 else 0
+        text_size_mb = len(encoded) / (1024 * 1024)
 
         self.add_result(
-            "Text I/O (bulk read/write)",
+            f"Text write (bulk, compression level {COMPARISON_COMPRESSLEVEL})",
             "io",
-            total_aiogzip,
-            aiogzip_write=f"{aiogzip_write_time:.3f}s",
-            aiogzip_read=f"{aiogzip_read_time:.3f}s",
-            gzip_write=f"{gzip_write_time:.3f}s",
-            gzip_read=f"{gzip_read_time:.3f}s",
-            speedup=format_speedup(total_aiogzip, total_gzip),
-            aiogzip_throughput=f"{aiogzip_throughput:.1f} MB/s",
-            gzip_throughput=f"{gzip_throughput:.1f} MB/s",
+            aiogzip_write_time,
+            aiogzip_time=f"{aiogzip_write_time:.4f}s",
+            gzip_time=f"{gzip_write_time:.4f}s",
+            speedup=format_speedup(aiogzip_write_time, gzip_write_time),
+            aiogzip_throughput=f"{text_size_mb / aiogzip_write_time:.1f} MB/s",
+            gzip_throughput=f"{text_size_mb / gzip_write_time:.1f} MB/s",
+        )
+        self.add_result(
+            "Text read (bulk, identical fixture)",
+            "io",
+            aiogzip_read_time,
+            aiogzip_time=f"{aiogzip_read_time:.4f}s",
+            gzip_time=f"{gzip_read_time:.4f}s",
+            speedup=format_speedup(aiogzip_read_time, gzip_read_time),
+            aiogzip_throughput=f"{text_size_mb / aiogzip_read_time:.1f} MB/s",
+            gzip_throughput=f"{text_size_mb / gzip_read_time:.1f} MB/s",
         )
 
     async def benchmark_line_iteration(self):
-        """Benchmark line-by-line iteration vs readline()."""
-        text_file = self.temp_mgr.get_path("lines_iter.gz")
+        """Compare line iteration against gzip using one read-only fixture."""
+        text_data = self.data_gen.generate_jsonl(self.data_size_mb)
+        encoded = text_data.encode("utf-8")
+        text_file = self.temp_mgr.get_path("line_iteration_fixture.gz")
+        write_comparison_fixture(text_file, encoded)
+        expected = (
+            text_data.count("\n") + (1 if text_data else 0),
+            len(text_data),
+        )
 
-        # Create file with varying line lengths
-        lines = []
-        for i in range(1000):
-            if i % 10 == 0:
-                # Long line every 10th line
-                lines.append(f"Long line {i}: " + "x" * 200 + "\n")
-            else:
-                # Short lines
-                lines.append(f"Short line {i}\n")
-
-        async with AsyncGzipTextFile(text_file, "wt") as f:
-            await f.write("".join(lines))
-
-        # Benchmark async for iteration
         start = time.perf_counter()
-        async with AsyncGzipTextFile(text_file, "rt") as f:
-            iter_lines = []
+        default_count = 0
+        default_chars = 0
+        async with AsyncGzipTextFile(text_file, "rt", encoding="utf-8") as f:
             async for line in f:
-                iter_lines.append(line)
-        iteration_time = time.perf_counter() - start
-
-        # Benchmark readline() loop
-        start = time.perf_counter()
-        async with AsyncGzipTextFile(text_file, "rt") as f:
-            readline_lines = []
-            while True:
-                line = await f.readline()
-                if not line:
-                    break
-                readline_lines.append(line)
-        readline_time = time.perf_counter() - start
-
-        # Compare with gzip
-        gzip_file = self.temp_mgr.get_path("lines_gzip.gz")
-        with gzip.open(gzip_file, "wt") as f:
-            f.write("".join(lines))
+                default_count += 1
+                default_chars += len(line)
+        default_time = time.perf_counter() - start
 
         start = time.perf_counter()
-        with gzip.open(gzip_file, "rt") as f:
-            list(f)
+        tuned_count = 0
+        tuned_chars = 0
+        async with AsyncGzipTextFile(
+            text_file,
+            "rt",
+            encoding="utf-8",
+            newline="\n",
+            chunk_size=512 * 1024,
+        ) as f:
+            async for line in f:
+                tuned_count += 1
+                tuned_chars += len(line)
+        tuned_time = time.perf_counter() - start
+
+        start = time.perf_counter()
+        gzip_count = 0
+        gzip_chars = 0
+        with gzip.open(text_file, "rt", encoding="utf-8", newline="\n") as f:
+            for line in f:
+                gzip_count += 1
+                gzip_chars += len(line)
         gzip_time = time.perf_counter() - start
 
+        assert (default_count, default_chars) == expected
+        assert (tuned_count, tuned_chars) == expected
+        assert (gzip_count, gzip_chars) == expected
+
         self.add_result(
-            "Line iteration (1000 mixed-length lines)",
+            "Text line iteration (default, identical fixture)",
             "io",
-            iteration_time,
-            async_for_time=f"{iteration_time:.3f}s",
-            readline_time=f"{readline_time:.3f}s",
-            gzip_iteration=f"{gzip_time:.3f}s",
-            async_for_vs_readline=f"{readline_time / iteration_time:.2f}x"
-            if iteration_time > 0
-            else "N/A",
-            lines_per_sec=f"{len(iter_lines) / iteration_time:.0f}",
+            default_time,
+            aiogzip_time=f"{default_time:.4f}s",
+            gzip_time=f"{gzip_time:.4f}s",
+            speedup=format_speedup(default_time, gzip_time),
+            aiogzip_lines_per_sec=f"{default_count / default_time:.0f}",
+            gzip_lines_per_sec=f"{gzip_count / gzip_time:.0f}",
+            lines=default_count,
+        )
+        self.add_result(
+            "Text line iteration (tuned, identical fixture)",
+            "io",
+            tuned_time,
+            aiogzip_time=f"{tuned_time:.4f}s",
+            gzip_time=f"{gzip_time:.4f}s",
+            speedup=format_speedup(tuned_time, gzip_time),
+            aiogzip_lines_per_sec=f"{tuned_count / tuned_time:.0f}",
+            gzip_lines_per_sec=f"{gzip_count / gzip_time:.0f}",
+            lines=tuned_count,
+            tuning='newline="\\n", chunk_size=512 KiB',
         )
 
     async def benchmark_flush_operations(self):
@@ -308,33 +349,6 @@ class IoBenchmarks(BenchmarkBase):
             ops_per_sec=f"{100 / duration:.0f}",
         )
 
-    async def benchmark_readline(self):
-        """Benchmark readline() performance."""
-        text_file = self.temp_mgr.get_path("lines.gz")
-
-        # Create file with 1000 lines
-        async with AsyncGzipTextFile(text_file, "wt") as f:
-            for i in range(1000):
-                await f.write(f"This is line number {i}\n")
-
-        # Benchmark readline
-        start = time.perf_counter()
-        async with AsyncGzipTextFile(text_file, "rt") as f:
-            lines = []
-            while True:
-                line = await f.readline()
-                if not line:
-                    break
-                lines.append(line)
-        duration = time.perf_counter() - start
-
-        self.add_result(
-            "readline() (1000 lines)",
-            "io",
-            duration,
-            lines_per_sec=f"{len(lines) / duration:.0f}",
-        )
-
     async def benchmark_read_all_isolated(self):
         """Full-read throughput with the write excluded from the timed region.
 
@@ -345,31 +359,25 @@ class IoBenchmarks(BenchmarkBase):
         signal cleaner.
         """
         payload = self.data_gen.generate_compressible(self.data_size_mb)
-        aiogzip_file = self.temp_mgr.get_path("readall_isolated.gz")
-        gzip_file = self.temp_mgr.get_path("readall_isolated_gzip.gz")
-
-        # Write outside the timed region.
-        async with AsyncGzipBinaryFile(aiogzip_file, "wb") as f:
-            await f.write(payload)
-        with gzip.open(gzip_file, "wb") as f:
-            f.write(payload)
+        fixture = self.temp_mgr.get_path("readall_isolated.gz")
+        write_comparison_fixture(fixture, payload)
 
         chunk_size = 512 * 1024
         aiogzip_times = []
         for _ in range(5):
             start = time.perf_counter()
-            async with AsyncGzipBinaryFile(
-                aiogzip_file, "rb", chunk_size=chunk_size
-            ) as f:
-                await f.read()
+            async with AsyncGzipBinaryFile(fixture, "rb", chunk_size=chunk_size) as f:
+                result = await f.read()
+            assert result == payload
             aiogzip_times.append(time.perf_counter() - start)
         aiogzip_best = min(aiogzip_times)
 
         gzip_times = []
         for _ in range(5):
             start = time.perf_counter()
-            with gzip.open(gzip_file, "rb") as f:
-                f.read()
+            with gzip.open(fixture, "rb") as f:
+                result = f.read()
+            assert result == payload
             gzip_times.append(time.perf_counter() - start)
         gzip_best = min(gzip_times)
 
@@ -438,6 +446,5 @@ class IoBenchmarks(BenchmarkBase):
         await self.benchmark_text_operations()
         await self.benchmark_line_iteration()
         await self.benchmark_flush_operations()
-        await self.benchmark_readline()
         await self.benchmark_read_all_isolated()
         await self.benchmark_text_large_reads()

--- a/benchmarks/bench_scenarios.py
+++ b/benchmarks/bench_scenarios.py
@@ -8,7 +8,7 @@ import gzip
 import json
 import time
 
-from bench_common import BenchmarkBase
+from bench_common import BenchmarkBase, format_speedup, write_comparison_fixture
 
 from aiogzip import AsyncGzipTextFile
 
@@ -17,43 +17,49 @@ class ScenariosBenchmarks(BenchmarkBase):
     """Real-world scenario benchmarks."""
 
     async def benchmark_jsonl_processing(self):
-        """Benchmark JSONL file processing."""
-        jsonl_data = self.data_gen.generate_jsonl(1)
-        aiogzip_file = self.temp_mgr.get_path("data_aiogzip.jsonl.gz")
-        gzip_file = self.temp_mgr.get_path("data_gzip.jsonl.gz")
+        """Benchmark read-only JSONL parsing from one identical fixture."""
+        jsonl_data = self.data_gen.generate_jsonl(self.data_size_mb)
+        fixture = self.temp_mgr.get_path("data.jsonl.gz")
+        write_comparison_fixture(fixture, jsonl_data.encode("utf-8"))
 
-        # aiogzip: Write and read JSONL
         start = time.perf_counter()
-        async with AsyncGzipTextFile(aiogzip_file, "wt") as f:
-            await f.write(jsonl_data)
-
-        records_aiogzip = []
-        async with AsyncGzipTextFile(aiogzip_file, "rt") as f:
+        aiogzip_count = 0
+        aiogzip_id_sum = 0
+        async with AsyncGzipTextFile(
+            fixture,
+            "rt",
+            encoding="utf-8",
+            newline="\n",
+            chunk_size=512 * 1024,
+        ) as f:
             async for line in f:
-                records_aiogzip.append(json.loads(line))
+                record = json.loads(line)
+                aiogzip_count += 1
+                aiogzip_id_sum += record["id"]
         aiogzip_time = time.perf_counter() - start
 
-        # gzip: Write and read JSONL
         start = time.perf_counter()
-        with gzip.open(gzip_file, "wt") as f:
-            f.write(jsonl_data)
-
-        records_gzip = []
-        with gzip.open(gzip_file, "rt") as f:
+        gzip_count = 0
+        gzip_id_sum = 0
+        with gzip.open(fixture, "rt", encoding="utf-8", newline="\n") as f:
             for line in f:
-                records_gzip.append(json.loads(line))
+                record = json.loads(line)
+                gzip_count += 1
+                gzip_id_sum += record["id"]
         gzip_time = time.perf_counter() - start
 
-        speedup = gzip_time / aiogzip_time if aiogzip_time > 0 else 0
+        assert aiogzip_count == gzip_count
+        assert aiogzip_id_sum == gzip_id_sum
 
         self.add_result(
-            "JSONL processing",
+            "JSONL read and parse (identical fixture)",
             "scenarios",
             aiogzip_time,
-            aiogzip_time=f"{aiogzip_time:.3f}s",
-            gzip_time=f"{gzip_time:.3f}s",
-            records=len(records_aiogzip),
-            speedup=f"{speedup:.2f}x",
+            aiogzip_time=f"{aiogzip_time:.4f}s",
+            gzip_time=f"{gzip_time:.4f}s",
+            records=aiogzip_count,
+            speedup=format_speedup(aiogzip_time, gzip_time),
+            tuning='newline="\\n", chunk_size=512 KiB',
         )
 
     async def run_all(self):

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -48,6 +48,29 @@ mypy src
 ty check src
 ```
 
+## Performance-Sensitive Changes
+
+Capture benchmark results before changing codec calls, buffering, text
+decoding, line iteration, executor offloading, or parser hot paths. Run the
+same command afterward so the comparison uses the same Python, engine,
+filesystem, data, and repeat count:
+
+```bash
+AIOGZIP_ENGINE=stdlib uv run python benchmarks/run_benchmarks.py \
+  --category io,scenarios,concurrency --size 8 --repeat 5 \
+  --output /tmp/aiogzip-before.json
+
+# Make the change, then repeat with --output /tmp/aiogzip-after.json.
+
+uv run python benchmarks/bench_compare.py \
+  /tmp/aiogzip-before.json /tmp/aiogzip-after.json
+```
+
+Repeat with the default engine when zlib-ng may be affected. Include the
+commands and any material wins or regressions in the pull request. The
+[benchmark guide](https://github.com/geoff-davis/aiogzip/tree/main/benchmarks)
+documents the comparison methodology and focused categories.
+
 ## Package Layout
 
 Core implementation is split across focused modules in `src/aiogzip`:

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,47 +1,80 @@
 # Performance Guide
 
-`aiogzip` is designed to be a high-performance, asynchronous alternative to Python's `gzip` module. This guide details its performance characteristics and provides tips for optimization.
+`aiogzip` is designed to keep gzip file processing from blocking an asyncio
+application while providing competitive codec throughput. It is not uniformly
+faster than synchronous `gzip`: the result depends on the codec, access pattern,
+line size, storage latency, and how much concurrency the application can use.
 
 ## Benchmark Summary
 
-All benchmarks were conducted on standard hardware using Python 3.12+.
+The table below is from a representative Linux x86-64 run on Python 3.12.12.
+Each result is the median of five runs. Direct I/O uses 8 MiB of uncompressed
+input; the concurrency case uses ten 1 MiB files plus simulated latency. Read
+comparisons use the exact same deterministic gzip bytes, and write comparisons
+use `compresslevel=6` for both libraries. These numbers illustrate tradeoffs
+rather than promising performance on different hardware or data.
 
-### Text Operations (Winner: `aiogzip`)
+| Workload | aiogzip (stdlib) vs `gzip` | aiogzip (zlib-ng) vs `gzip` |
+| --- | ---: | ---: |
+| Bulk text write, level 6 | ~1.01x slower | ~1.01x faster |
+| Bulk text read | ~2.01x slower | ~1.35x slower |
+| Tuned JSONL line iteration | ~1.82x slower | ~1.69x slower |
+| Tuned JSONL read and parse | ~1.19x slower | ~1.11x slower |
+| Highly compressible bulk `read(-1)` | ~1.07x faster | ~5.57x faster |
+| Ten files with simulated 10 ms latency | ~6.06x faster | ~6.09x faster |
 
-`aiogzip` is significantly optimized for text processing, often outperforming the standard `gzip` module due to efficient buffering and async handling.
+Run the suite on the target workload before making a capacity or latency
+decision:
 
-| Operation | aiogzip | gzip (sync) | Speedup |
-|-----------|---------|-------------|---------|
-| **Bulk Text Read/Write** | ~37 MB/s | ~13 MB/s | **~2.9x Faster** |
-| **JSONL Processing** | - | - | **~1.8x Faster** |
-| **Line Iteration** | ~4.2M lines/sec | - | - |
+```bash
+AIOGZIP_ENGINE=stdlib uv run python benchmarks/run_benchmarks.py \
+  --category io,scenarios,concurrency --size 8 --repeat 5
+```
 
-**Why?** `aiogzip` uses optimized UTF-8 decoding strategies (using `codecs.getincrementaldecoder`) and manages buffers efficiently to minimize encoding/decoding overhead. For the single-character newline modes (`None`, `"\n"`, `"\r"`), each decoded chunk's lines are bulk-split in one pass and served from a batch, which makes `async for` line iteration roughly **1.3x** faster than per-line scanning.
+Repeat without `AIOGZIP_ENGINE=stdlib` to measure the optional zlib-ng engine.
+See the repository's
+[benchmark methodology](https://github.com/geoff-davis/aiogzip/tree/main/benchmarks)
+for before/after comparison commands.
+
+### Text operations
+
+For a single warm local file, synchronous `gzip` has less per-operation
+overhead. In particular, every `async for` line crosses an async-iterator
+boundary, so direct line iteration can be slower even though aiogzip bulk-splits
+decoded chunks internally.
+
+That batched line path remains valuable: it made aiogzip 1.7 roughly 1.3x
+faster than aiogzip 1.6's previous per-line scanning implementation. It should
+not be interpreted as a 1.3x advantage over stdlib `gzip`.
 
 For writing many small records, prefer `writelines()` over an explicit loop of
 `await f.write(line)`. It combines inputs into bounded `chunk_size` batches,
 reducing Python coroutine and compressor-call overhead without loading the full
 iterable into memory.
 
-### Binary Operations (Tie)
+### Binary operations
 
-For bulk binary I/O, `aiogzip` matches the throughput of standard `gzip`.
+Bulk binary I/O with stdlib zlib is close to `gzip`; many tiny awaited calls are
+slower. Whole-file reads of highly compressible input are where the optional
+zlib-ng engine can produce a substantial throughput gain.
 
-| Operation | aiogzip | gzip (sync) | Result |
-|-----------|---------|-------------|--------|
-| **Bulk Binary I/O** | ~61 MB/s | ~62 MB/s | **Equivalent** |
-| **Tiny (10-byte) chunk writes** | ~1.6M ops/sec | ~3.3M ops/sec | **Slower** |
+The async write path adds a per-call cost, so batch small writes when throughput
+matters. A full `read(-1)` is fastest when the output comfortably fits in
+memory; use incremental reads for large or untrusted data.
 
-The async write path adds a small per-call cost, so writing in *very* small pieces is slower than synchronous `gzip` — batch writes (or use a larger working buffer) when throughput matters. Bulk reads are fast: a full `read(-1)` of compressible data runs at several hundred MB/s.
+### Concurrency
 
-### Concurrency (Winner: `aiogzip`)
+Concurrency and event-loop responsiveness are aiogzip's primary advantages over
+calling synchronous `gzip` directly inside an async application.
 
-When processing multiple files, especially where I/O latency (disk/network) is involved, `aiogzip` shines by not blocking the event loop.
-
-- **Concurrent I/O (latency-bound)**: up to **~6x faster** than sequential synchronous processing when each file incurs I/O latency.
-- **Mixed read/write workload**: **~1.5x faster**.
+- A synthetic ten-file workload with 10 ms of simulated latency measured about
+  6x faster than sequential synchronous processing. The gain comes from
+  overlapping the delays; it is not a raw codec-speed comparison.
+- A five-operation mixed read/write workload measured about 1.6-1.8x faster in
+  the same run.
 - CPU-bound `zlib` work above a 256 KiB chunk is offloaded to a thread, so multiple streams compress/decompress in parallel instead of serializing on the loop.
-- Allows the main thread to remain responsive (e.g., for a web server) while processing heavy compression tasks.
+- Independent application tasks can continue while file or offloaded codec
+  work is pending.
 
 ### Optional Faster Codec (`aiogzip[fast]` / zlib-ng)
 
@@ -53,14 +86,16 @@ pip install "aiogzip[fast]"
 ```
 
 - **Decompression** uses zlib-ng automatically whenever it is installed. Its
-  output is **byte-identical** to stdlib `zlib`, so this is transparent. Measured
-  read-throughput gains range from ~**1.2-2x** on typical data to **~7-10x** on
-  highly compressible data and bulk `read(-1)`.
+  output is **byte-identical** to stdlib `zlib`, so this is transparent. In the
+  representative run above it made aiogzip's bulk text read about 1.46x faster
+  than aiogzip with stdlib zlib, and its highly compressible bulk `read(-1)`
+  about 5x faster. Gains depend strongly on the data and access pattern.
 - **Compression** stays on stdlib `zlib` by default, because zlib-ng's compressed
   *bytes* are not identical to stdlib's — installing the extra alone must not
-  change produced `.gz` output. Opt in per file with `fast_compress=True` for a
-  ~**1.2-1.5x** compression speedup; the output is valid gzip readable by any
-  decompressor, just not byte-for-byte identical to stdlib.
+  change produced `.gz` output. Opt in per file with `fast_compress=True` for
+  faster compression; the output is valid gzip readable by any decompressor,
+  just not byte-for-byte identical to stdlib. Measure the compression gain on
+  representative input rather than assuming a fixed multiplier.
 
   ```python
   async with AsyncGzipBinaryFile("out.gz", "wb", fast_compress=True) as f:

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -1,4 +1,6 @@
 import argparse
+import ast
+import gzip
 import importlib
 import sys
 from pathlib import Path
@@ -10,8 +12,11 @@ sys.path.insert(0, str(BENCHMARKS_DIR))
 bench_common = importlib.import_module("bench_common")
 run_benchmarks = importlib.import_module("run_benchmarks")
 BenchmarkResults = bench_common.BenchmarkResults
+COMPARISON_COMPRESSLEVEL = bench_common.COMPARISON_COMPRESSLEVEL
+DataGenerator = bench_common.DataGenerator
 median_results = bench_common.median_results
 positive_int = run_benchmarks.positive_int
+write_comparison_fixture = bench_common.write_comparison_fixture
 
 
 def _result(name, duration, marker):
@@ -59,3 +64,59 @@ def test_positive_int(value, expected):
 def test_positive_int_rejects_nonpositive_values(value):
     with pytest.raises(argparse.ArgumentTypeError, match="positive integer"):
         positive_int(value)
+
+
+def test_comparison_fixture_is_deterministic(tmp_path):
+    payload = b"repeatable benchmark payload\n" * 100
+    first = tmp_path / "first.gz"
+    second = tmp_path / "second.gz"
+
+    write_comparison_fixture(first, payload)
+    write_comparison_fixture(second, payload)
+
+    assert COMPARISON_COMPRESSLEVEL == 6
+    assert first.read_bytes() == second.read_bytes()
+    assert gzip.decompress(first.read_bytes()) == payload
+
+
+def test_text_generators_are_deterministic():
+    assert DataGenerator.generate_text(1) == DataGenerator.generate_text(1)
+    assert DataGenerator.generate_jsonl(1) == DataGenerator.generate_jsonl(1)
+
+
+def _gzip_open_write_calls(path):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        function = node.func
+        if not (
+            isinstance(function, ast.Attribute)
+            and isinstance(function.value, ast.Name)
+            and function.value.id == "gzip"
+            and function.attr == "open"
+        ):
+            continue
+        mode = None
+        if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant):
+            mode = node.args[1].value
+        for keyword in node.keywords:
+            if keyword.arg == "mode" and isinstance(keyword.value, ast.Constant):
+                mode = keyword.value.value
+        if isinstance(mode, str) and any(operation in mode for operation in "wax"):
+            yield node
+
+
+def test_comparative_gzip_writes_set_compression_level_explicitly():
+    benchmark_paths = sorted(BENCHMARKS_DIR.glob("bench_*.py"))
+    write_calls = [
+        (path, call)
+        for path in benchmark_paths
+        for call in _gzip_open_write_calls(path)
+    ]
+
+    assert write_calls
+    for path, call in write_calls:
+        assert any(keyword.arg == "compresslevel" for keyword in call.keywords), (
+            f"{path.name}:{call.lineno} uses gzip's implicit compression level"
+        )


### PR DESCRIPTION
## Summary

- make comparative reads use identical deterministic gzip fixtures
- use compression level 6 explicitly for both writers and report reads and writes separately
- replace sub-millisecond line tests with size-scaled default and tuned JSONL comparisons
- isolate JSONL read-and-parse performance from compression
- add tests guarding deterministic fixtures and explicit comparison settings
- correct README and performance-guide claims, including where synchronous gzip remains faster
- document a required before-and-after benchmark workflow for performance-sensitive changes

## Representative corrected results

- equal-level bulk text writes: near parity
- tuned single-file JSONL iteration: 1.7-1.8x slower than synchronous gzip
- highly compressible bulk read with zlib-ng: about 5.6x faster
- ten files with simulated 10 ms latency: about 6x faster through concurrency

## Validation

- uv run pre-commit run --all-files
- uv run pytest (1223 passed)
- uv run mkdocs build --strict
- focused io, scenarios, and concurrency benchmarks with both stdlib zlib and zlib-ng