### PR TITLE
Speed up batched and universal-newline text reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Text `readlines()` now drains the reader's existing bounded line batches
+  directly instead of awaiting `readline()` once per line. Hinted calls retain
+  complete-line and text-position semantics while substantially reducing
+  coroutine overhead for batch-oriented processing.
+- Universal-newline text reads now recognize LF-only decoded chunks with one
+  CR scan, avoiding repeated full-string CRLF/LF/CR counts while preserving
+  mixed-newline tracking, translation, and chunk-boundary behavior.
 - Comparative benchmarks now use deterministic data, identical compressed
   fixtures for reads, explicit compression level 6 for both writers, separate
   read/write timings, realistic size-scaled line workloads, and median results.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ inputs and the concurrency case used ten 1 MiB files:
 - equal-level bulk text writes were at parity;
 - tuned single-file JSONL iteration was about 1.7-1.8x slower than `gzip`
   because each line crosses an async-iterator boundary;
+- bounded `readlines()` batches reduced an 8 MiB JSONL read-and-parse workload
+  by about 10-15% versus direct iteration and brought it roughly to `gzip`
+  parity;
+- an LF-only universal-newline fast path made the representative zlib-ng bulk
+  text read about 1.6x faster than `gzip` (the stdlib engine remained about
+  1.4x slower);
 - optional zlib-ng made a highly compressible bulk `read(-1)` about 5.6x
   faster than `gzip`; and
 - overlapping ten files with simulated 10 ms latency was about 6x faster than
@@ -203,12 +209,16 @@ inputs and the concurrency case used ten 1 MiB files:
 The concurrency result measures overlapped waiting, not a faster deflate
 codec, and benchmark ratios vary by hardware, storage, Python version, and
 data. Large codec calls are offloaded to the default executor so independent
-tasks can keep making progress. Line iteration and `writelines()` use bounded
-batching to reduce aiogzip's own coroutine overhead.
+tasks can keep making progress. Line splitting, `readlines()`, and
+`writelines()` use bounded batching to reduce aiogzip's own coroutine overhead.
 
 For large UTF-8 JSON Lines files with `\n` terminators, the measured fast path
 uses `newline="\n"` and `chunk_size=512 * 1024`. Tune memory and throughput for
 your workload rather than assuming one chunk size fits every application.
+When CPU-bound per-line processing permits it, repeated
+`await f.readlines(hint)` calls can process bounded groups of complete lines
+with fewer async transitions than `async for`; the hint is an approximate
+decoded-character target, not a hard memory limit.
 
 Install the optional codec with:
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -26,6 +26,7 @@ Core read/write performance:
 
 - Binary I/O with small (10-byte) chunks
 - Separate bulk text read and write comparisons
+- Default universal-newline bulk text reads, including the LF-only fast path
 - Default and tuned JSONL line iteration against the exact same gzip fixture
 - Flush operations (100 flushes)
 - Read-all isolated: `read(-1)` timed on its own (write excluded) on compressible data
@@ -61,6 +62,7 @@ Compression analysis:
 Practical use cases:
 
 - Read-only JSONL parsing from one identical fixture
+- Bounded-batch JSONL parsing with `readlines(1 MiB)`
 - JSON decoding and record validation with realistic data
 
 ### 6. 🛡️ Error Handling (`bench_errors.py`)
@@ -79,6 +81,7 @@ Fine-grained performance measurements:
 - read(-1) on 1MB files (100 iterations)
 - Line iteration efficiency (100K lines)
 - readline() loop performance (100K lines)
+- Whole-file and bounded-batch readlines() performance (100K lines)
 - Small write operations (1000 x 120 bytes)
 - Binary readline stress case (200KB line, 17-byte chunks)
 

--- a/benchmarks/bench_micro.py
+++ b/benchmarks/bench_micro.py
@@ -107,6 +107,66 @@ class MicroBenchmarks(BenchmarkBase):
             lines_per_sec=f"{n_lines / avg_time:.0f}",
         )
 
+    async def benchmark_readlines_batching(self):
+        """Benchmark whole-file and bounded-batch readlines consumption."""
+        text_file = self.temp_mgr.get_path("micro_readlines.gz")
+
+        n_lines = 100_000
+        lines = [f"This is line number {i}\n" for i in range(n_lines)]
+        expected_chars = sum(map(len, lines))
+        async with AsyncGzipTextFile(text_file, "wt") as f:
+            await f.write("".join(lines))
+
+        async def consume(hint):
+            line_count = 0
+            char_count = 0
+            async with AsyncGzipTextFile(
+                text_file,
+                "rt",
+                newline="\n",
+                chunk_size=512 * 1024,
+            ) as f:
+                while True:
+                    batch = await f.readlines(hint)
+                    if not batch:
+                        break
+                    line_count += len(batch)
+                    char_count += sum(map(len, batch))
+            assert line_count == n_lines
+            assert char_count == expected_chars
+
+        iterations = 30
+        whole_file_total = 0.0
+        bounded_total = 0.0
+        for _ in range(iterations):
+            start = time.perf_counter()
+            await consume(-1)
+            whole_file_total += time.perf_counter() - start
+
+            start = time.perf_counter()
+            await consume(1024 * 1024)
+            bounded_total += time.perf_counter() - start
+
+        whole_file_avg = whole_file_total / iterations
+        bounded_avg = bounded_total / iterations
+
+        self.add_result(
+            "readlines() - 100K lines",
+            "micro",
+            whole_file_avg,
+            iterations=iterations,
+            avg_time_ms=f"{whole_file_avg * 1000:.3f}ms",
+            lines_per_sec=f"{n_lines / whole_file_avg:.0f}",
+        )
+        self.add_result(
+            "readlines(1 MiB) batches - 100K lines",
+            "micro",
+            bounded_avg,
+            iterations=iterations,
+            avg_time_ms=f"{bounded_avg * 1000:.3f}ms",
+            lines_per_sec=f"{n_lines / bounded_avg:.0f}",
+        )
+
     async def benchmark_small_writes(self):
         """Benchmark many small write operations."""
         test_file = self.temp_mgr.get_path("micro_small_writes.gz")
@@ -187,6 +247,7 @@ class MicroBenchmarks(BenchmarkBase):
         await self.benchmark_read_all()
         await self.benchmark_line_iteration()
         await self.benchmark_readline_loop()
+        await self.benchmark_readlines_batching()
         await self.benchmark_small_writes()
         await self.benchmark_text_writelines_batching()
         await self.benchmark_binary_readline_long_line_small_chunks()

--- a/benchmarks/bench_scenarios.py
+++ b/benchmarks/bench_scenarios.py
@@ -39,6 +39,26 @@ class ScenariosBenchmarks(BenchmarkBase):
         aiogzip_time = time.perf_counter() - start
 
         start = time.perf_counter()
+        batched_count = 0
+        batched_id_sum = 0
+        async with AsyncGzipTextFile(
+            fixture,
+            "rt",
+            encoding="utf-8",
+            newline="\n",
+            chunk_size=512 * 1024,
+        ) as f:
+            while True:
+                lines = await f.readlines(1024 * 1024)
+                if not lines:
+                    break
+                for line in lines:
+                    record = json.loads(line)
+                    batched_count += 1
+                    batched_id_sum += record["id"]
+        batched_time = time.perf_counter() - start
+
+        start = time.perf_counter()
         gzip_count = 0
         gzip_id_sum = 0
         with gzip.open(fixture, "rt", encoding="utf-8", newline="\n") as f:
@@ -50,6 +70,8 @@ class ScenariosBenchmarks(BenchmarkBase):
 
         assert aiogzip_count == gzip_count
         assert aiogzip_id_sum == gzip_id_sum
+        assert batched_count == gzip_count
+        assert batched_id_sum == gzip_id_sum
 
         self.add_result(
             "JSONL read and parse (identical fixture)",
@@ -60,6 +82,16 @@ class ScenariosBenchmarks(BenchmarkBase):
             records=aiogzip_count,
             speedup=format_speedup(aiogzip_time, gzip_time),
             tuning='newline="\\n", chunk_size=512 KiB',
+        )
+        self.add_result(
+            "JSONL batched readlines and parse (identical fixture)",
+            "scenarios",
+            batched_time,
+            aiogzip_time=f"{batched_time:.4f}s",
+            gzip_time=f"{gzip_time:.4f}s",
+            records=batched_count,
+            speedup=format_speedup(batched_time, gzip_time),
+            tuning='newline="\\n", chunk_size=512 KiB, readlines=1 MiB',
         )
 
     async def run_all(self):

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -7,17 +7,18 @@ line size, storage latency, and how much concurrency the application can use.
 
 ## Benchmark Summary
 
-The table below is from a representative Linux x86-64 run on Python 3.12.12.
-Each result is the median of five runs. Direct I/O uses 8 MiB of uncompressed
-input; the concurrency case uses ten 1 MiB files plus simulated latency. Read
-comparisons use the exact same deterministic gzip bytes, and write comparisons
-use `compresslevel=6` for both libraries. These numbers illustrate tradeoffs
-rather than promising performance on different hardware or data.
+The table below is from representative Linux x86-64 runs on Python 3.12.12.
+Each result is the median of at least five runs. Direct I/O uses 8 MiB of
+uncompressed input; the concurrency case uses ten 1 MiB files plus simulated
+latency. Read comparisons use the exact same deterministic gzip bytes, and
+write comparisons use `compresslevel=6` for both libraries. These numbers
+illustrate tradeoffs rather than promising performance on different hardware
+or data.
 
 | Workload | aiogzip (stdlib) vs `gzip` | aiogzip (zlib-ng) vs `gzip` |
 | --- | ---: | ---: |
 | Bulk text write, level 6 | ~1.01x slower | ~1.01x faster |
-| Bulk text read | ~2.01x slower | ~1.35x slower |
+| Bulk LF-only text read | ~1.40x slower | ~1.62x faster |
 | Tuned JSONL line iteration | ~1.82x slower | ~1.69x slower |
 | Tuned JSONL read and parse | ~1.19x slower | ~1.11x slower |
 | Highly compressible bulk `read(-1)` | ~1.07x faster | ~5.57x faster |
@@ -46,6 +47,20 @@ decoded chunks internally.
 That batched line path remains valuable: it made aiogzip 1.7 roughly 1.3x
 faster than aiogzip 1.6's previous per-line scanning implementation. It should
 not be interpreted as a 1.3x advantage over stdlib `gzip`.
+
+For batch-oriented reads, `readlines(hint)` avoids awaiting that per-line path.
+In a local 100,000-line microbenchmark this reduced `readlines()` from about
+32.7 ms to 13.0 ms after the batched drain was introduced. On the representative
+8 MiB JSONL fixture, parsing 1 MiB groups was about 10-15% faster than direct
+`async for` and approximately matched synchronous `gzip`. This optimization
+does not change direct async-iteration performance.
+
+Default universal-newline reads also have a common LF-only fast path. It scans
+once for CR and returns the decoded text unchanged when none is present,
+instead of counting CRLF, LF, and CR separately. On the 8 MiB fixture this made
+the zlib-ng bulk text read about 1.6x faster than `gzip`; stdlib-zlib aiogzip
+remained about 1.4x slower. Mixed CR, LF, and CRLF input retains the full
+tracking and translation path.
 
 For writing many small records, prefer `writelines()` over an explicit loop of
 `await f.write(line)`. It combines inputs into bounded `chunk_size` batches,
@@ -87,9 +102,9 @@ pip install "aiogzip[fast]"
 
 - **Decompression** uses zlib-ng automatically whenever it is installed. Its
   output is **byte-identical** to stdlib `zlib`, so this is transparent. In the
-  representative run above it made aiogzip's bulk text read about 1.46x faster
-  than aiogzip with stdlib zlib, and its highly compressible bulk `read(-1)`
-  about 5x faster. Gains depend strongly on the data and access pattern.
+  representative runs above it changed bulk LF-only text reading from slower
+  than `gzip` to faster, and made highly compressible bulk `read(-1)` about 5x
+  faster. Gains depend strongly on the data and access pattern.
 - **Compression** stays on stdlib `zlib` by default, because zlib-ng's compressed
   *bytes* are not identical to stdlib's — installing the extra alone must not
   change produced `.gz` output. Opt in per file with `fast_compress=True` for
@@ -181,6 +196,34 @@ Why this is faster:
 
 In local measurements on gzipped JSONL reads, `newline="\n"` plus a larger
 chunk size was materially faster than the default text-mode configuration.
+
+If the work performed for each line is synchronous, process bounded groups to
+amortize the async-iterator transition for every individual line:
+
+```python
+import json
+
+import aiogzip
+
+async with aiogzip.open(
+    "events.jsonl.gz",
+    "rt",
+    newline="\n",
+    chunk_size=512 * 1024,
+) as f:
+    while True:
+        lines = await f.readlines(1024 * 1024)
+        if not lines:
+            break
+        for line in lines:
+            record = json.loads(line)
+```
+
+`readlines(hint)` stops after the complete line that reaches the approximate
+decoded-character hint. It therefore uses more than `hint` characters when a
+line crosses the boundary, and the reader also retains its normal bounded
+internal buffers. Use ordinary `async for` when per-line backpressure or the
+smallest practical result buffer matters more than throughput.
 
 ### 5. Buffer Management
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -22,6 +22,30 @@ For large UTF-8 JSON Lines files that are known to use `\n` terminators,
 project use `chunk_size=512 * 1024` to reduce async read overhead; tune that
 value for your memory budget and workload.
 
+For CPU-bound parsing, bounded `readlines()` batches avoid one async transition
+per input line while retaining a predictable application-level working set:
+
+```python
+async with aiogzip.open(
+    "events.jsonl.gz",
+    "rt",
+    newline="\n",
+    chunk_size=512 * 1024,
+) as f:
+    while True:
+        lines = await f.readlines(1024 * 1024)
+        if not lines:
+            break
+        for line in lines:
+            event = json.loads(line)
+            process(event)
+```
+
+The hint counts decoded characters and reading stops after the whole line that
+reaches it, so it is an approximate batch target rather than a strict memory
+limit. Prefer `async for` when each record is handed to an asynchronous
+consumer and per-line backpressure is desirable.
+
 ## Writing JSON Lines
 
 Write records as they become available instead of building the complete file

--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -1060,12 +1060,32 @@ class AsyncGzipTextFile:
         if need:
             start = 1 if crlf_completed else 0
             end = len(text) - 1 if pending_trailing_cr else len(text)
+            cr_count: Optional[int] = None
+
+            # LF-only text is overwhelmingly common and needs no translation.
+            # Count CR first when bare-CR tracking is still outstanding: if
+            # none exist, record a possible LF and avoid the two or three
+            # additional full-string scans below. When CR is present, reuse
+            # the count so mixed-newline input performs no extra scan.
+            if need & self._SEEN_CR and not crlf_completed and not pending_trailing_cr:
+                cr_count = text.count("\r")
+                if cr_count == 0:
+                    if need & self._SEEN_LF and "\n" in text:
+                        seen |= self._SEEN_LF
+                    self._seen_newline_types = seen
+                    self._trailing_cr = False
+                    return text
+
             crlf = text.count("\r\n", start, end)
             if crlf:
                 seen |= self._SEEN_CRLF
             if need & self._SEEN_LF and text.count("\n", start, end) > crlf:
                 seen |= self._SEEN_LF
-            if need & self._SEEN_CR and text.count("\r", start, end) > crlf:
+            if (
+                need & self._SEEN_CR
+                and (cr_count if cr_count is not None else text.count("\r", start, end))
+                > crlf
+            ):
                 seen |= self._SEEN_CR
 
         self._seen_newline_types = seen
@@ -1197,6 +1217,64 @@ class AsyncGzipTextFile:
             return line
         refilled = await self._next_fast_line()
         return refilled if refilled is not None else ""
+
+    async def _readlines_fast(self, hint: int) -> List[str]:
+        """Return lines while draining pre-split batches without per-line awaits.
+
+        ``_next_fast_line`` advances the text-buffer offset for the first line
+        in each new batch. This method advances it for the remaining lines as
+        they are transferred into the result, preserving tell()/seek() state.
+        """
+        lines: List[str] = []
+        total_size = 0
+
+        while True:
+            idx = self._pending_idx
+            pending = self._pending_lines
+            if idx < len(pending):
+                remaining = pending[idx:]
+                remaining_size = sum(map(len, remaining))
+
+                # Consume a complete pending batch when it cannot cross the
+                # hint. An exact hit may also be transferred in bulk and then
+                # returned immediately.
+                if hint <= 0 or total_size + remaining_size <= hint:
+                    lines.extend(remaining)
+                    self._pending_idx = len(pending)
+                    self._text_buffer_offset += remaining_size
+                    total_size += remaining_size
+                    if hint > 0 and total_size >= hint:
+                        return lines
+                    continue
+
+                # The hint lands within this batch. Walk only as far as the
+                # first whole line that reaches it, leaving the rest pending.
+                text_offset = self._text_buffer_offset
+                while idx < len(pending):
+                    line = pending[idx]
+                    idx += 1
+                    line_size = len(line)
+                    lines.append(line)
+                    total_size += line_size
+                    text_offset += line_size
+                    if total_size >= hint:
+                        self._pending_idx = idx
+                        self._text_buffer_offset = text_offset
+                        return lines
+
+                # Runtime callers can still pass non-integer values despite
+                # the annotation. Keep the stream state coherent even for an
+                # unusual comparison value such as float("nan").
+                self._pending_idx = idx
+                self._text_buffer_offset = text_offset
+
+            refilled = await self._next_fast_line()
+            if refilled is None:
+                return lines
+            lines.append(refilled)
+            total_size += len(refilled)
+            if hint > 0 and total_size >= hint:
+                return lines
 
     def __aiter__(self) -> "AsyncGzipTextFile":
         """Make AsyncGzipTextFile iterable for line-by-line reading."""
@@ -1340,6 +1418,9 @@ class AsyncGzipTextFile:
             raise ValueError("I/O operation on closed file.")
         if self._mode_op != "r":
             raise OSError("File not open for reading")
+
+        if self._line_term is not None:
+            return await self._readlines_fast(hint)
 
         lines: List[str] = []
         total_size = 0

--- a/tests/test_batched_readline.py
+++ b/tests/test_batched_readline.py
@@ -66,6 +66,14 @@ class TestMatchesStdlibOracle:
                 got.append(line)
         assert got == expected
 
+    async def test_readlines_matches_oracle(self, rich_gz, newline, chunk_size):
+        expected = oracle_lines(rich_gz, newline)
+        async with AsyncGzipTextFile(
+            rich_gz, "rt", newline=newline, chunk_size=chunk_size
+        ) as f:
+            got = await f.readlines()
+        assert got == expected
+
 
 class TestNoOverSplitting:
     """The control/Unicode chars in SPECIALS must NOT create line breaks."""
@@ -171,6 +179,122 @@ class TestBatchWindowing:
         async with AsyncGzipTextFile(path, "rt", newline="\n", chunk_size=1 << 20) as f:
             lines = [line async for line in f]
         assert lines == ["x" * 500 + "\n", "short\n", "y" * 300 + "\n"]
+
+
+class TestBatchedReadlines:
+    async def test_fast_readlines_does_not_await_per_line(self, tmp_path, monkeypatch):
+        lines = [f"row {i}\n" for i in range(10_000)]
+        path = tmp_path / "readlines-fast.gz"
+        path.write_bytes(gzip.compress("".join(lines).encode("utf-8")))
+
+        async def unexpected_readline(self):
+            raise AssertionError("readlines() awaited the per-line helper")
+
+        monkeypatch.setattr(AsyncGzipTextFile, "_readline_fast", unexpected_readline)
+        async with AsyncGzipTextFile(path, "rt", newline="\n") as f:
+            assert await f.readlines() == lines
+
+    async def test_hint_leaves_pending_lines_and_tell_seek_roundtrips(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(AsyncGzipTextFile, "_LINE_BATCH_CHARS", 128)
+        expected = [f"row {i:04d}\n" for i in range(1000)]
+        path = tmp_path / "readlines-hint.gz"
+        path.write_bytes(gzip.compress("".join(expected).encode("utf-8")))
+
+        async with AsyncGzipTextFile(path, "rt", newline="\n", chunk_size=1 << 20) as f:
+            first = await f.readlines(50)
+            assert sum(map(len, first)) >= 50
+            assert f._pending_idx < len(f._pending_lines)
+
+            cookie = await f.tell()
+            remainder = await f.read()
+            await f.seek(cookie)
+            replayed = await f.read()
+
+        assert "".join(first) + remainder == "".join(expected)
+        assert replayed == remainder
+
+    async def test_repeated_hinted_batches_preserve_every_line(self, tmp_path):
+        expected = [f"item {i}\n" for i in range(10_000)]
+        max_line_size = max(map(len, expected))
+        path = tmp_path / "readlines-repeated.gz"
+        path.write_bytes(gzip.compress("".join(expected).encode("utf-8")))
+
+        actual = []
+        async with AsyncGzipTextFile(path, "rt", newline="\n") as f:
+            while True:
+                batch = await f.readlines(1024)
+                if not batch:
+                    break
+                batch_size = sum(map(len, batch))
+                assert batch_size >= 1024 or batch[-1] == expected[-1]
+                assert batch_size < 1024 + max_line_size
+                actual.extend(batch)
+
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        ("newline", "terminator"), [(None, "\n"), ("\n", "\n"), ("\r", "\r")]
+    )
+    @pytest.mark.parametrize("chunk_size", [3, 64, 1 << 20])
+    async def test_hinted_batches_cover_all_fast_newline_modes(
+        self, tmp_path, newline, terminator, chunk_size
+    ):
+        expected = [f"héllo {i}{terminator}" for i in range(200)]
+        expected.append("final unterminated line")
+        max_line_size = max(map(len, expected))
+        path = tmp_path / "readlines-newline-modes.gz"
+        path.write_bytes(gzip.compress("".join(expected).encode("utf-8")))
+
+        actual = []
+        async with AsyncGzipTextFile(
+            path, "rt", newline=newline, chunk_size=chunk_size
+        ) as f:
+            while True:
+                batch = await f.readlines(37)
+                if not batch:
+                    break
+                batch_size = sum(map(len, batch))
+                assert batch_size >= 37 or batch[-1] == expected[-1]
+                assert batch_size < 37 + max_line_size
+                actual.extend(batch)
+
+        assert actual == expected
+
+    async def test_exact_hint_drains_pending_batch_in_bulk(self, tmp_path):
+        expected = [f"line {i}\n" for i in range(100)]
+        path = tmp_path / "readlines-exact-hint.gz"
+        path.write_bytes(gzip.compress("".join(expected).encode("utf-8")))
+
+        async with AsyncGzipTextFile(path, "rt", newline="\n") as f:
+            assert await f.readline() == expected[0]
+            assert await f.readline() == expected[1]
+            pending = f._pending_lines[f._pending_idx :]
+            assert pending
+            exact_hint = sum(map(len, pending))
+
+            assert await f.readlines(exact_hint) == pending
+            assert f._pending_idx == len(f._pending_lines)
+            assert await f.readlines() == []
+
+    async def test_hint_reached_by_first_refilled_line(self, tmp_path):
+        expected = ["first line\n", "second line\n"]
+        path = tmp_path / "readlines-first-line-hint.gz"
+        path.write_bytes(gzip.compress("".join(expected).encode("utf-8")))
+
+        async with AsyncGzipTextFile(path, "rt", newline="\n") as f:
+            assert await f.readlines(1) == expected[:1]
+            assert await f.readlines() == expected[1:]
+
+    async def test_nan_hint_preserves_unbounded_legacy_behavior(self, tmp_path):
+        expected = ["first\n", "second\n", "third\n", "fourth\n", "final"]
+        path = tmp_path / "readlines-nan-hint.gz"
+        path.write_bytes(gzip.compress("".join(expected).encode("utf-8")))
+
+        async with AsyncGzipTextFile(path, "rt", newline="\n") as f:
+            assert await f.readlines(float("nan")) == expected
+            assert await f.readlines() == []
 
 
 class TestBoundedReadlineInterleaving:

--- a/tests/test_newline_detection.py
+++ b/tests/test_newline_detection.py
@@ -51,6 +51,50 @@ def _write(path, raw):
         f.write(raw)
 
 
+class CountingText(str):
+    """Track full-string count scans in the newline hot path."""
+
+    def __new__(cls, value):
+        instance = super().__new__(cls, value)
+        instance.counted = []
+        return instance
+
+    def count(self, sub, *args):
+        self.counted.append(sub)
+        return super().count(sub, *args)
+
+
+@pytest.mark.parametrize("newline", [None, ""])
+def test_lf_only_chunk_uses_one_count_scan_and_tracks_newline(newline):
+    stream = AsyncGzipTextFile("unused.gz", "rt", newline=newline)
+    text = CountingText("first\nsecond\n")
+
+    assert stream._apply_newline_decoding(text) is text
+    assert text.counted == ["\r"]
+    assert stream.newlines == "\n"
+
+
+def test_lf_only_chunks_keep_one_scan_after_lf_is_known():
+    stream = AsyncGzipTextFile("unused.gz", "rt", newline=None)
+    first = CountingText("first\n")
+    second = CountingText("second\n")
+
+    assert stream._apply_newline_decoding(first) is first
+    assert stream._apply_newline_decoding(second) is second
+    assert first.counted == ["\r"]
+    assert second.counted == ["\r"]
+    assert stream.newlines == "\n"
+
+
+def test_mixed_chunk_reuses_initial_cr_count():
+    stream = AsyncGzipTextFile("unused.gz", "rt", newline=None)
+    text = CountingText("first\r\nsecond\rthird\n")
+
+    assert stream._apply_newline_decoding(text) == "first\nsecond\nthird\n"
+    assert text.counted == ["\r", "\r\n", "\n"]
+    assert stream.newlines == ("\r", "\n", "\r\n")
+
+
 @pytest.mark.parametrize("name", list(_payloads()))
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZES)
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- drain existing pre-split line batches directly in `readlines()` instead of awaiting `readline()` once per line
- add an LF-only universal-newline fast path that uses one CR scan while retaining the existing mixed-CR/CRLF fallback
- add bounded-batch JSONL and readlines microbenchmarks, usage guidance, and changelog entries

## Performance

- 100K-line `readlines()`: 32.66 ms to 12.95 ms (2.52x faster)
- 100K-line `readlines(1 MiB)`: 32.65 ms to 12.74 ms (2.56x faster)
- alternating old/new 8 MiB bulk universal-newline read: 1.66x faster with zlib-ng and 1.35x faster with stdlib zlib
- alternating old/new default line iteration: 1.20x faster with zlib-ng and 1.12x faster with stdlib zlib
- representative zlib-ng bulk LF-only text read moved from slower than `gzip` to about 1.62x faster

## Coverage and validation

- 198 focused tests cover every executable line and branch in both new fast paths
- coverage includes all fast newline modes, 1-byte through 1 MiB chunks, LF/CR/CRLF mixtures and boundary splits, exact and crossing hints, unterminated tails, Unicode, repeated batches, and tell/seek replay
- 1,268 tests pass with zlib-ng
- 1,268 tests pass with `AIOGZIP_ENGINE=stdlib`
- full branch coverage: 92.80%; `_text.py`: 91.11%
- `uv run pre-commit run --all-files`
- `uv run mkdocs build --strict`

## Stack

This PR is intentionally based on #61 (`fix/benchmark-accuracy`) so its diff contains only the text-performance work. Merge #61 first, then retarget this PR to `main`.