### PR TITLE
Advance main to 2.0.0a3.dev0

### DIFF
--- a/src/aiogzip/__init__.py
+++ b/src/aiogzip/__init__.py
@@ -29,7 +29,7 @@ from ._streaming import _compress_chunks, _decompress_chunks
 from ._text import AsyncGzipTextFile
 from .codec import CodecOperation, GzipDecoder, GzipEncoder
 
-__version__ = "2.0.0a2"
+__version__ = "2.0.0a3.dev0"
 
 # Mode strings that select a text stream (they contain a 't'). The factory
 # parses modes character-by-character and is permutation-tolerant, so these

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -52,13 +52,13 @@ def test_py_typed_marker_shipped():
     assert marker.exists(), "py.typed marker missing from installed package"
 
 
-def test_2_0_a2_release_metadata_is_synchronized():
+def test_2_0_a3_development_metadata_is_synchronized():
     root = Path(__file__).resolve().parents[1]
     data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
     changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
     project = data["project"]
 
-    assert aiogzip.__version__ == "2.0.0a2"
+    assert aiogzip.__version__ == "2.0.0a3.dev0"
     assert "## [Unreleased]" in changelog
     release = re.search(
         r"^## \[([^]]+)\] - (\d{4}-\d{2}-\d{2})$", changelog, re.MULTILINE


### PR DESCRIPTION
Post-release version bump after v2.0.0a2: set `__version__` to `2.0.0a3.dev0` and re-pin the phase version-sync test to the development metadata. Closes the final maintainer gate in the 2.0.0a2 release plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)