### PR TITLE
Prepare release v2.0.0a2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.0a2] - 2026-07-27
+
 ### Fixed
 
 - Replaced the decoder's monolithic pending-input buffer with immutable spans
@@ -721,5 +723,6 @@ All notable changes to this project will be documented in this file.
 - Normalize iteration errors from `AsyncGzipBinaryFile` to `TypeError`, matching the standard file API.
 - Declare project metadata dynamically via `aiogzip.__version__`, add explicit license info, and tidy packaging configuration.
 
-[Unreleased]: https://github.com/geoff-davis/aiogzip/compare/v2.0.0a1...HEAD
+[Unreleased]: https://github.com/geoff-davis/aiogzip/compare/v2.0.0a2...HEAD
+[2.0.0a2]: https://github.com/geoff-davis/aiogzip/compare/v2.0.0a1...v2.0.0a2
 [2.0.0a1]: https://github.com/geoff-davis/aiogzip/compare/v1.11.0...v2.0.0a1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,13 +216,17 @@ Always include:
 ## Version History
 
 - **0.3** - Major refactoring, binary/text separation
-- **2.0.0a1 (current)** - Requires Python 3.11+ and adds the public synchronous
+- **2.0.0a1** - Requires Python 3.11+ and adds the public synchronous
   sans-I/O `GzipEncoder` and `GzipDecoder`. File, iterable-streaming, inspection,
-  and verification paths now share that one gzip state machine. The codec API
-  remains provisional through the alpha series; established asyncio APIs keep
-  their compatibility contract.
+  and verification paths now share that one gzip state machine.
+- **2.0.0a2 (current)** - Repairs the decoder performance regressions from
+  the codec unification: bounded input spans and 256 KiB inflate windows,
+  incremental header parsing, internal output batches decoupled from public
+  `output_chunk_size`, and cooperative event-loop checkpoints. Adds the public
+  typed `CodecOperation`. The codec API remains provisional through the alpha
+  series; established asyncio APIs keep their compatibility contract.
 
 ---
 
-**Last Updated:** 2026-07-22
+**Last Updated:** 2026-07-27
 **Maintainer Notes:** Keep this file updated with new gotchas and best practices!

--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -29,7 +29,7 @@ from ._streaming import _compress_chunks, _decompress_chunks
 from ._text import AsyncGzipTextFile
 from .codec import CodecOperation, GzipDecoder, GzipEncoder
 
-__version__ = "2.0.0a2.dev0"
+__version__ = "2.0.0a2"
 
 # Mode strings that select a text stream (they contain a 't'). The factory
 # parses modes character-by-character and is permutation-tolerant, so these

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -52,20 +52,20 @@ def test_py_typed_marker_shipped():
     assert marker.exists(), "py.typed marker missing from installed package"
 
 
-def test_2_0_a2_development_metadata_is_synchronized():
+def test_2_0_a2_release_metadata_is_synchronized():
     root = Path(__file__).resolve().parents[1]
     data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
     changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
     project = data["project"]
 
-    assert aiogzip.__version__ == "2.0.0a2.dev0"
+    assert aiogzip.__version__ == "2.0.0a2"
     assert "## [Unreleased]" in changelog
     release = re.search(
         r"^## \[([^]]+)\] - (\d{4}-\d{2}-\d{2})$", changelog, re.MULTILINE
     )
     assert release is not None
-    assert release.group(1) == "2.0.0a1"
-    assert release.group(2) == "2026-07-22"
+    assert release.group(1) == "2.0.0a2"
+    assert release.group(2) == "2026-07-27"
     assert project["requires-python"] == ">=3.11"
     assert "Development Status :: 3 - Alpha" in project["classifiers"]
     assert any(


### PR DESCRIPTION
## Summary

Release preparation for **v2.0.0a2**, the second alpha of the 2.0 line. The full development branch (PR #82) is already on main; this PR only finalizes release metadata:

- Set `__version__` to `2.0.0a2` (from `2.0.0a2.dev0`)
- Date the `[2.0.0a2]` changelog entry 2026-07-27 and refresh comparison links
- Update the CLAUDE.md version-history summary
- Advance the phase-pinned version-sync test to the released metadata

## Changelog highlights for 2.0.0a2

- **Fixed:** decoder pending-buffer quadratic behavior, tiny-output engine-call amplification, quadratic fragmented-header parsing, and event-loop starvation on long inline drains
- **Added:** public typed `CodecOperation`
- **Changed:** decoder offload/fairness policy (1 MiB decode threshold, bounded checkpoints); decompression-limit probe accounting; internal batches decoupled from `output_chunk_size`
- **Performance:** Framework Desktop release matrix puts the 512/256 KiB `decompress_chunks()` case 21.5–23.2% below v1.11.0; 8–64 MiB one-feed decode scales linearly; max event-loop gaps under 1 ms
- **Documentation:** versioned docs via mike

After CI passes and this merges, `/release-tag` tags and publishes the prerelease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)