### PR TITLE
Prepare release v1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.10.2] - 2026-07-16
+
 ### Documentation
 
 - Refreshed the benchmark tables and README performance summary from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,11 +286,12 @@ Always include:
 ## Version History
 
 - **0.3** - Major refactoring, binary/text separation
-- **1.10.1 (current)** - See `CHANGELOG.md` for the full release history. Recent
+- **1.10.2 (current)** - See `CHANGELOG.md` for the full release history. Recent
   work adds package-level `open()`, whole-file helpers, engine diagnostics,
   gzip inspection and verification, and bounded async-iterable compression and
-  decompression. It also expands migration, recipe, streaming, operational, and
-  benchmark documentation.
+  decompression. Recent performance work speeds up batched line splitting and
+  LF-only newline detection and selects the fastest crc32 engine per platform;
+  the benchmark documentation reflects 2026-07-16 reference runs.
 
 ---
 

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -28,7 +28,7 @@ from ._inspection import (
 from ._streaming import _compress_chunks, _decompress_chunks
 from ._text import AsyncGzipTextFile
 
-__version__ = "1.10.1"
+__version__ = "1.10.2"
 
 # Mode strings that select a text stream (they contain a 't'). The factory
 # parses modes character-by-character and is permutation-tolerant, so these


### PR DESCRIPTION
## Summary

Release v1.10.2 — performance patch release.

### Changed

- `crc32` now uses zlib-ng's SIMD implementation when the `aiogzip[fast]` extra is installed, except on macOS where Apple's hardware-accelerated stdlib zlib is faster. Output is bit-identical; only speed changes. (#65)
- Batched text line splitting now uses C-level `str.splitlines(keepends=True)` behind a membership-probe guard; `readlines()` batches measured ~30% faster and direct line iteration ~10-15% faster on LF-only fixtures. (#64)
- The LF-only universal-newline fast path probes for CR with an early-exit scan instead of a full `str.count()` pass, bringing bulk LF-only text reads to near parity with synchronous `gzip` on the stdlib engine. (#64)

### Documentation

- Benchmark tables and README performance summary refreshed from 2026-07-16 Linux x86-64 reference runs; README comparison bullets now lead with the concurrency and accelerated-read results. (#66)

After CI passes and this merges, `/release-tag` tags and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)