### PR TITLE
Add versioned documentation deploys via mike

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,14 +4,17 @@ on:
   push:
     branches:
       - main
+      - 1.x
+  workflow_dispatch:
 
 permissions:
   contents: write
 
-# gh-deploy force-pushes gh-pages; never run two deploys concurrently.
+# mike appends commits to gh-pages; queue deploys so two runs never
+# interleave their commit/push sequences.
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -38,6 +41,28 @@ jobs:
           restore-keys: |
             mkdocs-material-
 
-      - run: pip install .[docs]
+      - run: pip install .[docs] mike
 
-      - run: mkdocs gh-deploy --force
+      - name: Fetch existing versioned docs
+        # actions/checkout restricts the fetch refspec to the triggering
+        # ref, so name the local branch explicitly for mike to build on.
+        run: git fetch --depth=1 origin gh-pages:gh-pages || true
+
+      - name: Deploy versioned docs
+        # Docs versions are one directory per minor line (1.11, 2.0, ...).
+        # main owns the moving aliases: stable releases take `latest` (the
+        # site default), pre-releases take `dev`. Maintenance branches
+        # (1.x) republish their minor line without touching aliases —
+        # existing aliases stay attached, so a 1.11 patch keeps updating
+        # `latest` for as long as `latest` still points at 1.11.
+        run: |
+          VERSION="$(python -c 'import aiogzip; print(aiogzip.__version__)')"
+          DOCS_VERSION="${VERSION%.*}"
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            mike deploy --push --title "$VERSION" "$DOCS_VERSION"
+          elif echo "$VERSION" | grep -Eq '^[0-9]+(\.[0-9]+)*$'; then
+            mike deploy --push --update-aliases --title "$VERSION" "$DOCS_VERSION" latest
+            mike set-default --push latest
+          else
+            mike deploy --push --update-aliases --title "$VERSION" "$DOCS_VERSION" dev
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Documentation
+
+- The documentation site is now versioned with mike. Each minor line
+  publishes to its own directory (`1.11`, `2.0`, ...); stable releases from
+  `main` move the `latest` alias (the site default), pre-releases publish
+  under the `dev` alias, and maintenance branches republish their own line
+  without touching aliases. Deep links into the previous single-version site
+  now resolve via the versioned paths.
+
 ## [2.0.0a1] - 2026-07-22
 
 ### Added

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,10 @@ theme:
         icon: material/weather-night
         name: Switch to light mode
 
+extra:
+  version:
+    provider: mike
+
 plugins:
   - search
   - mkdocstrings:


### PR DESCRIPTION
## Summary

Converts the docs site from single-version `mkdocs gh-deploy --force` publishing to mike-managed versioned docs, so the stable 1.11 docs stay the default landing version through the 2.0 alpha series.

- **mkdocs.yml**: enable the mkdocs-material version selector (`extra.version.provider: mike`).
- **docs.yml**: deploy with mike, deriving the docs version (`major.minor`) from `aiogzip.__version__`:
  - stable release on `main` → `mike deploy X.Y latest` + `set-default latest`
  - pre-release on `main` (current state, 2.0.0a1) → `mike deploy 2.0 dev`
  - maintenance branch (`1.x`, once cut) → `mike deploy X.Y` with no alias changes
- Queue concurrent deploys instead of cancelling (mike appends commits rather than force-pushing).

After this merges, gh-pages will be reseeded once (wipe the stale single-version root, publish `1.11` from the v1.11.0 tag as `latest`/default, republish `2.0` as `dev`), so the public site lands on 1.11 with 2.0 selectable as dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)