### PR TITLE
Use the fastest crc32 implementation per platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Performance
+
+- `crc32` now uses zlib-ng's SIMD implementation when the `aiogzip[fast]`
+  extra is installed, except on macOS where Apple's hardware-accelerated
+  stdlib zlib measured ~4x faster than zlib-ng (zlib-ng measured ~3.4x
+  faster than stdlib on x86-64 Linux). CRC-32 output is fully specified and
+  bit-identical across engines, so this affects only speed; the write path,
+  streaming encoder, and inspection/verification all share the selection,
+  and `AIOGZIP_ENGINE=stdlib` still forces stdlib everywhere.
+
 ## [1.10.1] - 2026-07-13
 
 ### Changed

--- a/src/aiogzip/_engine.py
+++ b/src/aiogzip/_engine.py
@@ -16,6 +16,7 @@ reproducible error behaviour or debugging).
 import asyncio
 import importlib
 import os
+import sys
 import zlib
 from dataclasses import dataclass
 from typing import Any, Callable, Tuple, Type
@@ -74,9 +75,17 @@ if _zng is not None:
 else:
     ZLIB_ERRORS = (zlib.error,)
 
-# crc32 stays on stdlib: the result is engine-independent, and pinning it
-# avoids any surprise from a divergent implementation.
-crc32 = zlib.crc32
+# crc32 output is bit-identical across engines (CRC-32 is fully specified),
+# so select the fastest implementation per platform. Measured on 8 MiB
+# inputs: zlib-ng's SIMD crc32 is ~3.4x faster than stdlib on x86-64 Linux
+# (12.9 vs 3.7 GB/s), but on macOS Apple ships a hardware-accelerated zlib
+# whose crc32 is ~4x faster than zlib-ng's (42 vs 11 GB/s) — keep stdlib
+# there. Every caller goes through this name, so the choice applies to the
+# write path, streaming encoder, and inspection/verification alike.
+if _HAVE_ZNG and sys.platform != "darwin":
+    crc32 = _zng.crc32
+else:
+    crc32 = zlib.crc32
 
 # Re-export the constants _binary.py needs so it has a single import surface.
 MAX_WBITS = zlib.MAX_WBITS

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8,6 +8,7 @@ zlib.error.
 
 import gzip
 import importlib
+import sys
 import zlib
 from dataclasses import FrozenInstanceError
 
@@ -46,8 +47,26 @@ class TestEngineSelection:
         assert _engine.decompress_engine_name() == expected
         assert _engine.have_fast_engine() is active_engine
 
-    def test_crc32_is_stdlib(self):
-        assert _engine.crc32 is zlib.crc32
+    def test_crc32_selection_is_platform_gated(self):
+        """crc32 uses zlib-ng's SIMD implementation when available, except on
+        macOS where Apple's hardware-accelerated stdlib zlib measured ~4x
+        faster than zlib-ng's."""
+        if ZNG_AVAILABLE and not _engine._FORCE_STDLIB and sys.platform != "darwin":
+            assert _engine.crc32 is _engine._zng.crc32
+        else:
+            assert _engine.crc32 is zlib.crc32
+
+    @pytest.mark.skipif(not ZNG_AVAILABLE, reason="zlib-ng not installed")
+    @pytest.mark.parametrize(
+        "data",
+        [b"", b"x", b"payload" * 10_000, bytes(range(256)) * 100],
+        ids=["empty", "single", "repetitive-70k", "binary-25k"],
+    )
+    def test_crc32_engines_agree(self, data):
+        """CRC-32 is fully specified; both engines must agree bit-for-bit,
+        including with a running-checksum seed."""
+        assert _engine._zng.crc32(data) == zlib.crc32(data)
+        assert _engine._zng.crc32(data, 12345) == zlib.crc32(data, 12345)
 
 
 class TestEngineInfo:
@@ -88,6 +107,8 @@ class TestEnvEscapeHatch:
         try:
             assert reloaded.have_fast_engine() is False
             assert reloaded.decompress_engine_name() == "stdlib"
+            # The escape hatch also pins crc32 back to stdlib.
+            assert reloaded.crc32 is zlib.crc32
         finally:
             # Restore module state (and the _binary reference to it) for other tests.
             monkeypatch.delenv("AIOGZIP_ENGINE", raising=False)


### PR DESCRIPTION
## Summary

The one keeper from the isal engine evaluation: unpin `_engine.crc32` from stdlib and select the fastest implementation per platform. CRC-32 is fully specified — output is bit-identical across engines — so this affects only speed.

| platform | stdlib zlib | zlib-ng | selected |
| --- | ---: | ---: | --- |
| x86-64 Linux (GH runner, avx2) | 3.7 GB/s | **12.9 GB/s** | zlib-ng |
| macOS arm64 (M3, Apple-accelerated zlib) | **42.5 GB/s** | 10.8 GB/s | stdlib |

(8 MiB realistic-entropy input, min of 9.)

- Selection: `zlib-ng` when the `[fast]` extra is installed **and** not on darwin; stdlib otherwise. `AIOGZIP_ENGINE=stdlib` still forces stdlib everywhere.
- Every caller already routes through `_engine.crc32`, so the write path, streaming encoder, and inspection/verification all pick up the selection.
- The engine-selection test asserts the platform gate; the Linux CI legs with zlib-ng installed exercise the non-darwin branch. A new cross-engine test pins seeded/unseeded agreement with stdlib.

## Context

From the isal investigation (evaluated as a third engine, rejected): on x86-64 with realistic text-like data isal decompresses ~1.3x faster than zlib-ng, but it loses on high-entropy input, loses everywhere on ARM, its macOS arm64 wheel ships without any NEON/PMULL assembly (filed upstream: pycompression/python-isal#254), and its 0–3 compression levels don't map onto the existing `compresslevel` contract. The crc32 measurements were the piece worth keeping.

## Test plan

- [x] Full suite: 1272 passed (4 new crc32 selection/agreement tests)
- [x] `AIOGZIP_ENGINE=stdlib` leg re-run locally: selection falls back to stdlib
- [x] Verified darwin gate locally (zlib-ng installed, crc32 stays stdlib)
- [x] pre-commit: ruff, ruff format, mypy, ty, python38-compat, markdownlint

🤖 Generated with [Claude Code](https://claude.com/claude-code)