### PR TITLE
Prepare release v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-19
+
 ### Documentation
 
 - New "Migrating from `gzip.open`" page: the exactly-three differences

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,12 +287,14 @@ Always include:
 ## Version History
 
 - **0.3** - Major refactoring, binary/text separation
-- **1.10.2 (current)** - See `CHANGELOG.md` for the full release history. Recent
-  work adds package-level `open()`, whole-file helpers, engine diagnostics,
-  gzip inspection and verification, and bounded async-iterable compression and
-  decompression. Recent performance work speeds up batched line splitting and
-  LF-only newline detection and selects the fastest crc32 engine per platform;
-  the benchmark documentation reflects 2026-07-16 reference runs.
+- **1.11.0 (current)** - See `CHANGELOG.md` for the full release history. Recent
+  work adds `iter_batches(hint)` batched line iteration, corrective TypeErrors
+  for `with`/`for` misuse, a `python -m aiogzip {inspect,verify}` CLI, an
+  `EngineInfo.crc32` field, and new docs (gzip.open migration, error taxonomy,
+  ISA-L ADR, S3/fsspec recipe). Prior releases added package-level `open()`,
+  whole-file helpers, engine diagnostics, gzip inspection and verification,
+  bounded async-iterable compression/decompression, and per-platform codec
+  selection; the benchmark documentation reflects 2026-07-16 reference runs.
 
 ---
 

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -28,7 +28,7 @@ from ._inspection import (
 from ._streaming import _compress_chunks, _decompress_chunks
 from ._text import AsyncGzipTextFile
 
-__version__ = "1.10.2"
+__version__ = "1.11.0"
 
 # Mode strings that select a text stream (they contain a 't'). The factory
 # parses modes character-by-character and is permutation-tolerant, so these


### PR DESCRIPTION
Bumps `__version__` to 1.11.0, dates the changelog section, and refreshes the CLAUDE.md version-history line.

## 1.11.0 highlights

**Added**
- `AsyncGzipTextFile.iter_batches(hint)` — batched line iteration (thin wrapper over the `readlines(hint)` drain; default hint 1 MiB, benchmark-chosen).
- Corrective `TypeError`s for `with`/`for` misuse on both file classes.
- `python -m aiogzip {inspect,verify}` CLI with `--json` and 0/1/2 exit codes.
- `EngineInfo.crc32` field surfacing the per-platform crc32 engine selection.

**Documentation**
- "Migrating from `gzip.open`", error-taxonomy page, ISA-L ADR, S3/fsspec recipe, `iter_batches` in recipes/performance, "When stdlib gzip is fine".

**Changed**
- Git-hook runner switched from `pre-commit` to `prek` (dev tooling).

After CI passes and this merges, `/release-tag` tags and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)