### PR TITLE
Prepare release v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-07-13
+
 ### Changed
 
 - Text `readlines()` now drains the reader's existing bounded line batches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,7 @@ Always include:
 ## Version History
 
 - **0.3** - Major refactoring, binary/text separation
-- **1.10.0 (current)** - See `CHANGELOG.md` for the full release history. Recent
+- **1.10.1 (current)** - See `CHANGELOG.md` for the full release history. Recent
   work adds package-level `open()`, whole-file helpers, engine diagnostics,
   gzip inspection and verification, and bounded async-iterable compression and
   decompression. It also expands migration, recipe, streaming, operational, and

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 An asynchronous API modeled after Python's `gzip` module for reading and
 writing gzip-compressed files.
 
+It can substantially outperform sequential `gzip` when async work overlaps or
+optional zlib-ng accelerates bulk decompression; direct single-file line
+iteration remains faster with synchronous `gzip`. See
+[Performance and optional acceleration](#performance-and-optional-acceleration).
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PyPI version](https://img.shields.io/pypi/v/aiogzip.svg)](https://pypi.org/project/aiogzip/)
 [![Python versions](https://img.shields.io/pypi/pyversions/aiogzip.svg)](https://pypi.org/project/aiogzip/)
@@ -17,15 +22,6 @@ pip install aiogzip
 ```
 
 Python 3.8 through 3.14 are supported by the 1.x release line.
-
-> **Performance profile:** aiogzip can substantially outperform sequential
-> `gzip` when independent latency-bound steps overlap or optional zlib-ng
-> accelerates bulk decompression. In one representative run, ten files with
-> simulated 10 ms latency completed roughly 7x faster, and a highly compressible
-> bulk read with zlib-ng was about 6x faster. Direct single-file line
-> iteration remains faster with synchronous `gzip`; aiogzip's advantage there
-> is non-blocking integration and concurrency. See
-> [Performance and optional acceleration](#performance-and-optional-acceleration).
 
 ## Text-mode quickstart
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Python 3.8 through 3.14 are supported by the 1.x release line.
 > **Performance profile:** aiogzip can substantially outperform sequential
 > `gzip` when independent latency-bound steps overlap or optional zlib-ng
 > accelerates bulk decompression. In one representative run, ten files with
-> simulated 10 ms latency completed about 6x faster, and a highly compressible
-> bulk read with zlib-ng was about 5.6x faster. Direct single-file line
+> simulated 10 ms latency completed roughly 7x faster, and a highly compressible
+> bulk read with zlib-ng was about 6x faster. Direct single-file line
 > iteration remains faster with synchronous `gzip`; aiogzip's advantage there
 > is non-blocking integration and concurrency. See
 > [Performance and optional acceleration](#performance-and-optional-acceleration).
@@ -193,18 +193,19 @@ On a representative Python 3.12 Linux run, the direct I/O cases used 8 MiB
 inputs and the concurrency case used ten 1 MiB files:
 
 - equal-level bulk text writes were at parity;
-- tuned single-file JSONL iteration was about 1.7-1.8x slower than `gzip`
+- tuned single-file JSONL iteration was about 1.6x slower than `gzip`
   because each line crosses an async-iterator boundary;
-- bounded `readlines()` batches reduced an 8 MiB JSONL read-and-parse workload
-  by about 10-15% versus direct iteration and brought it roughly to `gzip`
-  parity;
+- with zlib-ng, bounded `readlines()` batches reduced an 8 MiB JSONL
+  read-and-parse workload by about 13% versus direct iteration and matched
+  `gzip` in this run; with stdlib zlib, both aiogzip paths were about 1.2x
+  slower than `gzip`;
 - an LF-only universal-newline fast path made the representative zlib-ng bulk
   text read about 1.6x faster than `gzip` (the stdlib engine remained about
   1.4x slower);
-- optional zlib-ng made a highly compressible bulk `read(-1)` about 5.6x
-  faster than `gzip`; and
-- overlapping ten files with simulated 10 ms latency was about 6x faster than
-  processing them sequentially with `gzip`.
+- optional zlib-ng made a highly compressible bulk `read(-1)` about 6.1x
+  faster than `gzip`, while stdlib zlib was at parity; and
+- overlapping ten files with simulated 10 ms latency was about 6.7-7.0x
+  faster than processing them sequentially with `gzip`.
 
 The concurrency result measures overlapped waiting, not a faster deflate
 codec, and benchmark ratios vary by hardware, storage, Python version, and

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -203,20 +203,21 @@ uv add psutil
 ### Sample Output
 
 ```
-Text line iteration (tuned, identical fixture): 0.021s
-  aiogzip_time: 0.0210s
-  gzip_time: 0.0124s
-  speedup: 1.69x slower
+Text line iteration (tuned, identical fixture): 0.020s
+  aiogzip_time: 0.0197s
+  gzip_time: 0.0121s
+  speedup: 1.62x slower
   lines: 73849
 
-Read-all isolated (compressible, read-only timing): 0.003s
-  aiogzip_read_best: 2.67ms
-  gzip_read_best: 14.88ms
-  speedup: 5.57x faster
+Read-all isolated (compressible, read-only timing): 0.002s
+  aiogzip_read_best: 2.40ms
+  gzip_read_best: 14.69ms
+  speedup: 6.13x faster
 ```
 
-These are illustrative results from one zlib-ng-enabled machine, not expected
-values or acceptance thresholds.
+These are illustrative results from the 2026-07-13 Python 3.12.12 run at
+commit `9e85d8d` on one zlib-ng-enabled machine, not expected values or
+acceptance thresholds.
 
 ### Interpreting Results
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,10 @@ It is designed for high-performance I/O operations, especially for text-based da
 ## Features
 
 - **Truly Asynchronous**: Built with `asyncio` and `aiofiles` for non-blocking file I/O.
-- **High-Performance Text Processing**: Significantly faster than the standard `gzip` library for text and JSONL file operations.
+- **Async-Native Text Processing**: Bounded line batching and optional zlib-ng
+  acceleration provide competitive text and JSONL throughput without blocking
+  the event loop. Direct single-file line iteration can be slower than
+  synchronous `gzip`; see the [Performance Guide](performance.md).
 - **Simple API**: Mimics the interface of `gzip.open()`, making it easy to adopt.
 - **Separate Binary and Text Modes**: `AsyncGzipBinaryFile` and `AsyncGzipTextFile` provide clear, type-safe handling of data.
 - **Excellent Compression Quality**: Achieves compression ratios nearly identical to the standard `gzip` module.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -7,7 +7,8 @@ line size, storage latency, and how much concurrency the application can use.
 
 ## Benchmark Summary
 
-The table below is from representative Linux x86-64 runs on Python 3.12.12.
+The table below is from representative Linux x86-64 runs on Python 3.12.12
+on 2026-07-13 at commit `9e85d8d`.
 Each result is the median of at least five runs. Direct I/O uses 8 MiB of
 uncompressed input; the concurrency case uses ten 1 MiB files plus simulated
 latency. Read comparisons use the exact same deterministic gzip bytes, and
@@ -17,12 +18,12 @@ or data.
 
 | Workload | aiogzip (stdlib) vs `gzip` | aiogzip (zlib-ng) vs `gzip` |
 | --- | ---: | ---: |
-| Bulk text write, level 6 | ~1.01x slower | ~1.01x faster |
-| Bulk LF-only text read | ~1.40x slower | ~1.62x faster |
-| Tuned JSONL line iteration | ~1.82x slower | ~1.69x slower |
-| Tuned JSONL read and parse | ~1.19x slower | ~1.11x slower |
-| Highly compressible bulk `read(-1)` | ~1.07x faster | ~5.57x faster |
-| Ten files with simulated 10 ms latency | ~6.06x faster | ~6.09x faster |
+| Bulk text write, level 6 | parity (~1.02x slower) | parity (~1.01x slower) |
+| Bulk LF-only text read | ~1.36x slower | ~1.62x faster |
+| Tuned JSONL line iteration | ~1.64x slower | ~1.62x slower |
+| Tuned JSONL read and parse | ~1.24x slower | ~1.14x slower |
+| Highly compressible bulk `read(-1)` | parity | ~6.13x faster |
+| Ten files with simulated 10 ms latency | ~6.71x faster | ~7.02x faster |
 
 Run the suite on the target workload before making a capacity or latency
 decision:
@@ -49,11 +50,13 @@ faster than aiogzip 1.6's previous per-line scanning implementation. It should
 not be interpreted as a 1.3x advantage over stdlib `gzip`.
 
 For batch-oriented reads, `readlines(hint)` avoids awaiting that per-line path.
-In a local 100,000-line microbenchmark this reduced `readlines()` from about
-32.7 ms to 13.0 ms after the batched drain was introduced. On the representative
-8 MiB JSONL fixture, parsing 1 MiB groups was about 10-15% faster than direct
-`async for` and approximately matched synchronous `gzip`. This optimization
-does not change direct async-iteration performance.
+In the current 100,000-line microbenchmark, `readlines()` took about 14.1 ms
+versus 32.2 ms for a `readline()` loop, roughly 2.3x faster. On the
+representative 8 MiB JSONL fixture with zlib-ng, parsing 1 MiB groups was about
+13% faster than direct `async for` and matched synchronous `gzip`. With stdlib
+zlib, decompression dominated and both aiogzip parsing paths were about 1.2x
+slower than `gzip`. This optimization does not change direct async-iteration
+performance.
 
 Default universal-newline reads also have a common LF-only fast path. It scans
 once for CR and returns the decoded text unchanged when none is present,
@@ -83,10 +86,10 @@ Concurrency and event-loop responsiveness are aiogzip's primary advantages over
 calling synchronous `gzip` directly inside an async application.
 
 - A synthetic ten-file workload with 10 ms of simulated latency measured about
-  6x faster than sequential synchronous processing. The gain comes from
+  6.7-7.0x faster than sequential synchronous processing. The gain comes from
   overlapping the delays; it is not a raw codec-speed comparison.
-- A five-operation mixed read/write workload measured about 1.6-1.8x faster in
-  the same run.
+- The suite also includes a short five-operation mixed read/write workload;
+  treat its ratio as latency-sensitive rather than a stable throughput claim.
 - CPU-bound `zlib` work above a 256 KiB chunk is offloaded to a thread, so multiple streams compress/decompress in parallel instead of serializing on the loop.
 - Independent application tasks can continue while file or offloaded codec
   work is pending.
@@ -103,7 +106,7 @@ pip install "aiogzip[fast]"
 - **Decompression** uses zlib-ng automatically whenever it is installed. Its
   output is **byte-identical** to stdlib `zlib`, so this is transparent. In the
   representative runs above it changed bulk LF-only text reading from slower
-  than `gzip` to faster, and made highly compressible bulk `read(-1)` about 5x
+  than `gzip` to faster, and made highly compressible bulk `read(-1)` about 6x
   faster. Gains depend strongly on the data and access pattern.
 - **Compression** stays on stdlib `zlib` by default, because zlib-ng's compressed
   *bytes* are not identical to stdlib's — installing the extra alone must not

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -28,7 +28,7 @@ from ._inspection import (
 from ._streaming import _compress_chunks, _decompress_chunks
 from ._text import AsyncGzipTextFile
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 
 # Mode strings that select a text stream (they contain a 't'). The factory
 # parses modes character-by-character and is permutation-tolerant, so these


### PR DESCRIPTION
## Summary

- bump the package version and changelog to v1.10.1
- refresh README, performance-guide, and benchmark sample numbers from five-repeat Python 3.12.12 runs on merged main
- replace the legacy blanket text/JSONL speed claim with the measured async-concurrency and optional-codec tradeoffs
- use parity or rounded ranges where normal benchmark noise makes point estimates misleading

## Fresh benchmark highlights

- stdlib / zlib-ng bulk LF-only text read: 1.36x slower / 1.62x faster than gzip
- stdlib / zlib-ng tuned line iteration: 1.64x / 1.62x slower
- stdlib / zlib-ng highly compressible read(-1): parity / 6.13x faster
- simulated-latency concurrency: 6.71-7.02x faster
- current readlines microbenchmark: 14.1 ms versus 32.2 ms for a readline loop

## Validation

- `uv run pre-commit run --all-files`
- `uv run pytest --cov --cov-fail-under=85` — 1,268 passed, 92.80% coverage
- `AIOGZIP_ENGINE=stdlib uv run pytest` — 1,268 passed
- `uv run mkdocs build --strict`
- `uv build`
- `uvx twine check dist/aiogzip-1.10.1.tar.gz dist/aiogzip-1.10.1-py3-none-any.whl`
- inspected wheel and sdist contents
- installed-wheel smoke test on Python 3.12 covering read/write/open, inspect/verify, and streaming compression
- five-repeat `io,scenarios,concurrency` benchmarks with stdlib and zlib-ng, plus the focused microbenchmark