### PR TITLE
Speed up line splitting and LF-only newline detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Batched text line splitting now uses C-level `str.splitlines(keepends=True)`
+  when a cheap membership probe confirms the region contains none of the extra
+  break characters `splitlines` recognizes (`\v`, `\f`, `\x1c`-`\x1e`, `\x85`,
+  U+2028, U+2029), falling back to the keepends regex otherwise. Differentially
+  verified against the regex splitter; `readlines()` batches measured ~30%
+  faster and direct line iteration ~10-15% faster on LF-only fixtures, with
+  no regression for CRLF-content or mixed input.
+- The LF-only universal-newline fast path now probes for CR with an early-exit
+  membership scan instead of a full `str.count()` pass (~16x cheaper on
+  CR-free chunks), bringing bulk text reads on LF-only files to near parity
+  with synchronous `gzip` under the stdlib engine. Mixed-newline tracking,
+  translation, and chunk-boundary behavior are unchanged.
+
 ## [1.10.1] - 2026-07-13
 
 ### Changed

--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -35,6 +35,14 @@ from ._common import (
 _LINE_RE_LF = re.compile(r"[^\n]*\n")
 _LINE_RE_CR = re.compile(r"[^\r]*\r")
 
+# Characters str.splitlines() breaks on that are ordinary content for the
+# single-character terminator modes. When none of them appear in a region
+# that ends on the terminator, C-level str.splitlines(keepends=True) produces
+# exactly the same list as the keepends regex, ~1.4x faster. Each membership
+# test is a C-speed scan, so the guard costs far less than the regex pass.
+_SPLITLINES_UNSAFE_LF = "\r\v\f\x1c\x1d\x1e\x85\u2028\u2029"
+_SPLITLINES_UNSAFE_CR = "\n\v\f\x1c\x1d\x1e\x85\u2028\u2029"
+
 
 class AsyncGzipTextFile:
     """
@@ -111,6 +119,7 @@ class AsyncGzipTextFile:
         "_fast_compress",
         "_line_term",
         "_line_split_re",
+        "_splitlines_unsafe",
         "_pending_lines",
         "_pending_idx",
     )
@@ -248,9 +257,13 @@ class AsyncGzipTextFile:
             self._line_split_re: Optional[re.Pattern] = (
                 _LINE_RE_CR if newline == "\r" else _LINE_RE_LF
             )
+            self._splitlines_unsafe: Optional[str] = (
+                _SPLITLINES_UNSAFE_CR if newline == "\r" else _SPLITLINES_UNSAFE_LF
+            )
         else:
             self._line_term = None
             self._line_split_re = None
+            self._splitlines_unsafe = None
         self._pending_lines: List[str] = []
         self._pending_idx: int = 0
 
@@ -1060,16 +1073,16 @@ class AsyncGzipTextFile:
         if need:
             start = 1 if crlf_completed else 0
             end = len(text) - 1 if pending_trailing_cr else len(text)
-            cr_count: Optional[int] = None
 
             # LF-only text is overwhelmingly common and needs no translation.
-            # Count CR first when bare-CR tracking is still outstanding: if
-            # none exist, record a possible LF and avoid the two or three
-            # additional full-string scans below. When CR is present, reuse
-            # the count so mixed-newline input performs no extra scan.
+            # Probe for CR first when bare-CR tracking is still outstanding:
+            # `in` is an early-exit memchr scan (~16x cheaper than count() on
+            # CR-free text), and when no CR exists the two or three counting
+            # scans below are skipped entirely. When CR is present the probe
+            # exits at the first hit, so mixed-newline input pays only a
+            # negligible partial scan before the counts run.
             if need & self._SEEN_CR and not crlf_completed and not pending_trailing_cr:
-                cr_count = text.count("\r")
-                if cr_count == 0:
+                if "\r" not in text:
                     if need & self._SEEN_LF and "\n" in text:
                         seen |= self._SEEN_LF
                     self._seen_newline_types = seen
@@ -1081,11 +1094,7 @@ class AsyncGzipTextFile:
                 seen |= self._SEEN_CRLF
             if need & self._SEEN_LF and text.count("\n", start, end) > crlf:
                 seen |= self._SEEN_LF
-            if (
-                need & self._SEEN_CR
-                and (cr_count if cr_count is not None else text.count("\r", start, end))
-                > crlf
-            ):
+            if need & self._SEEN_CR and text.count("\r", start, end) > crlf:
                 seen |= self._SEEN_CR
 
         self._seen_newline_types = seen
@@ -1163,7 +1172,18 @@ class AsyncGzipTextFile:
             last = buf.find(term, start)
         if last >= start:
             region = buf[start : last + 1]
-            self._pending_lines = split_re.findall(region)
+            # str.splitlines(keepends=True) matches the keepends regex exactly
+            # when the region contains none of the extra break characters
+            # splitlines recognizes; the membership scans are C-speed and much
+            # cheaper than the regex pass they usually replace.
+            unsafe = self._splitlines_unsafe
+            assert unsafe is not None
+            for _ch in unsafe:
+                if _ch in region:
+                    self._pending_lines = split_re.findall(region)
+                    break
+            else:
+                self._pending_lines = region.splitlines(keepends=True)
             self._pending_idx = 0
             return self._take_first_refilled_line()
 

--- a/tests/test_newline_detection.py
+++ b/tests/test_newline_detection.py
@@ -52,46 +52,60 @@ def _write(path, raw):
 
 
 class CountingText(str):
-    """Track full-string count scans in the newline hot path."""
+    """Track count scans and membership probes in the newline hot path."""
 
     def __new__(cls, value):
         instance = super().__new__(cls, value)
         instance.counted = []
+        instance.probed = []
         return instance
 
     def count(self, sub, *args):
         self.counted.append(sub)
         return super().count(sub, *args)
 
+    def __contains__(self, sub):
+        self.probed.append(sub)
+        return super().__contains__(sub)
+
 
 @pytest.mark.parametrize("newline", [None, ""])
-def test_lf_only_chunk_uses_one_count_scan_and_tracks_newline(newline):
+def test_lf_only_chunk_probes_without_counting_and_tracks_newline(newline):
     stream = AsyncGzipTextFile("unused.gz", "rt", newline=newline)
     text = CountingText("first\nsecond\n")
 
     assert stream._apply_newline_decoding(text) is text
-    assert text.counted == ["\r"]
+    # LF-only text takes the early-exit membership probes and never pays a
+    # full counting scan.
+    assert text.counted == []
+    assert text.probed == ["\r", "\n"]
     assert stream.newlines == "\n"
 
 
-def test_lf_only_chunks_keep_one_scan_after_lf_is_known():
+def test_lf_only_chunks_stay_count_free_after_lf_is_known():
     stream = AsyncGzipTextFile("unused.gz", "rt", newline=None)
     first = CountingText("first\n")
     second = CountingText("second\n")
 
     assert stream._apply_newline_decoding(first) is first
     assert stream._apply_newline_decoding(second) is second
-    assert first.counted == ["\r"]
-    assert second.counted == ["\r"]
+    assert first.counted == []
+    assert first.probed == ["\r", "\n"]
+    # Once LF is recorded, later LF-only chunks pay only the single CR probe.
+    assert second.counted == []
+    assert second.probed == ["\r"]
     assert stream.newlines == "\n"
 
 
-def test_mixed_chunk_reuses_initial_cr_count():
+def test_mixed_chunk_probes_then_counts():
     stream = AsyncGzipTextFile("unused.gz", "rt", newline=None)
     text = CountingText("first\r\nsecond\rthird\n")
 
     assert stream._apply_newline_decoding(text) == "first\nsecond\nthird\n"
-    assert text.counted == ["\r", "\r\n", "\n"]
+    # The CR probe exits at the first hit, then the three counting scans
+    # classify the mix; translation re-probes CR before rewriting.
+    assert text.counted == ["\r\n", "\n", "\r"]
+    assert text.probed == ["\r", "\r"]
     assert stream.newlines == ("\r", "\n", "\r\n")
 
 


### PR DESCRIPTION
## Summary

Two benchmark-verified hot-path optimizations for text reads:

- **Batched line splitting** now uses C-level `str.splitlines(keepends=True)` when cheap membership probes confirm the region contains none of the extra break characters `splitlines` recognizes (`\v`, `\f`, `\x1c`–`\x1e`, `\x85`, U+2028, U+2029), falling back to the keepends regex otherwise. Verified equivalent to the regex splitter on 40k adversarial differential cases (regions salted with every break char, multibyte chars, empty lines).
- **LF-only universal-newline detection** now probes for CR with an early-exit membership scan instead of a full `str.count()` pass — ~16x cheaper on CR-free chunks (2.1 ms → 0.13 ms per 8 MiB decoded).

The scan-discipline tests in `test_newline_detection.py` now pin the new contract: zero counting scans on LF-only chunks, membership probes tracked via `__contains__`.

## Benchmarks

Min of 3 interleaved before/after rounds, stdlib engine, per the CLAUDE.md procedure (PYTHONPATH-shadowed baseline worktree, same venv/interpreter):

| Benchmark | Δ |
| --- | ---: |
| readlines(1 MiB) batches — 100K lines | −35.5% |
| readlines() — 100K lines | −33.9% |
| Text large reads (sized read + long line) | −31.9% |
| Text read (bulk, identical fixture) | −26.2% |
| Line iteration — 100K lines | −19.3% |
| readline() loop — 100K lines | −14.3% |
| Text line iteration (default, 8 MiB) | −10.0% |
| Writes / binary / flush | within measured run-to-run noise (±3%) |

Bulk LF-only text reads now reach near parity with synchronous `gzip` on the stdlib engine (warm-profile: 3.00 ms vs 3.16 ms on an 8 MiB LF-only file).

CRLF-content input bails on the first guard probe (`\r` is checked first) — measured no regression on that path.

## Not included

README/docs performance tables are from the Linux x86-64 reference runs and can't be reproduced on this machine (macOS ships an accelerated system zlib, changing the sync-gzip baseline). They should be regenerated there after this merges.

## Test plan

- [x] Full suite: 1268 passed
- [x] 40k-case differential test of guarded splitlines vs keepends regex
- [x] pre-commit: ruff, ruff format, mypy, ty, python38-compat, markdownlint
- [x] Interleaved before/after benchmarks (io, micro at 8 MB; headline io+scenarios both engines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)