### PR TITLE
1.11.0 usability: sync-protocol stubs, iter_batches, CLI, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Documentation
+
+- New "Migrating from `gzip.open`" page: the exactly-three differences
+  (`async with`, `async for`, `await` on reads/writes) with a before/after
+  pair.
+- New "Error handling" page documenting the exception taxonomy:
+  `gzip.BadGzipFile` for corrupt data (normalized across engines), `OSError`
+  for I/O failures, and a plain `OSError` — deliberately not `BadGzipFile`,
+  and thus distinguishable by type — with a stable message prefix when
+  `max_decompressed_size` is exceeded.
+- New ADR recording the ISA-L (python-isal) evaluation and why it was not
+  adopted, with revisit criteria.
+- New "Gzip over S3 / fsspec" recipe for streaming via async `fileobj`s; the
+  JSONL batching recipes and performance guide now use `iter_batches()`; new
+  "When stdlib gzip is fine" section in the performance guide.
+
 ### Added
 
 - `AsyncGzipTextFile.iter_batches(hint)`: first-class batched line iteration —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `AsyncGzipTextFile.iter_batches(hint)`: first-class batched line iteration —
+  `async for batch in f.iter_batches():` yields non-empty lists of complete
+  lines, ending naturally at EOF. Implemented as a thin wrapper over the same
+  internal drain as `readlines(hint)` so the two can never diverge; batching
+  amortizes the per-line `await` of `async for line in f` (roughly 2x on
+  line-dense files in the repo harness). The default hint is 1 MiB, chosen by
+  interleaved min-of-N benchmark: throughput was flat from 256 KiB to ~1 MiB
+  and slightly worse above 2 MiB. `hint` must be a positive integer,
+  validated eagerly at the call.
+
+- Using `with` or `for` on `AsyncGzipBinaryFile`/`AsyncGzipTextFile` now
+  raises a corrective `TypeError` (e.g. "must be used with 'async with', not
+  'with'") instead of the generic protocol errors, via `__enter__`/`__exit__`
+  and `__iter__` stubs.
+
+- `EngineInfo` gained a `crc32` field reporting which engine backs the crc32
+  selection (`"zlib-ng"` except on macOS or under `AIOGZIP_ENGINE=stdlib`,
+  where it is `"stdlib-zlib"`). The field is defaulted so existing
+  two-argument `EngineInfo(...)` construction keeps working.
+
 ### Changed
 
 - Switched the git-hook runner from `pre-commit` to `prek`, a Rust drop-in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to this project will be documented in this file.
   'with'") instead of the generic protocol errors, via `__enter__`/`__exit__`
   and `__iter__` stubs.
 
+- `python -m aiogzip {inspect,verify} FILE`: a minimal command-line interface
+  over the existing `inspect()`/`verify()` APIs. Human-readable output by
+  default, `--json` for machine use (bytes fields hex-encoded); exit code 0
+  on success, 1 for invalid or unreadable streams, 2 for usage errors.
+
 - `EngineInfo` gained a `crc32` field reporting which engine backs the crc32
   selection (`"zlib-ng"` except on macOS or under `AIOGZIP_ENGINE=stdlib`,
   where it is `"stdlib-zlib"`). The field is defaulted so existing

--- a/docs/adr-isal.md
+++ b/docs/adr-isal.md
@@ -1,0 +1,46 @@
+# ADR: ISA-L (python-isal) evaluated, not adopted
+
+**Status:** Decided (1.11.0) — not adopted. Revisit criteria below.
+
+## Context
+
+[python-isal](https://github.com/pycompression/python-isal) binds Intel's
+ISA-L library, which advertises substantially faster DEFLATE than zlib. aiogzip
+already ships an optional fast engine (zlib-ng via the `[fast]` extra), so the
+question was whether isal should be added as a second — or replacement —
+engine for decompression and/or compression.
+
+## Decision
+
+Not adopted. zlib-ng remains the only optional engine.
+
+## Key findings
+
+- **Correctness is not the issue.** isal's decompressed output is
+  byte-identical to zlib's, as gzip requires.
+- **ARM is a clear loss.** On macOS arm64 and Linux aarch64, isal was
+  dominated by zlib-ng in every measured cell. The macOS arm64 wheel of
+  isal 1.8.0 decompressed at plain-C speeds (~0.45 GB/s vs 2.4 GB/s for the
+  comparable manylinux aarch64 wheel) and appears to be built without the
+  optimized assembly; an upstream issue reports this.
+- **x86-64 Linux is a narrow, conditional win.** isal beat zlib-ng by about
+  1.4x on realistic-entropy data (~5x compression ratio) but lost on
+  high-ratio data. Benchmark fixtures with extreme compression ratios mostly
+  measure output copying rather than DEFLATE decode, and overstate engines
+  that optimize the copy path — a trap this evaluation had to correct for.
+- **Compression is capped at levels 0–3.** isal cannot express the default
+  gzip level 6, so it could at most back an opt-in "fast compression" mode —
+  a role zlib-ng already fills with full level support.
+- **An implementation hazard.** aiogzip's incremental decoder currently relies
+  on zlib's post-EOF behavior of aliasing leftover bytes into both
+  `unused_data` and `unconsumed_tail`. isal does not share that quirk, so
+  adopting it safely requires rewriting consumption accounting to count bytes
+  arithmetically instead of trusting post-EOF engine attributes — planned as
+  part of the 2.0 sans-IO extraction, not a minor-release change.
+
+## Revisit when
+
+- isal shows a decisive x86-64 decompression win over zlib-ng on
+  realistic-entropy data (not extreme-ratio fixtures), or
+- the engine-agnostic consumption-accounting rewrite lands (2.0 sans-IO
+  extraction), removing the main implementation hazard.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,66 @@
+# Error Handling
+
+aiogzip normalizes errors into a small, stable taxonomy. The engine backing
+decompression (stdlib zlib or zlib-ng from the `[fast]` extra) never changes
+which exception type you see: engine-specific errors are caught internally and
+re-raised uniformly, so `except` clauses written against stdlib behavior keep
+working when the fast engine is installed.
+
+## Taxonomy
+
+| Situation | Raises | Notes |
+|---|---|---|
+| Corrupt or malformed gzip data | `gzip.BadGzipFile` | Bad magic/header, CRC mismatch, wrong ISIZE, truncated or garbled deflate stream. Identical across engines. |
+| Underlying I/O failure | `OSError` | Missing file, permission denied, disk errors — whatever the OS raised. |
+| `max_decompressed_size` exceeded | `OSError` (not `BadGzipFile`) | Message starts with `"decompressed output exceeded max_decompressed_size"`. |
+| Wrong argument types / values | `TypeError` / `ValueError` | Raised eagerly at the call with a corrective message. |
+| Operations on a closed file | `ValueError` | Matches `io` module conventions. |
+| Reading a write-mode file (or vice versa) | `OSError` | e.g. `"File not open for reading"`. |
+
+`gzip.BadGzipFile` subclasses `OSError`, so order your handlers from specific
+to general:
+
+```python
+import gzip
+
+import aiogzip
+
+try:
+    data = await aiogzip.read("untrusted.gz", max_decompressed_size=100 * 2**20)
+except gzip.BadGzipFile:
+    ...  # corrupt or hostile input: reject the file
+except OSError as exc:
+    ...  # I/O failure, or the decompression cap tripped (see below)
+```
+
+## Telling the decompression cap apart from corruption
+
+A stream that exceeds `max_decompressed_size` (a decompression bomb, or just a
+bigger file than expected) raises a plain `OSError`, **not** `BadGzipFile` —
+the data may be perfectly valid gzip; it is the output budget that was
+exceeded. Because the cap error is not a `BadGzipFile`, the handler split
+above distinguishes the two cases by exception type alone. If you need to
+single the cap out from real I/O errors within the `OSError` branch, match on
+its stable message prefix:
+
+```python
+try:
+    data = await aiogzip.read("untrusted.gz", max_decompressed_size=100 * 2**20)
+except gzip.BadGzipFile:
+    raise  # corrupt input: not the cap
+except OSError as exc:
+    if str(exc).startswith("decompressed output exceeded max_decompressed_size"):
+        ...  # over budget: maybe retry with a larger cap
+    else:
+        raise
+```
+
+## Where errors surface
+
+Streaming helpers validate lazily where the work happens: the iterator
+returned by `decompress_chunks()` raises `BadGzipFile` only as the corrupt
+region is consumed, and complete trailer validation happens when the iterator
+is exhausted. `verify()` and `inspect()` scan the whole stream eagerly and
+raise before returning a result. See
+[Processing untrusted gzip input](recipes.md#processing-untrusted-gzip-input)
+for a full defensive-reading recipe.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,43 @@
+# Migrating from `gzip.open`
+
+`aiogzip.open()` accepts the same paths, modes, and keyword arguments as the
+stdlib's `gzip.open()`, and it reads and writes the same `.gz` format. Exactly
+three things change:
+
+| | `gzip` | `aiogzip` |
+|---|---|---|
+| Opening | `with gzip.open(...) as f:` | `async with aiogzip.open(...) as f:` |
+| Line iteration | `for line in f:` | `async for line in f:` |
+| Reads and writes | `f.read()`, `f.write(data)` | `await f.read()`, `await f.write(data)` |
+
+## Before / after
+
+```python
+# stdlib gzip
+import gzip
+
+def count_lines(path):
+    with gzip.open(path, "rt") as f:
+        return sum(1 for _ in f)
+```
+
+```python
+# aiogzip
+import aiogzip
+
+async def count_lines(path):
+    async with aiogzip.open(path, "rt") as f:
+        return sum([1 async for _ in f])
+```
+
+Everything else carries over unchanged: mode strings (`"rb"`, `"rt"`, `"wb"`,
+`"wt"`, append, exclusive), `compresslevel`, text-mode `encoding` / `errors` /
+`newline`, and interoperability — files written by either library are read by
+the other.
+
+If you forget and use `with` or `for`, aiogzip raises a `TypeError` that says
+exactly what to change (e.g. `"must be used with 'async with', not 'with'"`).
+
+Next steps: [Examples](examples.md) for common tasks,
+[Recipes](recipes.md) for streaming patterns, and the
+[Performance Guide](performance.md) for tuning.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -208,7 +208,7 @@ Why this is faster:
 In local measurements on gzipped JSONL reads, `newline="\n"` plus a larger
 chunk size was materially faster than the default text-mode configuration.
 
-If the work performed for each line is synchronous, process bounded groups to
+If the work performed for each line is synchronous, iterate in batches to
 amortize the async-iterator transition for every individual line:
 
 ```python
@@ -222,19 +222,20 @@ async with aiogzip.open(
     newline="\n",
     chunk_size=512 * 1024,
 ) as f:
-    while True:
-        lines = await f.readlines(1024 * 1024)
-        if not lines:
-            break
-        for line in lines:
+    async for batch in f.iter_batches():
+        for line in batch:
             record = json.loads(line)
 ```
 
-`readlines(hint)` stops after the complete line that reaches the approximate
-decoded-character hint. It therefore uses more than `hint` characters when a
-line crosses the boundary, and the reader also retains its normal bounded
-internal buffers. Use ordinary `async for` when per-line backpressure or the
-smallest practical result buffer matters more than throughput.
+`iter_batches(hint)` is exactly `readlines(hint)` in a loop: each batch is a
+non-empty list of complete lines totalling at least `hint` decoded characters
+(default 1 MiB), with the line that crosses the hint returned whole. In this
+project's interleaved min-of-N measurements on a line-dense file, batched
+iteration roughly halved wall-clock time versus per-line `async for`, and
+throughput was flat for hints between 256 KiB and ~1 MiB (degrading slightly
+above 2 MiB — there is no benefit to very large batches). Use ordinary
+`async for` when per-line backpressure or the smallest practical result
+buffer matters more than throughput.
 
 ### 5. Buffer Management
 
@@ -243,3 +244,25 @@ smallest practical result buffer matters more than throughput.
 - **Binary Mode**: Uses an efficient offset-pointer strategy to avoid expensive memory copies (`del buffer[:n]`) when reading small chunks.
 - **Text Mode**: Buffers decoded text to handle split multi-byte characters and split newlines correctly.
 - **Non-seekable `fileobj` Inputs**: Retains a bounded compressed-input rewind cache so backward seeks can replay the stream. The default cap is 128 MiB; lower `max_rewind_cache_size` for memory-sensitive streaming, or set it to `None` only when unbounded rewind support is acceptable.
+
+## When stdlib gzip is fine
+
+aiogzip's value is keeping an event loop responsive while gzip work happens.
+If there is no event loop to protect, the stdlib is the right tool:
+
+- **Synchronous scripts and batch jobs.** A CLI tool or cron job that just
+  decompresses a file gains nothing from async I/O; `gzip.open()` has less
+  overhead and no event-loop requirement.
+- **Small files.** Below roughly a chunk (256 KiB compressed), the whole
+  operation completes in one or two codec calls; wrapping it in coroutines
+  adds transitions without meaningful concurrency benefit.
+- **One file, nothing else to do.** Raw single-stream decompression is
+  CPU-bound in zlib either way; on equal engines, stdlib and aiogzip land in
+  the same range, and aiogzip's advantage in the benchmark tables above comes
+  from the accelerated codec, executor offload, and batched line handling —
+  not from making zlib itself faster.
+
+Reach for aiogzip when gzip I/O shares a process with other async work
+(servers, pipelines with concurrent files, object-store streaming), when you
+want CPU-heavy codec calls off the event loop, or when the async ecosystem
+(`aiocsv`, async fileobjs) is already in play.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -22,8 +22,8 @@ For large UTF-8 JSON Lines files that are known to use `\n` terminators,
 project use `chunk_size=512 * 1024` to reduce async read overhead; tune that
 value for your memory budget and workload.
 
-For CPU-bound parsing, bounded `readlines()` batches avoid one async transition
-per input line while retaining a predictable application-level working set:
+For CPU-bound parsing, batched iteration avoids one async transition per input
+line while retaining a predictable application-level working set:
 
 ```python
 async with aiogzip.open(
@@ -32,19 +32,18 @@ async with aiogzip.open(
     newline="\n",
     chunk_size=512 * 1024,
 ) as f:
-    while True:
-        lines = await f.readlines(1024 * 1024)
-        if not lines:
-            break
-        for line in lines:
+    async for batch in f.iter_batches():
+        for line in batch:
             event = json.loads(line)
             process(event)
 ```
 
-The hint counts decoded characters and reading stops after the whole line that
+`iter_batches(hint)` yields non-empty lists of complete lines and is exactly
+equivalent to calling `readlines(hint)` in a loop. The hint (default 1 MiB)
+counts decoded characters and a batch is complete after the whole line that
 reaches it, so it is an approximate batch target rather than a strict memory
-limit. Prefer `async for` when each record is handed to an asynchronous
-consumer and per-line backpressure is desirable.
+limit. Prefer `async for line in f` when each record is handed to an
+asynchronous consumer and per-line backpressure is desirable.
 
 ## Writing JSON Lines
 
@@ -196,3 +195,42 @@ async with aiofiles.open("payload.gz", "rb") as raw:
 With `closefd=False`, closing the gzip wrapper leaves the external object open.
 Pass `closefd=True` only when the wrapper should close it. Non-seekable readers
 use a bounded compressed-input replay cache for backward seeks.
+
+## Gzip over S3 / fsspec
+
+The same `fileobj` mechanism streams gzip straight from object storage:
+anything exposing an async `read()` (for reading) or async `write()` (for
+writing) satisfies the protocol. With [fsspec](https://filesystem-spec.readthedocs.io/)'s
+async filesystems (e.g. `s3fs`):
+
+```python
+import json
+
+import aiogzip
+import s3fs
+
+fs = s3fs.S3FileSystem(asynchronous=True)
+
+async def read_events(bucket_key):
+    session = await fs.set_session()
+    raw = await fs.open_async(bucket_key, "rb")
+    try:
+        async with aiogzip.open(None, "rt", fileobj=raw, closefd=False) as f:
+            async for batch in f.iter_batches():
+                for line in batch:
+                    process(json.loads(line))
+    finally:
+        await raw.close()
+        await session.close()
+```
+
+Notes:
+
+- Pass `filename=None` when supplying `fileobj`.
+- Object-store readers are typically non-seekable; forward reads stream
+  normally, while backward `seek()` relies on the bounded replay cache
+  (`max_rewind_cache_size`). For pure forward iteration, no tuning is needed.
+- Writing works symmetrically: open the remote object for binary write and
+  pass it as `fileobj` to `aiogzip.open(None, "wt", fileobj=...)`.
+- For untrusted buckets, combine this with `max_decompressed_size` — see
+  [Processing untrusted gzip input](#processing-untrusted-gzip-input).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,9 +56,12 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Migrating from gzip: migration.md
   - Examples: examples.md
   - Recipes: recipes.md
   - Async-iterable streaming: streaming.md
   - Performance: performance.md
+  - Error handling: errors.md
   - API Reference: api.md
+  - Design decisions (ISA-L): adr-isal.md
   - Contributing: contributing.md

--- a/src/aiogzip/__main__.py
+++ b/src/aiogzip/__main__.py
@@ -1,0 +1,87 @@
+"""Command-line entry point: ``python -m aiogzip {inspect,verify} FILE``.
+
+Thin argparse wrapper over the public :func:`aiogzip.inspect` and
+:func:`aiogzip.verify` APIs. Exit codes: 0 on success, 1 when the stream is
+invalid (or unreadable), 2 for usage errors (argparse's convention).
+"""
+
+import argparse
+import asyncio
+import dataclasses
+import gzip
+import json
+import sys
+from typing import Any, List, Optional
+
+from . import __version__, inspect, verify
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.hex()
+    raise TypeError(f"not JSON serializable: {type(value).__name__}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m aiogzip",
+        description="Inspect or verify gzip files using aiogzip.",
+    )
+    parser.add_argument("--version", action="version", version=__version__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    inspect_parser = subparsers.add_parser(
+        "inspect", help="show per-member metadata after full validation"
+    )
+    verify_parser = subparsers.add_parser(
+        "verify", help="validate headers, payloads, CRCs, and sizes"
+    )
+    for subparser in (inspect_parser, verify_parser):
+        subparser.add_argument("path", help="gzip file to read")
+        subparser.add_argument(
+            "--json", action="store_true", help="machine-readable JSON output"
+        )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "inspect":
+            info = asyncio.run(inspect(args.path))
+            if args.json:
+                print(json.dumps(dataclasses.asdict(info), default=_json_default))
+            else:
+                print(
+                    f"{args.path}: {info.member_count} member(s), "
+                    f"{info.compressed_size} bytes compressed, "
+                    f"{info.uncompressed_size} bytes uncompressed"
+                )
+                for m in info.members:
+                    name = m.original_filename or "-"
+                    print(
+                        f"  member {m.index}: offset={m.compressed_offset} "
+                        f"compressed={m.compressed_size} "
+                        f"uncompressed={m.uncompressed_size} mtime={m.mtime} "
+                        f"crc32={m.crc32:#010x} name={name}"
+                    )
+        else:
+            result = asyncio.run(verify(args.path))
+            if args.json:
+                print(json.dumps({"ok": True, **dataclasses.asdict(result)}))
+            else:
+                print(
+                    f"OK: {args.path}: {result.member_count} member(s), "
+                    f"{result.compressed_size} bytes compressed, "
+                    f"{result.uncompressed_size} bytes uncompressed"
+                )
+        return 0
+    except (gzip.BadGzipFile, OSError, EOFError) as exc:
+        if args.json:
+            print(json.dumps({"ok": False, "error": str(exc)}))
+        else:
+            print(f"FAILED: {args.path}: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/aiogzip/_binary.py
+++ b/src/aiogzip/_binary.py
@@ -7,7 +7,7 @@ import os
 import warnings
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, Iterable, List, Optional, Union, cast
+from typing import Any, Callable, Iterable, List, NoReturn, Optional, Union, cast
 
 import aiofiles
 
@@ -311,6 +311,34 @@ class AsyncGzipBinaryFile:
     ) -> None:
         """Exit the context manager, flushing and closing the file."""
         await self.close()
+
+    # Sync-protocol stubs. Without these, ``with`` / ``for`` fail with generic
+    # "does not support the context manager protocol" / "is not iterable"
+    # TypeErrors; these raise the same type but tell the caller the fix.
+    def __enter__(self) -> NoReturn:
+        raise TypeError(
+            "AsyncGzipBinaryFile must be used with 'async with', not 'with' "
+            "(e.g. \"async with aiogzip.open(path, 'rb') as f:\")"
+        )
+
+    def __exit__(
+        self,
+        exc_type: Optional[type],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[Any],
+    ) -> NoReturn:
+        # Unreachable via ``with`` because __enter__ always raises; kept so the
+        # class satisfies context-manager introspection with a curated error.
+        raise TypeError(
+            "AsyncGzipBinaryFile must be used with 'async with', not 'with' "
+            "(e.g. \"async with aiogzip.open(path, 'rb') as f:\")"
+        )
+
+    def __iter__(self) -> NoReturn:
+        raise TypeError(
+            "AsyncGzipBinaryFile must be iterated with 'async for', not 'for' "
+            '(e.g. "async for chunk in f:")'
+        )
 
     def __repr__(self) -> str:
         return _format_file_repr(self)

--- a/src/aiogzip/_engine.py
+++ b/src/aiogzip/_engine.py
@@ -61,6 +61,9 @@ class EngineInfo:
 
     compression: str
     decompression: str
+    # Defaulted so third-party code constructing EngineInfo positionally
+    # (it is public) keeps working; engine_info() always fills it in.
+    crc32: str = "stdlib-zlib"
 
 
 # Errors raised by the deflate engines. zlib-ng's (and isal's) error type is
@@ -136,4 +139,5 @@ def engine_info() -> EngineInfo:
     return EngineInfo(
         compression="stdlib-zlib",
         decompression="zlib-ng" if _HAVE_ZNG else "stdlib-zlib",
+        crc32="zlib-ng" if crc32 is not zlib.crc32 else "stdlib-zlib",
     )

--- a/src/aiogzip/_text.py
+++ b/src/aiogzip/_text.py
@@ -7,7 +7,16 @@ import re
 import secrets
 import struct
 from pathlib import Path
-from typing import Any, Iterable, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    AsyncIterator,
+    Iterable,
+    List,
+    NoReturn,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from ._binary import AsyncGzipBinaryFile
 from ._common import (
@@ -144,6 +153,11 @@ class AsyncGzipTextFile:
     # strings at once. 256 KiB matches the default chunk_size, so the common
     # case still splits a whole chunk in a single pass.
     _LINE_BATCH_CHARS = 256 * 1024
+    # Default characters-per-batch for iter_batches(). Chosen by interleaved
+    # min-of-N benchmark on a 1M-line file: throughput is flat from 256 KiB
+    # to ~1 MiB and degrades slightly above 2 MiB, so 1 MiB takes the top of
+    # the flat range while keeping per-batch memory modest.
+    DEFAULT_BATCH_HINT = 1024 * 1024
 
     def __init__(
         self,
@@ -327,6 +341,34 @@ class AsyncGzipTextFile:
     ) -> None:
         """Exit the context manager, flushing and closing the file."""
         await self.close()
+
+    # Sync-protocol stubs. Without these, ``with`` / ``for`` fail with generic
+    # "does not support the context manager protocol" / "is not iterable"
+    # TypeErrors; these raise the same type but tell the caller the fix.
+    def __enter__(self) -> NoReturn:
+        raise TypeError(
+            "AsyncGzipTextFile must be used with 'async with', not 'with' "
+            "(e.g. \"async with aiogzip.open(path, 'rt') as f:\")"
+        )
+
+    def __exit__(
+        self,
+        exc_type: Optional[type],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[Any],
+    ) -> NoReturn:
+        # Unreachable via ``with`` because __enter__ always raises; kept so the
+        # class satisfies context-manager introspection with a curated error.
+        raise TypeError(
+            "AsyncGzipTextFile must be used with 'async with', not 'with' "
+            "(e.g. \"async with aiogzip.open(path, 'rt') as f:\")"
+        )
+
+    def __iter__(self) -> NoReturn:
+        raise TypeError(
+            "AsyncGzipTextFile must be iterated with 'async for', not 'for' "
+            '(e.g. "async for line in f:")'
+        )
 
     def __repr__(self) -> str:
         return _format_file_repr(self)
@@ -1455,6 +1497,56 @@ class AsyncGzipTextFile:
                 break
 
         return lines
+
+    def iter_batches(self, hint: int = DEFAULT_BATCH_HINT) -> AsyncIterator[List[str]]:
+        """
+        Iterate over the file in batches of complete lines.
+
+        Equivalent to calling ``readlines(hint)`` in a loop until it returns an
+        empty list, but as an async iterator::
+
+            async with aiogzip.open("file.gz", "rt") as f:
+                async for batch in f.iter_batches():
+                    for line in batch:
+                        process(line)
+
+        Each yielded batch is a non-empty list of lines (trailing newlines
+        included, exactly as ``readlines`` returns them); iteration ends at
+        EOF. Batching amortizes the per-line ``await`` overhead of ``async
+        for line in f`` and is measurably faster on line-dense files, while
+        keeping memory bounded by roughly ``hint`` characters per batch.
+
+        Args:
+            hint: Positive batch size hint in characters. A batch is complete
+                once the lines collected so far total at least ``hint``
+                characters (the line that crosses the hint is returned whole).
+
+        Returns:
+            AsyncIterator[List[str]]: An async iterator of line batches.
+
+        Raises:
+            TypeError: If hint is not an integer.
+            ValueError: If hint is not positive.
+        """
+        # Validate eagerly, at the call, not at the first __anext__ inside the
+        # generator — matching the strict-parameter conventions elsewhere.
+        if not isinstance(hint, int) or isinstance(hint, bool):
+            raise TypeError("iter_batches hint must be a positive integer")
+        if hint <= 0:
+            raise ValueError("iter_batches hint must be a positive integer")
+        return self._iter_batches(hint)
+
+    async def _iter_batches(self, hint: int) -> AsyncIterator[List[str]]:
+        """Async-generator body of iter_batches.
+
+        A thin loop over ``readlines(hint)`` so batch semantics can never
+        diverge from it (closed-file and mode errors surface identically).
+        """
+        while True:
+            batch = await self.readlines(hint)
+            if not batch:
+                return
+            yield batch
 
     async def writelines(self, lines: Iterable[str]) -> None:
         """

--- a/tests/test_batched_readline.py
+++ b/tests/test_batched_readline.py
@@ -9,9 +9,12 @@ and read() must stay correct when interleaved with iteration.
 stdlib ``gzip.open(..., 'rt')`` is used as the oracle for line splitting.
 """
 
+import asyncio
 import gzip
 
 import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 
 from aiogzip import AsyncGzipTextFile
 
@@ -336,3 +339,147 @@ class TestLongLineSpanningChunks:
         async with AsyncGzipTextFile(path, "rt", newline=newline, chunk_size=64) as f:
             lines = [line async for line in f]
         assert lines == ["x" * 10_000 + term, "short" + term]
+
+
+class TestIterBatches:
+    """iter_batches(hint) is a thin wrapper over readlines(hint)-in-a-loop;
+    these tests pin that equivalence and the strict hint validation."""
+
+    @pytest.mark.parametrize("newline", [None, "\n", "\r", "\r\n", ""])
+    @pytest.mark.parametrize("chunk_size", [4, 64, 1 << 20])
+    async def test_flattened_batches_match_oracle(self, rich_gz, newline, chunk_size):
+        expected = oracle_lines(rich_gz, newline)
+        async with AsyncGzipTextFile(
+            rich_gz, "rt", newline=newline, chunk_size=chunk_size
+        ) as f:
+            got = [line async for batch in f.iter_batches(hint=32) for line in batch]
+        assert got == expected
+
+    async def test_batches_are_nonempty_lists_bounded_by_hint(self, tmp_path):
+        expected = [f"item {i}\n" for i in range(5000)]
+        max_line_size = max(map(len, expected))
+        path = tmp_path / "iter-batches-bounds.gz"
+        path.write_bytes(gzip.compress("".join(expected).encode("utf-8")))
+
+        actual = []
+        async with AsyncGzipTextFile(path, "rt", newline="\n") as f:
+            async for batch in f.iter_batches(hint=512):
+                assert isinstance(batch, list)
+                assert batch
+                batch_size = sum(map(len, batch))
+                assert batch_size >= 512 or batch[-1] == expected[-1]
+                assert batch_size < 512 + max_line_size
+                actual.extend(batch)
+        assert actual == expected
+
+    async def test_default_hint_reads_everything(self, rich_gz):
+        assert AsyncGzipTextFile.DEFAULT_BATCH_HINT == 1024 * 1024
+        async with AsyncGzipTextFile(rich_gz, "rt") as f:
+            batches = [batch async for batch in f.iter_batches()]
+        # RICH_TEXT is far smaller than the default hint: one batch, then EOF.
+        assert len(batches) == 1
+        assert batches[0] == oracle_lines(rich_gz, None)
+
+    @pytest.mark.parametrize(
+        ("bad_hint", "expected_error"),
+        [
+            (0, ValueError),
+            (-1, ValueError),
+            (-4096, ValueError),
+            (True, TypeError),
+            (False, TypeError),
+            (1.5, TypeError),
+            ("1024", TypeError),
+            (None, TypeError),
+        ],
+    )
+    async def test_hint_validated_eagerly_at_the_call(
+        self, rich_gz, bad_hint, expected_error
+    ):
+        async with AsyncGzipTextFile(rich_gz, "rt") as f:
+            # No awaiting: the error must come from the call itself, not the
+            # first __anext__ of a lazily-started generator.
+            with pytest.raises(expected_error, match="positive integer"):
+                f.iter_batches(bad_hint)
+
+    async def test_closed_file_raises_on_first_step(self, rich_gz):
+        f = AsyncGzipTextFile(rich_gz, "rt")
+        await f.open()
+        await f.close()
+        it = f.iter_batches(1024)
+        with pytest.raises(ValueError, match="closed"):
+            await it.__anext__()
+
+    async def test_write_mode_raises_on_first_step(self, tmp_path):
+        async with AsyncGzipTextFile(tmp_path / "w.gz", "wt") as f:
+            it = f.iter_batches(1024)
+            with pytest.raises(OSError, match="not open for reading"):
+                await it.__anext__()
+
+    async def test_interleaves_with_read_and_tell_seek(self, tmp_path):
+        expected = [f"row {i:03d}\n" for i in range(500)]
+        path = tmp_path / "iter-batches-interleave.gz"
+        path.write_bytes(gzip.compress("".join(expected).encode("utf-8")))
+
+        async with AsyncGzipTextFile(path, "rt", newline="\n", chunk_size=64) as f:
+            it = f.iter_batches(hint=128)
+            first = await it.__anext__()
+            cookie = await f.tell()
+            second = await it.__anext__()
+            await f.seek(cookie)
+            second_again = await it.__anext__()
+        assert second_again == second
+        assert "".join(first) + "".join(second) == "".join(
+            expected[: len(first) + len(second)]
+        )
+
+
+# Hypothesis parity: random content (with the splitlines-unsafe specials mixed
+# into ordinary line text), random chunking, and a small random hint must all
+# agree with readlines() on a fresh handle and with the stdlib gzip oracle.
+_line_text = st.text(
+    alphabet=st.sampled_from("ab é\x0b\x0c\x1c\x1d\x1e\x85  "),
+    max_size=20,
+)
+_document = st.builds(
+    lambda parts, tail: "".join(p + t for p, t in parts) + tail,
+    st.lists(st.tuples(_line_text, st.sampled_from(["\n", "\r", "\r\n"])), max_size=30),
+    _line_text,
+)
+
+
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+@given(
+    document=_document,
+    newline=st.sampled_from([None, "\n", "\r", "\r\n", ""]),
+    chunk_size=st.sampled_from([1, 3, 7, 64, 1024]),
+    hint=st.integers(min_value=1, max_value=64),
+)
+def test_iter_batches_hypothesis_parity(
+    tmp_path_factory, document, newline, chunk_size, hint
+):
+    path = tmp_path_factory.mktemp("hyp") / "doc.gz"
+    path.write_bytes(gzip.compress(document.encode("utf-8")))
+
+    with gzip.open(path, "rt", encoding="utf-8", newline=newline) as g:
+        oracle = g.readlines()
+
+    async def collect():
+        async with AsyncGzipTextFile(
+            path, "rt", newline=newline, chunk_size=chunk_size
+        ) as f:
+            flattened = [
+                line async for batch in f.iter_batches(hint=hint) for line in batch
+            ]
+        async with AsyncGzipTextFile(
+            path, "rt", newline=newline, chunk_size=chunk_size
+        ) as f:
+            all_lines = await f.readlines()
+        return flattened, all_lines
+
+    flattened, all_lines = asyncio.run(collect())
+    assert flattened == all_lines == oracle

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,129 @@
+"""Tests for the ``python -m aiogzip`` command-line interface."""
+
+import gzip
+import json
+import subprocess
+import sys
+
+import pytest
+
+from aiogzip import __version__
+from aiogzip.__main__ import main
+
+PAYLOAD = b"hello world\n" * 100
+
+
+@pytest.fixture
+def good_gz(tmp_path):
+    path = tmp_path / "good.gz"
+    with gzip.open(path, "wb") as f:
+        f.write(PAYLOAD)
+    return path
+
+
+@pytest.fixture
+def corrupt_gz(tmp_path, good_gz):
+    path = tmp_path / "bad.gz"
+    raw = good_gz.read_bytes()
+    # Zero out the trailer (CRC32 + ISIZE) so the payload decodes but fails
+    # integrity validation.
+    path.write_bytes(raw[:-8] + b"\x00" * 8)
+    return path
+
+
+class TestVerifyCommand:
+    def test_ok_exit_zero_and_summary(self, good_gz, capsys):
+        assert main(["verify", str(good_gz)]) == 0
+        out = capsys.readouterr().out
+        assert out.startswith("OK: ")
+        assert "1 member(s)" in out
+        assert f"{len(PAYLOAD)} bytes uncompressed" in out
+
+    def test_ok_json_shape(self, good_gz, capsys):
+        assert main(["verify", str(good_gz), "--json"]) == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data == {
+            "ok": True,
+            "member_count": 1,
+            "compressed_size": good_gz.stat().st_size,
+            "uncompressed_size": len(PAYLOAD),
+        }
+
+    def test_corrupt_exit_one_and_stderr(self, corrupt_gz, capsys):
+        assert main(["verify", str(corrupt_gz)]) == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err.startswith("FAILED: ")
+        assert "CRC" in captured.err
+
+    def test_corrupt_json_reports_error(self, corrupt_gz, capsys):
+        assert main(["verify", str(corrupt_gz), "--json"]) == 1
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is False
+        assert "CRC" in data["error"]
+
+    def test_missing_file_exit_one(self, tmp_path, capsys):
+        assert main(["verify", str(tmp_path / "missing.gz")]) == 1
+        assert "FAILED" in capsys.readouterr().err
+
+
+class TestInspectCommand:
+    def test_human_output_lists_members(self, good_gz, capsys):
+        assert main(["inspect", str(good_gz)]) == 0
+        out = capsys.readouterr().out
+        assert "1 member(s)" in out
+        assert "member 0:" in out
+        assert f"uncompressed={len(PAYLOAD)}" in out
+
+    def test_json_matches_inspect_dataclass(self, good_gz, capsys):
+        assert main(["inspect", str(good_gz), "--json"]) == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["uncompressed_size"] == len(PAYLOAD)
+        assert len(data["members"]) == 1
+        member = data["members"][0]
+        assert member["index"] == 0
+        assert member["trailer_isize"] == len(PAYLOAD)
+
+    def test_json_encodes_extra_bytes_as_hex(self, tmp_path, capsys):
+        # Hand-build a member with an FEXTRA field (FLG bit 2).
+        payload = b"x"
+        body = gzip.compress(payload)
+        extra = b"\xde\xad"
+        xlen = len(extra).to_bytes(2, "little")
+        raw = body[:3] + b"\x04" + body[4:10] + xlen + extra + body[10:]
+        path = tmp_path / "extra.gz"
+        path.write_bytes(raw)
+        assert main(["inspect", str(path), "--json"]) == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["members"][0]["extra"] == "dead"
+
+    def test_corrupt_exit_one(self, corrupt_gz, capsys):
+        assert main(["inspect", str(corrupt_gz)]) == 1
+        assert "FAILED" in capsys.readouterr().err
+
+
+class TestUsage:
+    def test_no_command_is_usage_error(self, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            main([])
+        assert excinfo.value.code == 2
+
+    def test_unknown_command_is_usage_error(self, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            main(["bogus"])
+        assert excinfo.value.code == 2
+
+    def test_version_flag(self, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            main(["--version"])
+        assert excinfo.value.code == 0
+        assert capsys.readouterr().out.strip() == __version__
+
+    def test_module_entry_point_runs(self, good_gz):
+        proc = subprocess.run(
+            [sys.executable, "-m", "aiogzip", "verify", str(good_gz)],
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.startswith("OK: ")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -72,11 +72,29 @@ class TestEngineSelection:
 class TestEngineInfo:
     def test_reports_default_configuration(self):
         expected_decompression = "zlib-ng" if _engine._HAVE_ZNG else "stdlib-zlib"
+        expected_crc32 = "zlib-ng" if _engine.crc32 is not zlib.crc32 else "stdlib-zlib"
 
         assert engine_info() == EngineInfo(
             compression="stdlib-zlib",
             decompression=expected_decompression,
+            crc32=expected_crc32,
         )
+
+    def test_crc32_field_matches_selected_function(self):
+        """The reported crc32 engine tracks the actual module-level selection
+        (zlib-ng except on macOS or under AIOGZIP_ENGINE=stdlib)."""
+        info = engine_info()
+        if _engine.crc32 is zlib.crc32:
+            assert info.crc32 == "stdlib-zlib"
+        else:
+            assert _engine.crc32 is _engine._zng.crc32
+            assert info.crc32 == "zlib-ng"
+
+    def test_crc32_field_defaults_for_positional_construction(self):
+        """EngineInfo is public: two-field construction predating the crc32
+        field must keep working."""
+        info = EngineInfo("stdlib-zlib", "stdlib-zlib")
+        assert info.crc32 == "stdlib-zlib"
 
     @pytest.mark.parametrize(
         ("have_zng", "expected_decompression"),

--- a/tests/test_modes_and_api.py
+++ b/tests/test_modes_and_api.py
@@ -405,3 +405,39 @@ class TestNewAPIMethods:
 
         async with AsyncGzipTextFile(temp_file, "rt") as f:
             assert await f.read() == "first\nsecond\n"
+
+
+class TestSyncProtocolStubs:
+    """`with` and `for` on the async file classes raise corrective TypeErrors
+    instead of the generic protocol errors."""
+
+    @pytest.mark.parametrize("cls", [AsyncGzipBinaryFile, AsyncGzipTextFile])
+    def test_with_statement_raises_corrective_typeerror(self, cls):
+        f = cls("dummy.gz")
+        with pytest.raises(TypeError, match="async with"):
+            with f:
+                pass  # pragma: no cover - __enter__ always raises
+
+    @pytest.mark.parametrize("cls", [AsyncGzipBinaryFile, AsyncGzipTextFile])
+    def test_enter_names_the_class(self, cls):
+        with pytest.raises(TypeError, match=cls.__name__):
+            cls("dummy.gz").__enter__()
+
+    @pytest.mark.parametrize("cls", [AsyncGzipBinaryFile, AsyncGzipTextFile])
+    def test_exit_raises_corrective_typeerror(self, cls):
+        # Unreachable via `with` (enter raises first) but must still be curated
+        # for anyone poking at the protocol directly.
+        with pytest.raises(TypeError, match="async with"):
+            cls("dummy.gz").__exit__(None, None, None)
+
+    @pytest.mark.parametrize("cls", [AsyncGzipBinaryFile, AsyncGzipTextFile])
+    def test_for_statement_raises_corrective_typeerror(self, cls):
+        f = cls("dummy.gz")
+        with pytest.raises(TypeError, match="async for"):
+            for _ in f:
+                pass  # pragma: no cover - __iter__ always raises
+
+    @pytest.mark.parametrize("cls", [AsyncGzipBinaryFile, AsyncGzipTextFile])
+    def test_iter_names_the_class(self, cls):
+        with pytest.raises(TypeError, match=cls.__name__):
+            iter(cls("dummy.gz"))


### PR DESCRIPTION
## Summary

Implements the 1.11.0 "first contact" plan against current main. Work items 1 (splitlines fast path) and the core of 3 (crc32 engine selection) had already shipped in 1.10.2 and were skipped after auditing.

- **Sync-protocol stubs**: `with` / `for` on `AsyncGzipBinaryFile`/`AsyncGzipTextFile` now raise corrective `TypeError`s pointing at `async with` / `async for`.
- **`iter_batches(hint)`** on the text class: batched line iteration as a thin wrapper over the `readlines(hint)` drain. Default hint 1 MiB chosen by interleaved min-of-N benchmark (throughput flat 256 KiB–1 MiB, degrading above 2 MiB; ~2x faster than per-line `async for` on line-dense files). Hypothesis parity test pins flattened batches == `readlines()` == stdlib `gzip` across newline modes, chunkings, and hints.
- **`EngineInfo.crc32`**: surfaces the per-platform crc32 engine selection (defaulted field, additive).
- **`python -m aiogzip {inspect,verify}`**: minimal argparse CLI over the public APIs; `--json`; exit codes 0/1/2.
- **Docs**: "Migrating from gzip.open" page, error-taxonomy page (verified the `max_decompressed_size` cap raises plain `OSError`, distinguishable from `BadGzipFile` by type), ISA-L ADR, S3/fsspec recipe, `iter_batches` in the JSONL recipes, "When stdlib gzip is fine" section.

Roadmap issues filed alongside: #70 (sans-IO codec), #71 (anyio), #72 (indexed random access).

## Verification

- 1326 tests pass, plus the full suite again under `AIOGZIP_ENGINE=stdlib`; mypy and ty green; `mkdocs build --strict` clean.
- Benchmarked per CLAUDE.md (worktree baseline, same venv, stdlib engine pinned): harness-level deltas did not survive an A/A noise control; targeted interleaved in-process micro-tests show readlines −2.0% / per-line iteration +1.6%, i.e. no real change to existing hot paths, as expected for additive methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)